### PR TITLE
[deployment, docs] feat: Local deployment sandbox

### DIFF
--- a/docs/source/start/agent_env.md
+++ b/docs/source/start/agent_env.md
@@ -18,19 +18,23 @@ The first step is to start a sandbox. You can do this either locally or on a rem
 
 ### Local deployment
 
-**This implementation has not been completed and tested now.**
+Local deployment starts a sandbox on the current machine, then connects to the `swerex` server inside that sandbox. This is the easiest way to debug environment behavior before moving to a remote platform.
 
-Local deployment uses SWE-ReX's built-in local runtime. It runs commands on the current machine while preserving shell session state through `AgentEnv`.
+The local backend prefers Apptainer or Singularity when available. Docker and Podman are also supported and can be selected explicitly with `container_runtime` or discovered from `PATH` when Apptainer/Singularity are not installed.
 
-**Dependencies.** Install the runtime package:
+**Dependencies.** Install the runtime package and make sure a supported runtime is available. For Apptainer:
 
 ```bash
-pip install swerex
+pip install swe-rex
+apptainer --version
 ```
+
+If your runtime is not on `PATH`, set `LOCAL_CONTAINER_RUNTIME` or `UNI_AGENT_CONTAINER_RUNTIME` to the binary path. When no explicit `container_runtime` is provided, the local backend checks these environment variables, then discovers `apptainer`, `singularity`, `docker`, or `podman` from `PATH`.
 
 **Config and start.** Build the config, create the environment, and start it:
 
 ```python
+import os
 import uuid
 from uni_agent.interaction import AgentEnv, AgentEnvConfig
 
@@ -38,6 +42,13 @@ run_id = str(uuid.uuid4())
 env_config = {
     "deployment": {
         "type": "local",
+        "image": os.getenv("LOCAL_DEPLOYMENT_IMAGE", "python:3.12"),
+        "command": (
+            "python3 -m pip install -q swe-rex && "
+            "python3 -m swerex.server --host 0.0.0.0 --port {port} --auth-token {token}"
+        ),
+        "timeout": 300.0,
+        "startup_timeout": 180.0,
     },
     "env_variables": {
         "PIP_PROGRESS_BAR": "off",
@@ -49,11 +60,27 @@ env.start()
 ```
 
 - **`type`** must be `"local"`.
+- **`image`** is the sandbox image. For Apptainer, plain image names such as `python:3.12` are treated as Docker/OCI images and run as `docker://python:3.12`.
+- **`command`** runs inside the sandbox and should start `swerex.server`. It can use `{token}` and `{port}` placeholders.
+- **`container_runtime`** can be set to an Apptainer/Singularity binary path, `docker`, or `podman`.
+- **`published_port`** optionally pins the localhost port used by the `swerex` server.
+- **`extra_run_args`** can pass additional runtime flags. For example, Apptainer bind mounts or GPU flags must appear before the image argument.
+- **`network`** is Docker/Podman-specific and useful when the current process is itself running inside Docker.
+
+Apptainer launches the server with host networking, so the selected port is passed directly to `swerex.server`. Docker and Podman keep using port publishing.
 
 You can run the full demo from the repo root with:
 
 ```bash
-DEPLOYMENT=local python examples/agent_env/demo.py
+DEPLOYMENT=local DEBUG_MODE=1 python examples/agent_env/demo.py
+```
+
+Useful local overrides:
+
+```bash
+export LOCAL_CONTAINER_RUNTIME=/opt/apptainer/bin/apptainer
+export LOCAL_DEPLOYMENT_IMAGE=python:3.12
+export LOCAL_DEPLOYMENT_EXTRA_ARGS="--bind /data:/data"
 ```
 
 ### Remote deployment (VEFAAS)

--- a/examples/agent_env/demo.py
+++ b/examples/agent_env/demo.py
@@ -1,7 +1,11 @@
 # ruff: noqa: E501
 import os
 import shlex
+import sys
 import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from uni_agent.interaction import AgentEnv, AgentEnvConfig
 from uni_agent.tools import ToolConfig
@@ -11,7 +15,32 @@ run_id = str(uuid.uuid4())
 impl = os.getenv("DEPLOYMENT", "vefaas").lower()
 
 if impl == "local":
-    raise NotImplementedError("Local deployment is not implemented yet")
+    deployment_config = {
+        "type": "local",
+        "image": os.getenv("LOCAL_DEPLOYMENT_IMAGE", "python:3.12"),
+        "command": os.getenv(
+            "LOCAL_DEPLOYMENT_COMMAND",
+            "python3 -m pip install -q swe-rex && "
+            "python3 -m swerex.server --host 0.0.0.0 --port {port} --auth-token {token}",
+        ),
+        "timeout": 300.0,
+        "startup_timeout": 180.0,
+    }
+    local_runtime = os.getenv("LOCAL_CONTAINER_RUNTIME")
+    local_network = os.getenv("LOCAL_DEPLOYMENT_NETWORK")
+    local_host = os.getenv("LOCAL_DEPLOYMENT_HOST")
+    local_port = os.getenv("LOCAL_DEPLOYMENT_PORT")
+    local_extra_args = os.getenv("LOCAL_DEPLOYMENT_EXTRA_ARGS")
+    if local_runtime:
+        deployment_config["container_runtime"] = local_runtime
+    if local_network:
+        deployment_config["network"] = local_network
+    if local_host:
+        deployment_config["host"] = local_host
+    if local_port:
+        deployment_config["published_port"] = int(local_port)
+    if local_extra_args:
+        deployment_config["extra_run_args"] = shlex.split(local_extra_args)
 elif impl == "vefaas":
     assert os.getenv("VOLCE_ACCESS_KEY") is not None, "VOLCE_ACCESS_KEY must be set"
     assert os.getenv("VOLCE_SECRET_KEY") is not None, "VOLCE_SECRET_KEY must be set"

--- a/tests/deployment/test_local_deployment.py
+++ b/tests/deployment/test_local_deployment.py
@@ -1,0 +1,198 @@
+import asyncio
+
+from uni_agent.deployment.local import deployment as local_deployment
+from uni_agent.deployment.local.deployment import (
+    LocalDeployment,
+    _is_apptainer_runtime,
+    _normalize_apptainer_image,
+)
+
+
+def _clear_runtime_env(monkeypatch):
+    for env_var in local_deployment._CONTAINER_RUNTIME_ENV_VARS:
+        monkeypatch.delenv(env_var, raising=False)
+
+
+def test_default_container_runtime_uses_env_override_before_path(monkeypatch):
+    monkeypatch.setenv("UNI_AGENT_CONTAINER_RUNTIME", "/custom/bin/runtime")
+    monkeypatch.setenv("LOCAL_CONTAINER_RUNTIME", "/local/bin/runtime")
+    monkeypatch.setattr(local_deployment.shutil, "which", lambda runtime: f"/usr/bin/{runtime}")
+
+    assert local_deployment._default_container_runtime() == "/custom/bin/runtime"
+
+
+def test_default_container_runtime_uses_local_env_override(monkeypatch):
+    monkeypatch.delenv("UNI_AGENT_CONTAINER_RUNTIME", raising=False)
+    monkeypatch.setenv("LOCAL_CONTAINER_RUNTIME", "/local/bin/apptainer")
+    monkeypatch.setattr(local_deployment.shutil, "which", lambda runtime: f"/usr/bin/{runtime}")
+
+    assert local_deployment._default_container_runtime() == "/local/bin/apptainer"
+
+
+def test_default_container_runtime_discovers_supported_runtime_from_path(monkeypatch):
+    _clear_runtime_env(monkeypatch)
+    paths = {"singularity": "/usr/bin/singularity", "docker": "/usr/bin/docker"}
+    calls = []
+
+    def fake_which(runtime):
+        calls.append(runtime)
+        return paths.get(runtime)
+
+    monkeypatch.setattr(local_deployment.shutil, "which", fake_which)
+
+    assert local_deployment._default_container_runtime() == "/usr/bin/singularity"
+    assert calls == ["apptainer", "singularity"]
+
+
+def test_default_container_runtime_falls_back_to_apptainer_name(monkeypatch):
+    _clear_runtime_env(monkeypatch)
+    monkeypatch.setattr(local_deployment.shutil, "which", lambda runtime: None)
+
+    assert local_deployment._default_container_runtime() == "apptainer"
+
+
+def test_apptainer_runtime_detection_accepts_paths_and_singularity_alias():
+    assert _is_apptainer_runtime("/opt/apptainer/bin/apptainer")
+    assert _is_apptainer_runtime("singularity")
+    assert not _is_apptainer_runtime("docker")
+
+
+def test_normalize_apptainer_image_adds_docker_scheme_for_oci_names():
+    assert _normalize_apptainer_image("python:3.12") == "docker://python:3.12"
+    assert _normalize_apptainer_image("registry.example.com/ns/image:tag") == (
+        "docker://registry.example.com/ns/image:tag"
+    )
+    assert _normalize_apptainer_image("docker://python:3.12") == "docker://python:3.12"
+    assert _normalize_apptainer_image("local-image.sif") == "local-image.sif"
+
+
+def test_apptainer_command_places_runtime_args_before_image_and_uses_shell():
+    deployment = LocalDeployment(
+        run_id="test",
+        type="local",
+        container_runtime="/opt/apptainer/bin/apptainer",
+        image="python:3.12",
+        shell="/bin/sh",
+        extra_run_args=["--bind", "/host:/mnt"],
+    )
+
+    command = deployment._build_apptainer_command("python3 -m swerex.server --port 3456")
+
+    assert command == [
+        "/opt/apptainer/bin/apptainer",
+        "exec",
+        "--cleanenv",
+        "--compat",
+        "--bind",
+        "/host:/mnt",
+        "docker://python:3.12",
+        "/bin/sh",
+        "-lc",
+        "python3 -m swerex.server --port 3456",
+    ]
+
+
+def test_format_command_supports_token_and_port_placeholders():
+    deployment = LocalDeployment(
+        run_id="test",
+        type="local",
+        container_runtime="apptainer",
+        command="server --port {port} --auth-token {token}",
+    )
+
+    assert deployment._format_command(token="secret", port=4567) == "server --port 4567 --auth-token secret"
+
+
+def test_docker_command_keeps_published_to_runtime_port_mapping():
+    deployment = LocalDeployment(
+        run_id="test",
+        type="local",
+        container_runtime="docker",
+        image="python:3.12",
+        runtime_port=8000,
+        shell="/bin/bash",
+        extra_run_args=["--cpus", "1"],
+    )
+    deployment._get_current_container_network = lambda: None
+
+    command = deployment._build_run_command("sandbox-name", 4567, "server")
+
+    assert command == [
+        "docker",
+        "run",
+        "--rm",
+        "-d",
+        "--name",
+        "sandbox-name",
+        "--entrypoint",
+        "/bin/bash",
+        "-p",
+        "4567:8000",
+        "--cpus",
+        "1",
+        "python:3.12",
+        "-lc",
+        "server",
+    ]
+
+
+class _FakeRuntime:
+    def __init__(self):
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+class _FakeProcess:
+    def __init__(self):
+        self.terminated = False
+        self.killed = False
+        self.wait_timeout = None
+
+    def poll(self):
+        return None
+
+    def terminate(self):
+        self.terminated = True
+
+    def wait(self, timeout=None):
+        self.wait_timeout = timeout
+        return 0
+
+    def kill(self):
+        self.killed = True
+
+
+def test_stop_closes_runtime_and_apptainer_process_without_docker_rm(tmp_path):
+    deployment = LocalDeployment(
+        run_id="test",
+        type="local",
+        container_runtime="apptainer",
+    )
+    runtime = _FakeRuntime()
+    process = _FakeProcess()
+    log_path = tmp_path / "apptainer.log"
+    log_path.write_text("server log", encoding="utf-8")
+    log_handle = log_path.open("a", encoding="utf-8")
+
+    deployment._runtime = runtime
+    deployment._server_process = process
+    deployment._server_log_path = log_path
+    deployment._server_log_handle = log_handle
+    deployment._container_name = "sandbox-name"
+    deployment._container_id = "container-id"
+    deployment._stopped = False
+
+    asyncio.run(deployment.stop())
+
+    assert runtime.closed
+    assert process.terminated
+    assert not process.killed
+    assert process.wait_timeout == 10
+    assert deployment._server_process is None
+    assert deployment._server_log_handle is None
+    assert deployment._server_log_path is None
+    assert deployment._container_name is None
+    assert deployment._container_id is None
+    assert not log_path.exists()

--- a/uni_agent/deployment/config.py
+++ b/uni_agent/deployment/config.py
@@ -2,7 +2,6 @@ from pathlib import PurePath
 from typing import Annotated, Any, Literal, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field
-from swerex.deployment.config import LocalDeploymentConfig as SwerexLocalDeploymentConfig
 
 
 class HostDeploymentConfig(BaseModel):
@@ -27,8 +26,40 @@ class HostDeploymentConfig(BaseModel):
         return HostDeployment.from_config(self, run_id)
 
 
-class LocalDeploymentConfig(SwerexLocalDeploymentConfig):
-    """SWE-ReX local config with Uni-Agent's deployment factory signature."""
+class LocalDeploymentConfig(BaseModel):
+    """Configuration for a local sandbox."""
+
+    image: str = "python:3.12"
+    """Container image used for the sandbox."""
+    command: str = (
+        "python3 -m pip install -q swe-rex && "
+        "python3 -m swerex.server --host 0.0.0.0 --port {port} --auth-token {token}"
+    )
+    """Command to run inside the sandbox."""
+    timeout: float = 60.0
+    """Timeout for runtime operations."""
+    startup_timeout: float = 180.0
+    """Timeout waiting for runtime to start."""
+    container_runtime: str = "apptainer"
+    """Container runtime executable. If omitted by the user, local deployment discovers one at startup."""
+    container_name: str | None = None
+    """Optional container name override."""
+    host: str | None = None
+    """Override the runtime host. Defaults to localhost outside containers and container IP inside containers."""
+    published_port: int | None = None
+    """Host port mapped to the sandbox runtime port. If unset, a free local port is chosen."""
+    runtime_port: int = 8000
+    """Port exposed by the swerex server inside the sandbox."""
+    network: str | None = None
+    """Optional Docker network to attach the sandbox to."""
+    shell: str = "/bin/bash"
+    """Shell executable used as the container entrypoint."""
+    extra_run_args: list[str] = Field(default_factory=list)
+    """Extra args appended to the container runtime startup command."""
+
+    type: Literal["local"] = "local"
+    """Discriminator for (de)serialization/CLI. Do not change."""
+    model_config = ConfigDict(extra="forbid")
 
     def get_deployment(self, run_id: str):
         from .local.deployment import LocalDeployment

--- a/uni_agent/deployment/local/deployment.py
+++ b/uni_agent/deployment/local/deployment.py
@@ -1,32 +1,423 @@
 import asyncio
-from typing import Self
+import os
+import re
+import shlex
+import shutil
+import socket
+import subprocess
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any, Self
 
-from swerex.deployment.local import LocalDeployment as SwerexLocalDeployment
-from swerex.runtime.abstract import CreateBashSessionRequest
+from swerex.deployment.abstract import AbstractDeployment
+from swerex.deployment.hooks.abstract import CombinedDeploymentHook, DeploymentHook
+from swerex.exceptions import DeploymentNotStartedError
+from swerex.runtime.abstract import Command, CreateBashSessionRequest, IsAliveResponse, UploadRequest
+from swerex.utils.wait import _wait_until_alive
 
+from uni_agent.async_logging import get_logger
 from uni_agent.deployment.config import LocalDeploymentConfig
+from uni_agent.deployment.remote_runtime import RemoteRuntime as LocalRuntime
+from uni_agent.deployment.remote_runtime import RemoteRuntimeConfig as LocalRuntimeConfig
+
+_APPTAINER_RUNTIMES = {"apptainer", "singularity"}
+_CONTAINER_RUNTIME_ENV_VARS = ("UNI_AGENT_CONTAINER_RUNTIME", "LOCAL_CONTAINER_RUNTIME")
+_DEFAULT_CONTAINER_RUNTIME_CANDIDATES = ("apptainer", "singularity", "docker", "podman")
+_IMAGE_URI_PREFIXES = (
+    "docker://",
+    "oras://",
+    "library://",
+    "shub://",
+    "instance://",
+    "http://",
+    "https://",
+    "file://",
+)
 
 
-class LocalDeployment(SwerexLocalDeployment):
-    """SWE-ReX local deployment with Uni-Agent retry startup."""
+def _shell_join(parts: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in parts)
+
+
+def _sanitize_name(value: str) -> str:
+    sanitized = re.sub(r"[^a-zA-Z0-9_.-]+", "-", value).strip("-").lower()
+    return sanitized or "uni-agent-local"
+
+
+def _is_running_in_container() -> bool:
+    return Path("/.dockerenv").exists()
+
+
+def _pick_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _default_container_runtime() -> str:
+    for env_var in _CONTAINER_RUNTIME_ENV_VARS:
+        runtime = os.getenv(env_var)
+        if runtime:
+            return runtime
+    for runtime in _DEFAULT_CONTAINER_RUNTIME_CANDIDATES:
+        runtime_path = shutil.which(runtime)
+        if runtime_path:
+            return runtime_path
+    return "apptainer"
+
+
+def _runtime_basename(runtime: str) -> str:
+    return Path(runtime).name.lower()
+
+
+def _is_apptainer_runtime(runtime: str) -> bool:
+    return _runtime_basename(runtime) in _APPTAINER_RUNTIMES
+
+
+def _normalize_apptainer_image(image: str) -> str:
+    if image.startswith(_IMAGE_URI_PREFIXES):
+        return image
+    image_path = Path(image)
+    if image.startswith(("/", ".")) or image_path.exists() or image_path.suffix in {".sif", ".sqsh", ".img"}:
+        return image
+    return f"docker://{image}"
+
+
+class LocalDeployment(AbstractDeployment):
+    def __init__(self, run_id: str, **kwargs: Any):
+        self.run_id = run_id
+        config_kwargs = dict(kwargs)
+        if not config_kwargs.get("container_runtime"):
+            config_kwargs["container_runtime"] = _default_container_runtime()
+        self._config = LocalDeploymentConfig(**config_kwargs)
+        self._runtime: LocalRuntime | None = None
+        self.logger = get_logger("deployment", run_id)
+        self._hooks = CombinedDeploymentHook()
+        self._container_name: str | None = None
+        self._container_id: str | None = None
+        self._server_process: subprocess.Popen[str] | None = None
+        self._server_log_path: Path | None = None
+        self._server_log_handle: Any | None = None
+        self._stopped = False
+
+    def add_hook(self, hook: DeploymentHook):
+        self._hooks.add_hook(hook)
 
     @classmethod
     def from_config(cls, config: LocalDeploymentConfig, run_id: str | None = None) -> Self:
-        return cls(**config.model_dump())
+        if not run_id:
+            run_id = str(uuid.uuid4())
+        config_kwargs = config.model_dump()
+        if "container_runtime" not in config.model_fields_set:
+            config_kwargs["container_runtime"] = _default_container_runtime()
+        return cls(run_id=run_id, **config_kwargs)
+
+    async def is_alive(self, *, timeout: float | None = None) -> IsAliveResponse:
+        if self._runtime is None:
+            raise DeploymentNotStartedError("Runtime not started")
+        return await self._runtime.is_alive(timeout=timeout)
+
+    async def _wait_until_alive(self, timeout: float) -> IsAliveResponse:
+        try:
+            return await _wait_until_alive(self.is_alive, timeout=timeout, function_timeout=0.5)
+        except TimeoutError as e:
+            self.logger.error("Local runtime did not start within timeout.")
+            await self.stop()
+            raise e
+
+    def _get_token(self) -> str:
+        return str(uuid.uuid4())
+
+    def _runtime_exec(self, args: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
+        self.logger.debug(f"Running container runtime command: {_shell_join(args)}")
+        try:
+            return subprocess.run(args, check=check, text=True, capture_output=True)
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"Container runtime {self._config.container_runtime!r} was not found in PATH") from exc
+
+    def _get_current_container_network(self) -> str | None:
+        if not _is_running_in_container():
+            return None
+
+        container_id = os.getenv("HOSTNAME")
+        if not container_id:
+            return None
+
+        try:
+            result = self._runtime_exec(
+                [
+                    self._config.container_runtime,
+                    "inspect",
+                    container_id,
+                    "--format",
+                    "{{range $name, $_ := .NetworkSettings.Networks}}{{println $name}}{{end}}",
+                ]
+            )
+        except subprocess.CalledProcessError as exc:
+            self.logger.warning(
+                f"Failed to inspect current container network: {exc.stderr.strip() or exc.stdout.strip()}"
+            )
+            return None
+
+        networks = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        if not networks:
+            return None
+        return networks[0]
+
+    def _get_container_ip(self, container_name: str) -> str | None:
+        try:
+            result = self._runtime_exec(
+                [
+                    self._config.container_runtime,
+                    "inspect",
+                    container_name,
+                    "--format",
+                    "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}",
+                ]
+            )
+        except subprocess.CalledProcessError as exc:
+            self.logger.warning(f"Failed to inspect sandbox IP: {exc.stderr.strip() or exc.stdout.strip()}")
+            return None
+
+        ip_address = result.stdout.strip()
+        return ip_address or None
+
+    def _get_runtime_host(self, container_name: str) -> str:
+        if self._config.host:
+            return self._config.host
+
+        if _is_running_in_container() or self._config.network:
+            container_ip = self._get_container_ip(container_name)
+            if container_ip:
+                return f"http://{container_ip}"
+
+        return "http://127.0.0.1"
+
+    def _format_command(self, token: str, port: int) -> str:
+        return self._config.command.format(token=token, port=port)
+
+    def _build_run_command(self, container_name: str, published_port: int, command: str) -> list[str]:
+        network = self._config.network or self._get_current_container_network()
+
+        args = [
+            self._config.container_runtime,
+            "run",
+            "--rm",
+            "-d",
+            "--name",
+            container_name,
+            "--entrypoint",
+            self._config.shell,
+        ]
+        if network:
+            args.extend(["--network", network])
+        args.extend(["-p", f"{published_port}:{self._config.runtime_port}"])
+        args.extend(self._config.extra_run_args)
+        args.extend([self._config.image, "-lc", command])
+        return args
+
+    def _build_apptainer_command(self, command: str) -> list[str]:
+        args = [
+            self._config.container_runtime,
+            "exec",
+            "--cleanenv",
+            "--compat",
+        ]
+        args.extend(self._config.extra_run_args)
+        args.extend([_normalize_apptainer_image(self._config.image), self._config.shell, "-lc", command])
+        return args
+
+    def _get_container_logs(self, container_name: str) -> str:
+        if _is_apptainer_runtime(self._config.container_runtime):
+            return self._get_apptainer_logs()
+
+        try:
+            result = self._runtime_exec([self._config.container_runtime, "logs", container_name], check=False)
+        except Exception as exc:
+            return f"<failed to fetch logs: {exc}>"
+        return (result.stdout or result.stderr).strip()
+
+    def _get_apptainer_logs(self) -> str:
+        if self._server_log_handle:
+            try:
+                self._server_log_handle.flush()
+            except Exception:
+                pass
+        if not self._server_log_path:
+            return ""
+        try:
+            return self._server_log_path.read_text(encoding="utf-8", errors="replace").strip()
+        except Exception as exc:
+            return f"<failed to fetch logs: {exc}>"
+
+    def _start_apptainer_process(self, args: list[str]) -> subprocess.Popen[str]:
+        fd, log_path = tempfile.mkstemp(prefix=f"uni-agent-local-{_sanitize_name(self.run_id)}-", suffix=".log")
+        os.close(fd)
+        self._server_log_path = Path(log_path)
+        self._server_log_handle = self._server_log_path.open("w", encoding="utf-8", errors="replace")
+        self.logger.debug(f"Running Apptainer command: {_shell_join(args)}")
+        return subprocess.Popen(
+            args,
+            stdout=self._server_log_handle,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+    async def _start_apptainer(self, token: str, published_port: int) -> None:
+        command = self._format_command(token=token, port=published_port)
+        self._server_process = self._start_apptainer_process(self._build_apptainer_command(command))
+        runtime_config = LocalRuntimeConfig(
+            auth_token=token,
+            host=self._config.host or "http://127.0.0.1",
+            port=published_port,
+            timeout=self._config.timeout,
+        )
+        self._runtime = LocalRuntime.from_config(runtime_config, run_id=self.run_id)
+
+    async def _start_oci_container(self, token: str, container_name: str, published_port: int) -> None:
+        command = self._format_command(token=token, port=self._config.runtime_port)
+        result = self._runtime_exec(self._build_run_command(container_name, published_port, command))
+        self._container_id = result.stdout.strip()
+        runtime_config = LocalRuntimeConfig(
+            auth_token=token,
+            host=self._get_runtime_host(container_name),
+            port=self._config.runtime_port,
+            timeout=self._config.timeout,
+        )
+        self._runtime = LocalRuntime.from_config(runtime_config, run_id=self.run_id)
 
     async def start(self, max_retries: int = 5) -> None:
+        token = self._get_token()
+        published_port = self._config.published_port or _pick_free_port()
+        container_name = self._config.container_name or f"uni-agent-{_sanitize_name(self.run_id)}"
+        self._stopped = False
         last_error: Exception | None = None
-        for retry in range(max_retries):
+        for attempt in range(max_retries):
+            self._stopped = False
+            self.logger.info(
+                f"Starting local deployment with runtime={self._config.container_runtime}, image={self._config.image}."
+            )
+            self._hooks.on_custom_step("Creating local sandbox")
+            self._container_name = container_name
+
             try:
-                await super().start()
-                await self.runtime.create_session(CreateBashSessionRequest())
+                if _is_apptainer_runtime(self._config.container_runtime):
+                    await self._start_apptainer(token=token, published_port=published_port)
+                else:
+                    await self._start_oci_container(
+                        token=token,
+                        container_name=container_name,
+                        published_port=published_port,
+                    )
+
+                await self._wait_until_alive(timeout=self._config.startup_timeout)
+                await self.runtime.create_session(
+                    CreateBashSessionRequest(startup_source=["/root/.bashrc"], startup_timeout=60)
+                )
+                self._stopped = False
                 return
             except Exception as exc:
                 last_error = exc
+                logs = self._get_container_logs(container_name)
+                self.logger.error(f"Failed to start local sandbox: {exc}\nContainer logs:\n{logs}")
                 await self.stop()
-                if retry < max_retries - 1:
-                    sleep_time = min(30, 2**retry)
+                if attempt < max_retries - 1:
+                    sleep_time = min(30, 2**attempt)
                     self.logger.info(f"Retrying local deployment startup in {sleep_time} seconds...")
                     await asyncio.sleep(sleep_time)
 
-        raise RuntimeError(f"Failed to start local deployment after {max_retries} retries") from last_error
+        raise RuntimeError(f"Failed to create local sandbox after {max_retries} retries") from last_error
+
+    async def copy_to_container(self, src: Path, tgt: Path):
+        await self.runtime.execute(Command(command=["mkdir", "-p", str(tgt.parent)]))
+        await self.runtime.upload(UploadRequest(source_path=str(src), target_path=str(tgt)))
+
+    @property
+    def tool_install_dir(self) -> Path:
+        """Directory inside the container where tool scripts are installed."""
+        return Path("/usr/local/bin")
+
+    async def stop(self):
+        if self._stopped:
+            return
+
+        if self._runtime:
+            try:
+                await self._runtime.close()
+            except Exception as exc:
+                self.logger.error(f"Failed to close local runtime within timeout: {exc}")
+            self._runtime = None
+
+        if self._server_process:
+            try:
+                if self._server_process.poll() is None:
+                    self._server_process.terminate()
+                    self._server_process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self._server_process.kill()
+                self._server_process.wait()
+            except Exception as exc:
+                self.logger.error(f"Failed to stop local Apptainer process: {exc}")
+            finally:
+                self._server_process = None
+
+        if self._server_log_handle:
+            try:
+                self._server_log_handle.close()
+            except Exception:
+                pass
+            finally:
+                self._server_log_handle = None
+
+        if self._server_log_path:
+            try:
+                self._server_log_path.unlink(missing_ok=True)
+            except Exception:
+                pass
+            finally:
+                self._server_log_path = None
+
+        if self._container_name and not _is_apptainer_runtime(self._config.container_runtime):
+            try:
+                self._runtime_exec([self._config.container_runtime, "rm", "-f", self._container_name], False)
+            except Exception as exc:
+                self.logger.error(f"Failed to delete local sandbox {self._container_name}: {exc}")
+            finally:
+                self._container_name = None
+                self._container_id = None
+        else:
+            self._container_name = None
+            self._container_id = None
+
+        self._stopped = True
+
+    @property
+    def runtime(self) -> LocalRuntime:
+        if self._runtime is None:
+            raise DeploymentNotStartedError()
+        return self._runtime
+
+    async def __aenter__(self):
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.stop()
+
+    def __del__(self):
+        if hasattr(self, "_container_name") and self._container_name and not getattr(self, "_stopped", False):
+            msg = "Ensuring local deployment is stopped because object is deleted"
+            try:
+                self.logger.debug(msg)
+            except Exception:
+                print(msg)
+            try:
+                loop = asyncio.get_event_loop()
+                if loop.is_running():
+                    loop.create_task(self.stop())
+                else:
+                    loop.run_until_complete(self.stop())
+            except Exception:
+                pass
+        self._stopped = True

--- a/uni_agent/deployment/local/deployment.py
+++ b/uni_agent/deployment/local/deployment.py
@@ -356,10 +356,10 @@ class LocalDeployment(AbstractDeployment):
             try:
                 if self._server_process.poll() is None:
                     self._server_process.terminate()
-                    self._server_process.wait(timeout=10)
+                    await asyncio.to_thread(self._server_process.wait, 10)
             except subprocess.TimeoutExpired:
                 self._server_process.kill()
-                self._server_process.wait()
+                await asyncio.to_thread(self._server_process.wait)
             except Exception as exc:
                 self.logger.error(f"Failed to stop local Apptainer process: {exc}")
             finally:

--- a/uni_agent/deployment/local/deployment.py
+++ b/uni_agent/deployment/local/deployment.py
@@ -383,7 +383,11 @@ class LocalDeployment(AbstractDeployment):
 
         if self._container_name and not _is_apptainer_runtime(self._config.container_runtime):
             try:
-                self._runtime_exec([self._config.container_runtime, "rm", "-f", self._container_name], False)
+                await asyncio.to_thread(
+                    self._runtime_exec,
+                    [self._config.container_runtime, "rm", "-f", self._container_name],
+                    False,
+                )
             except Exception as exc:
                 self.logger.error(f"Failed to delete local sandbox {self._container_name}: {exc}")
             finally:

--- a/uni_agent/deployment/local/deployment.py
+++ b/uni_agent/deployment/local/deployment.py
@@ -277,11 +277,14 @@ class LocalDeployment(AbstractDeployment):
 
     async def _start_oci_container(self, token: str, container_name: str, published_port: int) -> None:
         command = self._format_command(token=token, port=self._config.runtime_port)
-        result = self._runtime_exec(self._build_run_command(container_name, published_port, command))
+        result = await asyncio.to_thread(
+            self._runtime_exec, self._build_run_command(container_name, published_port, command)
+        )
         self._container_id = result.stdout.strip()
+        host = await asyncio.to_thread(self._get_runtime_host, container_name)
         runtime_config = LocalRuntimeConfig(
             auth_token=token,
-            host=self._get_runtime_host(container_name),
+            host=host,
             port=self._config.runtime_port,
             timeout=self._config.timeout,
         )

--- a/uni_agent/interaction/__init__.py
+++ b/uni_agent/interaction/__init__.py
@@ -1,13 +1,26 @@
 from .env import AgentEnv, AgentEnvConfig
-from .interaction import AgentInteraction
-from .model import AgentChatModel, OpenAICompatibleChatModel
-from .tools_manager import ToolsManager, ToolsManagerConfig
+
+
+def __getattr__(name: str):
+    if name == "AgentInteraction":
+        from .interaction import AgentInteraction
+
+        return AgentInteraction
+    if name in {"AgentChatModel", "OpenAICompatibleChatModel"}:
+        from .model import AgentChatModel, OpenAICompatibleChatModel
+
+        return {"AgentChatModel": AgentChatModel, "OpenAICompatibleChatModel": OpenAICompatibleChatModel}[name]
+    if name in {"ToolsManager", "ToolsManagerConfig"}:
+        from .tools_manager import ToolsManager, ToolsManagerConfig
+
+        return {"ToolsManager": ToolsManager, "ToolsManagerConfig": ToolsManagerConfig}[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "AgentInteraction",
     "AgentEnvConfig",
     "AgentEnv",
-    "AgentInteraction",
     "AgentChatModel",
     "OpenAICompatibleChatModel",
     "ToolsManagerConfig",

--- a/uni_agent/interaction/tools_manager.py
+++ b/uni_agent/interaction/tools_manager.py
@@ -104,7 +104,7 @@ class ToolsManager:
                 continue
 
             # Use JSON for structured types so the script can json.loads them
-            if isinstance(param_value, (list | dict)):
+            if isinstance(param_value, list | dict):
                 param_str = json.dumps(param_value, ensure_ascii=False)
             else:
                 param_str = str(param_value)


### PR DESCRIPTION
### What does this PR do?
This PR adds `sandbox` functionality for `local deployment` environment.

### Checklist Before Starting

- [x] Search for similar PRs or issues and paste at least one relevant link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (checked by CI)
  - `{modules}` may include `core`, `interaction`, `model`, `env`, `tools`, `deployment`, `reward`, `dashboard`, `docs`, `examples`, `data`, `train`, `ci`, `build`, `deps`, `misc`
  - If this PR involves multiple modules, separate them with `,` like `[interaction, tools, docs]`
  - `{type}` must be one of `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks an API, config contract, workflow, or other compatibility boundary, add `[BREAKING]` to the beginning of the title
  - For a stacked PR series, you may prepend a progress marker such as `[1/N]`
  - Example: `[BREAKING][deployment, docs] feat: simplify runtime env configuration`

### Test

> List the checks you ran. If CI coverage is not practical for this change, describe the manual validation or experiment results.
+ DEPLOYMENT=local DEBUG_MODE=1 python ./uni-agent/examples/agent_env/demo.py
```shell
$ LOCAL_CONTAINER_RUNTIME=/home/scratch.jianbingd_sw/tools_ai/apptainer/aarch64/bin/apptainer DEPLOYMENT=local DEBUG_MODE=1 python ./uni-agent/examples/agent_env/demo.py
2026-05-11 06:36:24.566 | INFO     | uni_agent.interaction.env:start:65 - Beginning environment startup...
2026-05-11 06:36:24.566 | INFO     | uni_agent.deployment.local.deployment:start:332 - Starting local deployment with runtime=/home/scratch.jianbingd_sw/tools_ai/apptainer/aarch64/bin/apptainer, image=python:3.12.
2026-05-11 06:36:52.356 | INFO     | uni_agent.interaction.env:start:68 - Runtime initialized
2026-05-11 06:36:52.690 | INFO     | uni_agent.interaction.env:install_tools:93 - Tool execute_bash successfully installed
2026-05-11 06:36:55.728 | INFO     | uni_agent.interaction.env:install_tools:93 - Tool str_replace_editor successfully installed
[Tool check] which str_replace_editor
  -> /usr/local/bin/str_replace_editor

============================================================
  Sandbox demo: create script -> run -> output to file -> cat
============================================================

[Step 1] Install numpy
  -> done

[Step 2] str_replace_editor create /tmp/demo.py
  -> done

[Step 3] Run script (python3 /tmp/demo.py > /tmp/demo_out.txt)
  -> done

[Step 4] cat /tmp/demo_out.txt
  -> 6

============================================================
  Demo done (sandbox: script + output file persisted)
============================================================
2026-05-11 06:36:59.356 | INFO     | uni_agent.interaction.env:close:98 - Beginning environment shutdown...
2026-05-11 06:37:09.459 | INFO     | uni_agent.interaction.env:close:100 - Environment shutdown completed

```

### API and Usage Example

> Show any public interface changes or updated usage examples if relevant.

```python
# Add a short example here when the PR changes public behavior
```

### Design & Code Changes

> Summarize the approach for non-trivial changes and call out important implementation details or trade-offs.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](../CONTRIBUTING.md)
- [x] Run `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add or update docs/examples for user-facing changes
- [x] Add tests or explain why tests are not practical
- [x] Confirm the PR title matches the required format
- [x] Confirm the placeholder text in this template has been replaced with real content
