### PR TITLE
[env] fix: solider host deployment

### DIFF
--- a/tests/uni_agent/deployment/test_host_runtime.py
+++ b/tests/uni_agent/deployment/test_host_runtime.py
@@ -1,0 +1,103 @@
+"""Tests for HostRuntime: concurrency, timeout recovery, and session rebuild.
+
+Requires swerex to be installed (HostRuntime depends on its abstract types).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+import pytest_asyncio
+
+pytest.importorskip("swerex")
+
+from swerex.exceptions import CommandTimeoutError  # noqa: E402
+from swerex.runtime.abstract import (  # noqa: E402
+    BashAction,
+    BashInterruptAction,
+    CreateSessionRequest,
+)
+
+from uni_agent.deployment.host.deployment import HostRuntime  # noqa: E402
+
+
+@pytest_asyncio.fixture
+async def runtime():
+    rt = HostRuntime(run_id="test")
+    await rt.create_session(CreateSessionRequest(startup_source=[], startup_timeout=10))
+    try:
+        yield rt
+    finally:
+        await rt.close()
+
+
+@pytest.mark.asyncio
+async def test_sequential_commands_keep_session_state(runtime: HostRuntime) -> None:
+    """Persistent session: state from one command must be visible in the next."""
+    r1 = await runtime.run_in_session(BashAction(command="export FOO=bar", timeout=10))
+    assert r1.exit_code == 0
+
+    r2 = await runtime.run_in_session(BashAction(command="echo $FOO", timeout=10))
+    assert r2.exit_code == 0
+    assert r2.output.strip() == "bar"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_commands_are_serialized(runtime: HostRuntime) -> None:
+    """Concurrent run_in_session calls must not interleave their stdout/stdin."""
+    commands = [f"echo line_{i}" for i in range(8)]
+    results = await asyncio.gather(
+        *(runtime.run_in_session(BashAction(command=c, timeout=10)) for c in commands)
+    )
+    outputs = [r.output.strip() for r in results]
+    # Each result must match exactly one input, with no cross-contamination.
+    assert sorted(outputs) == sorted(f"line_{i}" for i in range(8))
+    for r in results:
+        assert r.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_timeout_does_not_pollute_next_command(runtime: HostRuntime) -> None:
+    """After a timeout, the next command must see a clean stdout stream."""
+    with pytest.raises(CommandTimeoutError):
+        await runtime.run_in_session(BashAction(command="sleep 30", timeout=1))
+
+    # Next command should return exactly its own output, no leftover markers
+    # or "sleep" output bleeding in.
+    r = await runtime.run_in_session(BashAction(command="echo recovered", timeout=10))
+    assert r.exit_code == 0
+    assert r.output.strip() == "recovered"
+
+
+@pytest.mark.asyncio
+async def test_interrupt_unblocks_running_command(runtime: HostRuntime) -> None:
+    """BashInterruptAction must be deliverable while another command holds the
+    IO lock, and the next command must still work."""
+
+    async def long_running() -> None:
+        with pytest.raises(CommandTimeoutError):
+            await runtime.run_in_session(BashAction(command="sleep 30", timeout=2))
+
+    task = asyncio.create_task(long_running())
+    await asyncio.sleep(0.3)
+    # Interrupt while `sleep` is blocking inside the lock holder.
+    await runtime.run_in_session(BashInterruptAction(timeout=5))
+    await task
+
+    r = await runtime.run_in_session(BashAction(command="echo after_interrupt", timeout=10))
+    assert r.output.strip() == "after_interrupt"
+
+
+@pytest.mark.asyncio
+async def test_session_rebuilds_after_bash_dies(runtime: HostRuntime) -> None:
+    """If the bash process exits, the next call should transparently rebuild."""
+    proc = runtime._process
+    assert proc is not None
+    proc.kill()
+    await proc.wait()
+
+    r = await runtime.run_in_session(BashAction(command="echo alive_again", timeout=10))
+    assert r.exit_code == 0
+    assert r.output.strip() == "alive_again"
+    assert runtime._process is not None and runtime._process.returncode is None

--- a/tests/uni_agent/deployment/test_host_runtime.py
+++ b/tests/uni_agent/deployment/test_host_runtime.py
@@ -101,9 +101,7 @@ async def test_interrupt_kills_entire_pipeline(runtime: HostRuntime) -> None:
     result: dict[str, object] = {}
 
     async def long_pipeline() -> None:
-        result["obs"] = await runtime.run_in_session(
-            BashAction(command="sleep 30 | cat | cat", timeout=15)
-        )
+        result["obs"] = await runtime.run_in_session(BashAction(command="sleep 30 | cat | cat", timeout=15))
 
     task = asyncio.create_task(long_pipeline())
     await asyncio.sleep(0.3)

--- a/tests/uni_agent/deployment/test_host_runtime.py
+++ b/tests/uni_agent/deployment/test_host_runtime.py
@@ -47,9 +47,7 @@ async def test_sequential_commands_keep_session_state(runtime: HostRuntime) -> N
 async def test_concurrent_commands_are_serialized(runtime: HostRuntime) -> None:
     """Concurrent run_in_session calls must not interleave their stdout/stdin."""
     commands = [f"echo line_{i}" for i in range(8)]
-    results = await asyncio.gather(
-        *(runtime.run_in_session(BashAction(command=c, timeout=10)) for c in commands)
-    )
+    results = await asyncio.gather(*(runtime.run_in_session(BashAction(command=c, timeout=10)) for c in commands))
     outputs = [r.output.strip() for r in results]
     # Each result must match exactly one input, with no cross-contamination.
     assert sorted(outputs) == sorted(f"line_{i}" for i in range(8))

--- a/tests/uni_agent/deployment/test_host_runtime.py
+++ b/tests/uni_agent/deployment/test_host_runtime.py
@@ -12,7 +12,7 @@ import pytest_asyncio
 
 pytest.importorskip("swerex")
 
-from swerex.exceptions import CommandTimeoutError  # noqa: E402
+from swerex.exceptions import CommandTimeoutError, SessionNotInitializedError  # noqa: E402
 from swerex.runtime.abstract import (  # noqa: E402
     BashAction,
     BashInterruptAction,
@@ -72,32 +72,41 @@ async def test_timeout_does_not_pollute_next_command(runtime: HostRuntime) -> No
 
 @pytest.mark.asyncio
 async def test_interrupt_unblocks_running_command(runtime: HostRuntime) -> None:
-    """BashInterruptAction must be deliverable while another command holds the
-    IO lock, and the next command must still work."""
+    """BashInterruptAction must be deliverable while another command holds
+    the IO lock. The interrupted run_in_session should return cleanly with
+    a non-zero exit code (SIGINT → 130), not hang or pollute the next call."""
+    result: dict[str, object] = {}
 
     async def long_running() -> None:
-        with pytest.raises(CommandTimeoutError):
-            await runtime.run_in_session(BashAction(command="sleep 30", timeout=2))
+        # Use a generous timeout: we expect the interrupt to finish this
+        # well before the deadline.
+        result["obs"] = await runtime.run_in_session(BashAction(command="sleep 30", timeout=15))
 
     task = asyncio.create_task(long_running())
     await asyncio.sleep(0.3)
-    # Interrupt while `sleep` is blocking inside the lock holder.
     await runtime.run_in_session(BashInterruptAction(timeout=5))
-    await task
+    await asyncio.wait_for(task, timeout=5)
+
+    obs = result["obs"]
+    assert obs.exit_code == 130, f"expected SIGINT exit code, got {obs.exit_code}"
 
     r = await runtime.run_in_session(BashAction(command="echo after_interrupt", timeout=10))
+    assert r.exit_code == 0
     assert r.output.strip() == "after_interrupt"
 
 
 @pytest.mark.asyncio
-async def test_session_rebuilds_after_bash_dies(runtime: HostRuntime) -> None:
-    """If the bash process exits, the next call should transparently rebuild."""
+async def test_dead_session_raises_instead_of_silent_rebuild(runtime: HostRuntime) -> None:
+    """If the bash process exits, the next call must surface the failure so
+    the upper layer can fail the episode, rather than silently respawning a
+    fresh shell with lost state."""
     proc = runtime._process
     assert proc is not None
     proc.kill()
     await proc.wait()
 
-    r = await runtime.run_in_session(BashAction(command="echo alive_again", timeout=10))
-    assert r.exit_code == 0
-    assert r.output.strip() == "alive_again"
-    assert runtime._process is not None and runtime._process.returncode is None
+    with pytest.raises(SessionNotInitializedError):
+        await runtime.run_in_session(BashAction(command="echo never_runs", timeout=10))
+
+    alive = await runtime.is_alive()
+    assert not alive.is_alive

--- a/tests/uni_agent/deployment/test_host_runtime.py
+++ b/tests/uni_agent/deployment/test_host_runtime.py
@@ -94,6 +94,31 @@ async def test_interrupt_unblocks_running_command(runtime: HostRuntime) -> None:
 
 
 @pytest.mark.asyncio
+async def test_interrupt_kills_entire_pipeline(runtime: HostRuntime) -> None:
+    """A pipeline (e.g. `sleep 30 | cat | cat`) spawns multiple processes
+    in one process group. Interrupt must signal the whole group, otherwise
+    bash stays blocked waiting for the surviving stages to finish."""
+    result: dict[str, object] = {}
+
+    async def long_pipeline() -> None:
+        result["obs"] = await runtime.run_in_session(
+            BashAction(command="sleep 30 | cat | cat", timeout=15)
+        )
+
+    task = asyncio.create_task(long_pipeline())
+    await asyncio.sleep(0.3)
+    await runtime.run_in_session(BashInterruptAction(timeout=5))
+    await asyncio.wait_for(task, timeout=5)
+
+    obs = result["obs"]
+    assert obs.exit_code != 0, "pipeline should not exit cleanly after SIGINT"
+
+    r = await runtime.run_in_session(BashAction(command="echo still_alive", timeout=10))
+    assert r.exit_code == 0
+    assert r.output.strip() == "still_alive"
+
+
+@pytest.mark.asyncio
 async def test_dead_session_raises_instead_of_silent_rebuild(runtime: HostRuntime) -> None:
     """If the bash process exits, the next call must surface the failure so
     the upper layer can fail the episode, rather than silently respawning a

--- a/uni_agent/deployment/host/deployment.py
+++ b/uni_agent/deployment/host/deployment.py
@@ -56,9 +56,7 @@ def _list_child_pids(parent_pid: int) -> list[int]:
         except (FileNotFoundError, PermissionError, ValueError):
             pass
     try:
-        out = subprocess.check_output(
-            ["pgrep", "-P", str(parent_pid)], stderr=subprocess.DEVNULL
-        )
+        out = subprocess.check_output(["pgrep", "-P", str(parent_pid)], stderr=subprocess.DEVNULL)
         return [int(p) for p in out.decode().split() if p]
     except (FileNotFoundError, subprocess.CalledProcessError):
         return []
@@ -120,9 +118,7 @@ class HostRuntime(AbstractRuntime):
             raise SessionNotInitializedError("Host bash session has not been started")
         if self._process.returncode is not None:
             self._dead = True
-            raise SessionNotInitializedError(
-                f"Host bash session exited (returncode={self._process.returncode})"
-            )
+            raise SessionNotInitializedError(f"Host bash session exited (returncode={self._process.returncode})")
 
     async def _read_until_marker(self, marker: str, timeout: float) -> tuple[str, int]:
         """Read stdout until the marker line appears. Returns (output, exit_code)."""
@@ -261,11 +257,7 @@ class HostRuntime(AbstractRuntime):
         return UploadResponse()
 
     async def is_alive(self, *, timeout: float | None = None) -> IsAliveResponse:
-        alive = (
-            not self._dead
-            and self._process is not None
-            and self._process.returncode is None
-        )
+        alive = not self._dead and self._process is not None and self._process.returncode is None
         return IsAliveResponse(is_alive=alive)
 
     async def close_session(self, request: CloseSessionRequest) -> CloseSessionResponse:

--- a/uni_agent/deployment/host/deployment.py
+++ b/uni_agent/deployment/host/deployment.py
@@ -4,13 +4,19 @@ import asyncio
 import os
 import shutil
 import signal
+import subprocess
+import sys
 import uuid
 from pathlib import Path
 from typing import Any, Self
 
 from swerex.deployment.abstract import AbstractDeployment
 from swerex.deployment.hooks.abstract import CombinedDeploymentHook, DeploymentHook
-from swerex.exceptions import CommandTimeoutError, DeploymentNotStartedError
+from swerex.exceptions import (
+    CommandTimeoutError,
+    DeploymentNotStartedError,
+    SessionNotInitializedError,
+)
 from swerex.runtime.abstract import (
     AbstractRuntime,
     Action,
@@ -37,6 +43,27 @@ from uni_agent.async_logging import get_logger
 from uni_agent.deployment.config import HostDeploymentConfig
 
 
+def _list_child_pids(parent_pid: int) -> list[int]:
+    """Return direct child PIDs of `parent_pid`.
+
+    On Linux we read /proc/PID/task/PID/children, which is cheap and exact.
+    Elsewhere (macOS, etc.) we fall back to `pgrep -P`.
+    """
+    if sys.platform.startswith("linux"):
+        try:
+            with open(f"/proc/{parent_pid}/task/{parent_pid}/children") as f:
+                return [int(p) for p in f.read().split() if p]
+        except (FileNotFoundError, PermissionError, ValueError):
+            pass
+    try:
+        out = subprocess.check_output(
+            ["pgrep", "-P", str(parent_pid)], stderr=subprocess.DEVNULL
+        )
+        return [int(p) for p in out.decode().split() if p]
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return []
+
+
 class HostRuntime(AbstractRuntime):
     """Runtime that executes commands in a persistent local bash session."""
 
@@ -49,17 +76,14 @@ class HostRuntime(AbstractRuntime):
         # of the lock (a blocked `_read_until_marker`) gets unblocked when bash
         # finishes the interrupted command and prints the trailing marker.
         self._io_lock = asyncio.Lock()
-        # Session start time + a generation counter so a stale rebuild does
-        # not clobber a fresh session created by a concurrent path.
-        self._session_startup_timeout: float = 10.0
-        self._broken = False
+        # Once the session is unusable (bash died, or stdout cannot be drained
+        # after a timeout), we don't try to rebuild it: state would be lost
+        # silently. Instead we mark it dead and surface errors so the upper
+        # layer can fail the episode, matching the sandbox-based deployments.
+        self._dead = False
 
     async def create_session(self, request: CreateSessionRequest) -> CreateSessionResponse:
-        self._session_startup_timeout = request.startup_timeout or 10
-        await self._spawn_bash(self._session_startup_timeout)
-        return CreateSessionResponse()
-
-    async def _spawn_bash(self, startup_timeout: float) -> None:
+        startup_timeout = request.startup_timeout or 10
         self._process = await asyncio.create_subprocess_exec(
             "bash",
             "--norc",
@@ -68,28 +92,37 @@ class HostRuntime(AbstractRuntime):
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
             env=self._env,
+            # Job control (`set -m` below) puts each foreground command in
+            # its own process group, so we can SIGINT just the user command
+            # without killing the bash shell itself.
+            start_new_session=True,
         )
-        setup = "export PS1='' PS2='' PROMPT_COMMAND=''\n"
+        # `set -m` enables job control; PS1/PS2/PROMPT_COMMAND are zeroed so
+        # nothing accidentally injects bytes between commands.
+        setup = "set -m\nexport PS1='' PS2='' PROMPT_COMMAND=''\n"
         self._process.stdin.write(setup.encode())
         await self._process.stdin.drain()
         marker = f"__UNIAGENT_READY_{uuid.uuid4().hex[:12]}__"
         self._process.stdin.write(f"echo '{marker}'\n".encode())
         await self._process.stdin.drain()
         await self._read_until_marker(marker, timeout=startup_timeout)
-        self._broken = False
+        self._dead = False
         self.logger.info("Host bash session created")
+        return CreateSessionResponse()
 
-    async def _ensure_session(self) -> None:
-        """Rebuild bash if the previous one died or was marked broken."""
-        if self._process is None or self._process.returncode is not None or self._broken:
-            if self._process is not None and self._process.returncode is None:
-                try:
-                    self._process.kill()
-                    await asyncio.wait_for(self._process.wait(), timeout=2)
-                except Exception:
-                    pass
-            self.logger.warning("Rebuilding host bash session")
-            await self._spawn_bash(self._session_startup_timeout)
+    def _check_session_alive(self) -> None:
+        """Raise if the session is unusable. Callers are expected to surface
+        this so the upper layer can fail the episode instead of silently
+        running on a partially-recovered or fresh session with lost state."""
+        if self._dead:
+            raise SessionNotInitializedError("Host bash session is no longer usable")
+        if self._process is None:
+            raise SessionNotInitializedError("Host bash session has not been started")
+        if self._process.returncode is not None:
+            self._dead = True
+            raise SessionNotInitializedError(
+                f"Host bash session exited (returncode={self._process.returncode})"
+            )
 
     async def _read_until_marker(self, marker: str, timeout: float) -> tuple[str, int]:
         """Read stdout until the marker line appears. Returns (output, exit_code)."""
@@ -118,20 +151,21 @@ class HostRuntime(AbstractRuntime):
 
     async def run_in_session(self, action: Action) -> Observation:
         if isinstance(action, BashInterruptAction):
-            # Fire SIGINT WITHOUT taking the IO lock so we can interrupt a
-            # command whose run_in_session is currently waiting on stdout.
-            # bash will abort the foreground command and resume reading stdin,
-            # so the original `_read_until_marker` call will eventually see
-            # its marker (with exit_code != 0) and return cleanly.
-            if self._process and self._process.returncode is None:
-                self._process.send_signal(signal.SIGINT)
+            # SIGINT the foreground child of bash, NOT bash itself. With
+            # `set -m`, bash puts each command in its own process group, so
+            # this kills only the user command. bash then resumes reading
+            # stdin, the trailing marker line gets printed, and the original
+            # `_read_until_marker` call returns cleanly with exit_code=130.
+            # We do this outside the IO lock so we can interrupt a command
+            # whose run_in_session is currently waiting on stdout.
+            self._signal_foreground_child(signal.SIGINT)
             return Observation(output="", exit_code=130)
 
         if not isinstance(action, BashAction):
             raise TypeError(f"Unsupported action type: {type(action)}")
 
         async with self._io_lock:
-            await self._ensure_session()
+            self._check_session_alive()
 
             marker = f"__UNIAGENT_{uuid.uuid4().hex[:16]}__"
             wrapped = f"{action.command}\n__ua_ec=$?\necho '{marker}'\"$__ua_ec\"\n"
@@ -143,11 +177,12 @@ class HostRuntime(AbstractRuntime):
             try:
                 output, exit_code = await self._read_until_marker(marker, timeout)
             except CommandTimeoutError:
-                # The user's command is still running inside bash. Try to
-                # interrupt it and drain stdout up to the original marker so
-                # the next command starts on a clean stream. If that fails,
-                # mark the session broken so the next call rebuilds it.
-                await self._recover_after_timeout(marker)
+                # User command is still running. Try to interrupt it and drain
+                # stdout up to the original marker so the next command sees a
+                # clean stream. If draining fails, mark the session dead so
+                # subsequent calls raise SessionNotInitializedError and the
+                # upper layer fails the episode.
+                await self._drain_after_timeout(marker)
                 raise
 
             if output.endswith("\n"):
@@ -155,27 +190,37 @@ class HostRuntime(AbstractRuntime):
 
             return Observation(output=output, exit_code=exit_code)
 
-    async def _recover_after_timeout(self, pending_marker: str) -> None:
-        """Best-effort: SIGINT the running command and consume residual output
-        up to its marker. Marks the session broken on failure."""
+    async def _drain_after_timeout(self, pending_marker: str) -> None:
+        """SIGINT the running user command and consume residual output up to
+        its marker so the next command starts on a clean stream. If we
+        cannot drain, mark the session as dead."""
         if self._process is None or self._process.returncode is not None:
-            self._broken = True
+            self._dead = True
             return
+        # No child to signal is fine (race: command may have just finished).
+        # Either way, try to drain whatever the marker is following.
+        self._signal_foreground_child(signal.SIGINT)
         try:
-            self._process.send_signal(signal.SIGINT)
-        except ProcessLookupError:
-            self._broken = True
-            return
-        try:
-            # Short timeout: bash should produce the trailing marker quickly
-            # once the foreground command stops. If not, the shell is wedged.
             await self._read_until_marker(pending_marker, timeout=5)
             self.logger.info("Drained residual output after command timeout")
         except CommandTimeoutError:
-            self.logger.warning(
-                "Failed to drain stdout after SIGINT; marking session as broken"
-            )
-            self._broken = True
+            self.logger.warning("Failed to drain stdout after SIGINT; session is dead")
+            self._dead = True
+
+    def _signal_foreground_child(self, sig: int) -> bool:
+        """Send `sig` to bash's direct child processes (its foreground
+        command). With `set -m`, signaling bash itself would either be
+        ignored or kill the shell; we want to kill only the user command.
+        Returns True if at least one signal was delivered."""
+        if self._process is None or self._process.returncode is not None:
+            return False
+        for pid in _list_child_pids(self._process.pid):
+            try:
+                os.kill(pid, sig)
+                return True
+            except ProcessLookupError:
+                continue
+        return False
 
     async def execute(self, command: Command) -> CommandResponse:
         proc = await asyncio.create_subprocess_exec(
@@ -216,7 +261,11 @@ class HostRuntime(AbstractRuntime):
         return UploadResponse()
 
     async def is_alive(self, *, timeout: float | None = None) -> IsAliveResponse:
-        alive = self._process is not None and self._process.returncode is None
+        alive = (
+            not self._dead
+            and self._process is not None
+            and self._process.returncode is None
+        )
         return IsAliveResponse(is_alive=alive)
 
     async def close_session(self, request: CloseSessionRequest) -> CloseSessionResponse:

--- a/uni_agent/deployment/host/deployment.py
+++ b/uni_agent/deployment/host/deployment.py
@@ -44,8 +44,22 @@ class HostRuntime(AbstractRuntime):
         self.logger = get_logger("host-runtime", run_id)
         self._env = dict(env or os.environ)
         self._process: asyncio.subprocess.Process | None = None
+        # Serialize all bash stdin/stdout IO. interrupt_session intentionally
+        # does NOT acquire this lock: it sends SIGINT out-of-band so the holder
+        # of the lock (a blocked `_read_until_marker`) gets unblocked when bash
+        # finishes the interrupted command and prints the trailing marker.
+        self._io_lock = asyncio.Lock()
+        # Session start time + a generation counter so a stale rebuild does
+        # not clobber a fresh session created by a concurrent path.
+        self._session_startup_timeout: float = 10.0
+        self._broken = False
 
     async def create_session(self, request: CreateSessionRequest) -> CreateSessionResponse:
+        self._session_startup_timeout = request.startup_timeout or 10
+        await self._spawn_bash(self._session_startup_timeout)
+        return CreateSessionResponse()
+
+    async def _spawn_bash(self, startup_timeout: float) -> None:
         self._process = await asyncio.create_subprocess_exec(
             "bash",
             "--norc",
@@ -58,14 +72,24 @@ class HostRuntime(AbstractRuntime):
         setup = "export PS1='' PS2='' PROMPT_COMMAND=''\n"
         self._process.stdin.write(setup.encode())
         await self._process.stdin.drain()
-        # Drain any startup output
         marker = f"__UNIAGENT_READY_{uuid.uuid4().hex[:12]}__"
         self._process.stdin.write(f"echo '{marker}'\n".encode())
         await self._process.stdin.drain()
-        startup_timeout = request.startup_timeout or 10
         await self._read_until_marker(marker, timeout=startup_timeout)
+        self._broken = False
         self.logger.info("Host bash session created")
-        return CreateSessionResponse()
+
+    async def _ensure_session(self) -> None:
+        """Rebuild bash if the previous one died or was marked broken."""
+        if self._process is None or self._process.returncode is not None or self._broken:
+            if self._process is not None and self._process.returncode is None:
+                try:
+                    self._process.kill()
+                    await asyncio.wait_for(self._process.wait(), timeout=2)
+                except Exception:
+                    pass
+            self.logger.warning("Rebuilding host bash session")
+            await self._spawn_bash(self._session_startup_timeout)
 
     async def _read_until_marker(self, marker: str, timeout: float) -> tuple[str, int]:
         """Read stdout until the marker line appears. Returns (output, exit_code)."""
@@ -94,30 +118,64 @@ class HostRuntime(AbstractRuntime):
 
     async def run_in_session(self, action: Action) -> Observation:
         if isinstance(action, BashInterruptAction):
+            # Fire SIGINT WITHOUT taking the IO lock so we can interrupt a
+            # command whose run_in_session is currently waiting on stdout.
+            # bash will abort the foreground command and resume reading stdin,
+            # so the original `_read_until_marker` call will eventually see
+            # its marker (with exit_code != 0) and return cleanly.
             if self._process and self._process.returncode is None:
                 self._process.send_signal(signal.SIGINT)
-                await asyncio.sleep(0.5)
             return Observation(output="", exit_code=130)
 
         if not isinstance(action, BashAction):
             raise TypeError(f"Unsupported action type: {type(action)}")
 
+        async with self._io_lock:
+            await self._ensure_session()
+
+            marker = f"__UNIAGENT_{uuid.uuid4().hex[:16]}__"
+            wrapped = f"{action.command}\n__ua_ec=$?\necho '{marker}'\"$__ua_ec\"\n"
+
+            self._process.stdin.write(wrapped.encode())
+            await self._process.stdin.drain()
+
+            timeout = getattr(action, "timeout", 60) or 60
+            try:
+                output, exit_code = await self._read_until_marker(marker, timeout)
+            except CommandTimeoutError:
+                # The user's command is still running inside bash. Try to
+                # interrupt it and drain stdout up to the original marker so
+                # the next command starts on a clean stream. If that fails,
+                # mark the session broken so the next call rebuilds it.
+                await self._recover_after_timeout(marker)
+                raise
+
+            if output.endswith("\n"):
+                output = output[:-1]
+
+            return Observation(output=output, exit_code=exit_code)
+
+    async def _recover_after_timeout(self, pending_marker: str) -> None:
+        """Best-effort: SIGINT the running command and consume residual output
+        up to its marker. Marks the session broken on failure."""
         if self._process is None or self._process.returncode is not None:
-            raise RuntimeError("No active bash session")
-
-        marker = f"__UNIAGENT_{uuid.uuid4().hex[:16]}__"
-        wrapped = f"{action.command}\n__ua_ec=$?\necho '{marker}'\"$__ua_ec\"\n"
-
-        self._process.stdin.write(wrapped.encode())
-        await self._process.stdin.drain()
-
-        timeout = getattr(action, "timeout", 60) or 60
-        output, exit_code = await self._read_until_marker(marker, timeout)
-
-        if output.endswith("\n"):
-            output = output[:-1]
-
-        return Observation(output=output, exit_code=exit_code)
+            self._broken = True
+            return
+        try:
+            self._process.send_signal(signal.SIGINT)
+        except ProcessLookupError:
+            self._broken = True
+            return
+        try:
+            # Short timeout: bash should produce the trailing marker quickly
+            # once the foreground command stops. If not, the shell is wedged.
+            await self._read_until_marker(pending_marker, timeout=5)
+            self.logger.info("Drained residual output after command timeout")
+        except CommandTimeoutError:
+            self.logger.warning(
+                "Failed to drain stdout after SIGINT; marking session as broken"
+            )
+            self._broken = True
 
     async def execute(self, command: Command) -> CommandResponse:
         proc = await asyncio.create_subprocess_exec(

--- a/uni_agent/deployment/host/deployment.py
+++ b/uni_agent/deployment/host/deployment.py
@@ -204,19 +204,38 @@ class HostRuntime(AbstractRuntime):
             self._dead = True
 
     def _signal_foreground_child(self, sig: int) -> bool:
-        """Send `sig` to bash's direct child processes (its foreground
-        command). With `set -m`, signaling bash itself would either be
-        ignored or kill the shell; we want to kill only the user command.
-        Returns True if at least one signal was delivered."""
+        """Send `sig` to bash's foreground job. With `set -m`, bash places
+        each job (including a multi-process pipeline) in its own process
+        group, so we look up each direct child's pgid and signal the group.
+        Signaling bash itself would either be ignored or kill the shell;
+        we want to terminate only the user command, including every stage
+        of a pipeline. Returns True if at least one group was signaled."""
         if self._process is None or self._process.returncode is not None:
             return False
+        signaled_pgids: set[int] = set()
+        delivered = False
         for pid in _list_child_pids(self._process.pid):
             try:
-                os.kill(pid, sig)
-                return True
+                pgid = os.getpgid(pid)
             except ProcessLookupError:
                 continue
-        return False
+            if pgid in signaled_pgids or pgid == self._process.pid:
+                # Skip duplicates and refuse to signal bash's own group,
+                # which would happen if job control somehow wasn't enabled.
+                continue
+            signaled_pgids.add(pgid)
+            try:
+                os.killpg(pgid, sig)
+                delivered = True
+            except (ProcessLookupError, PermissionError):
+                # Fall back to per-pid kill if the group is gone or we
+                # don't have permission for killpg.
+                try:
+                    os.kill(pid, sig)
+                    delivered = True
+                except ProcessLookupError:
+                    continue
+        return delivered
 
     async def execute(self, command: Command) -> CommandResponse:
         proc = await asyncio.create_subprocess_exec(

--- a/uni_agent/interaction/env.py
+++ b/uni_agent/interaction/env.py
@@ -139,8 +139,12 @@ class AgentEnv:
                 # check current terminal is still alive
                 terminal_alive = False
                 for _ in range(5):
-                    terminal_alive = await self.communicate("echo 'terminal still alive'", check="ignore")
-                    if isinstance(terminal_alive, str) and terminal_alive.strip() == "terminal still alive":
+                    probe_output = await self.communicate("echo 'terminal still alive'", check="ignore")
+                    # Use substring match on stripped lines so residual marker
+                    # noise from a recovering session does not fail the probe.
+                    if isinstance(probe_output, str) and any(
+                        line.strip() == "terminal still alive" for line in probe_output.splitlines()
+                    ):
                         terminal_alive = True
                         break
                 if not terminal_alive:


### PR DESCRIPTION
### What does this PR do?

Fix bugs in host deployment:
Use IO lock to serialize all stdin write and stdout read.
Timeout commands will not  pollute stdout.

Add a unit test.


### Checklist Before Starting

- [x] Search for similar PRs or issues and paste at least one relevant link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (checked by CI)
  - `{modules}` may include `core`, `interaction`, `model`, `env`, `tools`, `deployment`, `reward`, `dashboard`, `docs`, `examples`, `data`, `train`, `ci`, `build`, `deps`, `misc`
  - If this PR involves multiple modules, separate them with `,` like `[interaction, tools, docs]`
  - `{type}` must be one of `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks an API, config contract, workflow, or other compatibility boundary, add `[BREAKING]` to the beginning of the title
  - For a stacked PR series, you may prepend a progress marker such as `[1/N]`
  - Example: `[BREAKING][deployment, docs] feat: simplify runtime env configuration`

### Test

> List the checks you ran. If CI coverage is not practical for this change, describe the manual validation or experiment results.

### API and Usage Example

> Show any public interface changes or updated usage examples if relevant.

```python
# Add a short example here when the PR changes public behavior
```

### Design & Code Changes

> Summarize the approach for non-trivial changes and call out important implementation details or trade-offs.

### Checklist Before Submitting

- [ ] Read the [Contribute Guide](../CONTRIBUTING.md)
- [ ] Run `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add or update docs/examples for user-facing changes
- [ ] Add tests or explain why tests are not practical
- [ ] Confirm the PR title matches the required format
- [ ] Confirm the placeholder text in this template has been replaced with real content
