### PR TITLE
[model] feat: support qwen3.5 and fix compatible issues about latest verl

### DIFF
--- a/uni_agent/agent_loop.py
+++ b/uni_agent/agent_loop.py
@@ -205,18 +205,16 @@ class UniAgentLoop(AgentLoopBase):
         if routed_experts is not None:
             routed_experts = routed_experts[: len(prompt_ids) + len(response_ids)]
 
+        multi_modal_data = {}
         return AgentLoopOutput(
             prompt_ids=prompt_ids,
             response_ids=response_ids,
             response_mask=response_mask,
             response_logprobs=response_logprobs,
             routed_experts=routed_experts,
+            multi_modal_data=multi_modal_data,
             reward_score=reward_score,
             num_turns=num_turns,
             metrics=metrics,
             extra_fields=extra_fields,
         )
-
-
-# Backward-compatible alias for existing configs/imports.
-AgentLoop = UniAgentLoop

--- a/uni_agent/interaction/model.py
+++ b/uni_agent/interaction/model.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from uni_agent.utils import get_event_loop
 from verl.utils.profiler import simple_timer
+from verl.utils.tokenizer import normalize_token_ids
 
 try:
     from openai import AsyncOpenAI
@@ -48,6 +49,7 @@ class AgentChatModel:
                 tools=self.tools_schemas,
             ),
         )
+        prompt_ids = normalize_token_ids(prompt_ids)
         return {
             "request_id": str(uuid.uuid4()),
             "prompt_ids": prompt_ids,
@@ -135,17 +137,48 @@ class AgentChatModel:
         return response_str, rollout_cache, generation_info
 
     async def _get_new_message_ids(self, new_messages: list[dict[str, str]]) -> list[int]:
-        messages = [{"role": "system", "content": "mock message"}]
-        system_prompt_ids = await self.loop.run_in_executor(
-            None, lambda: self.tokenizer.apply_chat_template(messages, tokenize=True)
+        messages = [
+            {"role": "system", "content": "mock system"},
+            {"role": "user", "content": "mock user"},
+            {"role": "assistant", "content": "mock assistant"},
+        ]
+        base_ids = await self.loop.run_in_executor(
+            None,
+            lambda: self.tokenizer.apply_chat_template(
+                messages,
+                tokenize=True,
+                tools=self.tools_schemas,
+            ),
         )
-        eos_index = system_prompt_ids.index(self.tokenizer.eos_token_id)
+        base_ids = normalize_token_ids(base_ids)
+
         messages.extend(new_messages)
-        full_prompt_ids = await self.loop.run_in_executor(
-            None, lambda: self.tokenizer.apply_chat_template(messages, add_generation_prompt=True, tokenize=True)
+        full_ids = await self.loop.run_in_executor(
+            None,
+            lambda: self.tokenizer.apply_chat_template(
+                messages,
+                add_generation_prompt=True,
+                tokenize=True,
+                tools=self.tools_schemas,
+            ),
         )
-        tool_response_ids = full_prompt_ids[eos_index + 1 :]
-        return tool_response_ids
+        full_ids = normalize_token_ids(full_ids)
+
+        # Drop trailing whitespace ("\n") the template appends after the
+        # assistant's eos, so base_ids ends exactly where real generation stops.
+        eos_id = self.tokenizer.eos_token_id
+        cut = 0
+        for i in range(len(base_ids) - 1, -1, -1):
+            if base_ids[i] == eos_id:
+                cut = i + 1
+                break
+        base_ids = base_ids[:cut]
+
+        assert full_ids[: len(base_ids)] == base_ids, (
+            "base_ids must be an exact prefix of full_ids; "
+            "chat template produced inconsistent rendering between baseline and full."
+        )
+        return full_ids[len(base_ids) :]
 
 
 # this class is only used for Inference-Only Scenario


### PR DESCRIPTION
1. make uni-agent compatible with the latest verl with transformers>5.0
2. fix chat template bug in `get_new_messages`
3. support qwen3.5 model