### PR TITLE
[deployment] fix: remove hard-coded veFaaS SDK proxy

### DIFF
--- a/uni_agent/deployment/vefaas/deployment.py
+++ b/uni_agent/deployment/vefaas/deployment.py
@@ -254,7 +254,6 @@ def get_vefaas_client(access_key: str, secret_key: str, region: str):
     configuration.auto_retry = False
     configuration.region = region
     configuration.client_side_validation = True
-    configuration.proxy = "http://[fdbd:dc02:fe:20a2::1]:8118"
     api_client = volcenginesdkcore.ApiClient(configuration)
     return volcenginesdkvefaas.VEFAASApi(api_client)
 


### PR DESCRIPTION
### What does this PR do?

This PR comments out a hard-coded proxy assignment in the veFaaS SDK client configuration.

The `proxy` field itself is provided by the Volcengine SDK. This change only stops Uni-Agent from assigning a fixed proxy URL to it by default:

```python
# When set, requests made by this Volcengine SDK client use this proxy.
# configuration.proxy = "http://[fdbd:dc02:fe:20a2::1]:8118"
```

### Why is this needed?

The previous code always set `configuration.proxy` to a concrete proxy URL when creating the veFaaS SDK client.

When this field is set, requests made by that SDK client use the proxy. Since the URL is environment-specific, keeping it enabled by default can make veFaaS deployment depend on a proxy that may not be available in other environments.

### Test

- `./.venv/bin/pre-commit run --files uni_agent/deployment/vefaas/deployment.py`
- `./.venv/bin/python -m compileall -q uni_agent/deployment/vefaas/deployment.py`
- `PR_TITLE='[deployment] fix: remove hard-coded veFaaS SDK proxy' ./.venv/bin/python tests/special_sanity/check_pr_title.py`
- `git diff --check`