### PR TITLE
[docs] fix: correct example script paths

### DIFF
--- a/docs/source/start/search_agent.md
+++ b/docs/source/start/search_agent.md
@@ -4,7 +4,7 @@ Suppose you want an agent that can search arXiv, read recent paper abstracts, an
 
 With Uni-Agent, this is a small customization task rather than a framework rewrite. In this example, we build an arXiv search agent from scratch and use it to search recent papers, read their abstracts, and produce a ranked paper list.
 
-The runnable code lives in `examples/search_agent/demo.py`.
+The runnable code lives in `examples/search_arxiv/demo.py`.
 
 We will go through the process in three simple steps:
 
@@ -99,7 +99,7 @@ export MODEL_NAME=Qwen/Qwen3-Coder-30B-A3B-Instruct
 Then run the demo from the repository root:
 
 ```bash
-DEBUG_MODE=1 python examples/search_agent/demo.py
+DEBUG_MODE=1 python examples/search_arxiv/demo.py
 ```
 
 Setting `DEBUG_MODE=1` is recommended while developing. It prints the full runtime information to the current terminal, which makes it much easier to inspect environment startup, tool installation, model interaction, and final execution results.

--- a/examples/agent_interaction/README.md
+++ b/examples/agent_interaction/README.md
@@ -29,7 +29,7 @@ Use the `parallel_infer.py` script to start the inference process. It can run **
 
 ```bash
 # From repo root
-python examples/parallel_infer/parallel_infer.py \
+python examples/agent_interaction/parallel_infer.py \
     --data-path ~/data/swe_agent/swe_bench_verified.parquet \
     --model-path /path/to/your/local/model \
     --engine vllm \
@@ -49,7 +49,7 @@ export RUNTIME_ENV=/path/to/runtime_env.yaml   # optional
 
 ray job submit --no-wait --runtime-env "$RUNTIME_ENV" \
   --working-dir "${WORKING_DIR}" \
-  -- python3 examples/parallel_infer/parallel_infer.py \
+  -- python3 examples/agent_interaction/parallel_infer.py \
   --data-path /path/to/swe_bench_verified.parquet \
   --model-path /path/to/model \
   --engine vllm \
@@ -75,7 +75,7 @@ ray job submit --no-wait --runtime-env "$RUNTIME_ENV" \
 
 For a complete list of parameters, run:
 ```bash
-python examples/parallel_infer/parallel_infer.py --help
+python examples/agent_interaction/parallel_infer.py --help
 ```
 
 ## Output

--- a/examples/search_agent/README.md
+++ b/examples/search_agent/README.md
@@ -85,7 +85,7 @@ The training script automatically resolves the Ray head IP and patches the agent
 If you just want to run rollouts without training, point `parallel_infer.py` at the same dataset / agent config:
 
 ```bash
-python examples/parallel_infer/parallel_infer.py \
+python examples/agent_interaction/parallel_infer.py \
     --data-path ~/data/asearcher_uni_processed/test.parquet \
     --model-path /path/to/your/model \
     --agent-config-path examples/search_agent/agent_config.yaml \


### PR DESCRIPTION
### What does this PR do?

Fix stale example script paths in the documentation.

This PR updates references to scripts that no longer exist at the documented paths:

- `examples/search_agent/demo.py` -> `examples/search_arxiv/demo.py`
- `examples/parallel_infer/parallel_infer.py` -> `examples/agent_interaction/parallel_infer.py`

The arXiv search agent page already describes the `search_arxiv` tool and the demo task implemented by `examples/search_arxiv/demo.py`, so the updated path matches the surrounding
documentation.

### Test

- Verified the new script paths exist locally.
- Verified the old script paths do not exist locally.
- Ran `rg` to confirm stale paths are no longer referenced.
- Ran `git diff --check HEAD~1..HEAD`.

### API and Usage Example

Documentation-only change. No API changes.

### Design & Code Changes

No code changes. This only corrects README/docs command examples so users can run the documented scripts from the repository root.