### PR TITLE
[interaction,tools] feat: support lark agent demo + skills system

### DIFF
--- a/examples/lark/demo.py
+++ b/examples/lark/demo.py
@@ -1,30 +1,44 @@
 # ruff: noqa: E501
-"""Demo: run the ``lark-cli`` tool + user-managed skills on a local runtime.
+"""Demo: run a reasoning lark agent on a local_native runtime.
 
-Mirrors ``examples/agent_env/demo.py`` but:
+Mirrors ``examples/search_arxiv/demo.py`` (full ``AgentInteraction``
+reasoning loop) but tailored for lark:
 
-- uses the ``local_native`` deployment (pexpect bash session on the host,
-  no container) so the already-authenticated ``lark-cli`` Just Works;
-- installs the ``lark-cli`` tool (the install step is now an *assertion*
-  -- you must have ``npm install -g @larksuite/cli`` + ``lark-cli auth
-  login`` done beforehand);
-- points ``SkillsManagerConfig.skills_dir`` at a host-side directory you
-  curate (here: ``~/.agents/skills`` since that's where ``npx skills add
-  larksuite/cli -y -g`` lays out the 27 lark-* SKILL.md packs);
-- prints the skills manifest that would be injected into the system
-  prompt and ``cat``s one SKILL.md to show progressive disclosure;
-- runs a couple of ``lark-cli`` commands through the env.
+- ``local_native`` deployment (pexpect bash on the host, no container) so
+  the already-authenticated ``lark-cli`` Just Works -- no copy, no auth
+  shuffle.
+- Tools: ``execute_bash`` + ``lark-cli`` + ``finish``. The ``lark-cli``
+  install step is now an *assertion* (you must have already done
+  ``npm install -g @larksuite/cli`` and ``lark-cli auth login`` on this
+  host); see ``uni_agent/tools/lark_cli/__init__.py``.
+- Skills: user-managed. Drop the SKILL.md packs you want exposed under
+  one directory and point ``SkillsManagerConfig.skills_dir`` at it.
+  ``env.install_skills`` registers the runtime path of each skill on the
+  ``SkillsManager``; ``interaction.inject_skills_manifest()`` then
+  appends an XML manifest (``<available_skills>...``) into the system
+  prompt so the model can ``cat`` the right SKILL.md on demand.
 
-Prereqs (on the host, all one-time):
+Prereqs (on the host, one-time):
 
 1. ``npm install -g @larksuite/cli``
 2. ``lark-cli auth login --recommend``
-3. (Optional, for skills) ``npx skills add larksuite/cli -y -g`` -- drops
-   ~27 ``lark-*`` SKILL.md dirs into ``~/.agents/skills/``. Substitute
-   any other dir you want; just point ``skills_dir`` at it below.
+3. (Optional, for skills) ``npx skills add larksuite/cli -y -g`` or
+   manually copy any ``<name>/SKILL.md`` packs under ``~/.uni-agent/skills/``.
+   Override the directory with ``LARK_SKILLS_DIR=...``.
+4. An OpenAI-compatible chat completion endpoint serving a tool-calling
+   model (e.g. vLLM hosting Qwen3-Coder). Defaults to ``localhost:8000``.
+
+vllm serve /mnt/hdfs/yyding/models/Qwen3.6-35B-A3B \
+  --served-model-name Qwen/Qwen3.6-35B-A3B \
+  --tensor-parallel-size 4 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --port 8000
 
 Run:
 
+    BASE_URL=http://localhost:8000/v1 \
+    MODEL_NAME=Qwen/Qwen3-Coder-30B-A3B-Instruct \
     python examples/lark/demo.py
 """
 
@@ -35,83 +49,219 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from uni_agent.interaction import AgentEnv, AgentEnvConfig
+from uni_agent.interaction import (
+    AgentEnv,
+    AgentEnvConfig,
+    AgentInteraction,
+    OpenAICompatibleChatModel,
+    ToolsManager,
+    ToolsManagerConfig,
+)
 from uni_agent.skills import SkillsManager, SkillsManagerConfig
 from uni_agent.tools import ToolConfig
 
-# --- env config ------------------------------------------------------------
+# --- config ----------------------------------------------------------------
 run_id = str(uuid.uuid4())
 
-deployment_config = {
-    "type": "local_native",
-    "startup_timeout": 60.0,
-}
+user_request = os.getenv(
+    "LARK_USER_REQUEST",
+    "帮我整理一下最近 7 天收到的邮件，私聊发到我自己的飞书。",
+)
 
-# /usr/local/bin usually needs sudo. Override to a user-writable dir.
+model_base_url = os.getenv("BASE_URL", "http://localhost:8000/v1")
+model_api_key = os.getenv("API_KEY", "EMPTY")
+model_name = os.getenv("MODEL_NAME", "Qwen/Qwen3.6-35B-A3B")
+
+# /usr/local/bin usually needs sudo; default to a user-writable dir.
 tool_install_dir = Path(os.getenv("LARK_TOOL_INSTALL_DIR", str(Path.home() / ".uni-agent" / "bin")))
 tool_install_dir.mkdir(parents=True, exist_ok=True)
 
+skills_dir = Path(os.getenv("LARK_SKILLS_DIR", str(Path.home() / ".uni-agent" / "skills")))
+
+print("=" * 80)
+print("Lark reasoning agent")
+print("=" * 80)
+print(f"Run ID:           {run_id}")
+print(f"User request:     {user_request}")
+print(f"Model endpoint:   {model_base_url}")
+print(f"Model name:       {model_name}")
+print(f"API key configured: {model_api_key != 'EMPTY'}")
+print(f"Tool install dir: {tool_install_dir}")
+print(f"Skills dir:       {skills_dir} (exists={skills_dir.is_dir()})")
+
+# --- env -------------------------------------------------------------------
 env_config = AgentEnvConfig(
-    deployment=deployment_config,
+    deployment={
+        "type": "local_native",
+        "startup_timeout": 60.0,
+    },
     tool_install_dir=tool_install_dir,
+    # NO_COLOR / TERM=dumb keep lark-cli from emitting OSC color queries
+    # that pexpect would otherwise echo back into stdout as escape junk.
     env_variables={"NO_COLOR": "1", "TERM": "dumb"},
 )
 env = AgentEnv(run_id=run_id, env_config=env_config)
-env.start()
-
-print(f"[env] local_native runtime ready (tool_install_dir={tool_install_dir})\n")
 
 # --- tools -----------------------------------------------------------------
-tools_config = [
-    {"name": "execute_bash"},
-    {"name": "lark-cli"},
-]
-tools = [ToolConfig(**tc).get_tool() for tc in tools_config]
-env.install_tools(tools)
+tools_manager = ToolsManager(
+    ToolsManagerConfig(
+        tools=[
+            ToolConfig(name="execute_bash"),
+            ToolConfig(name="lark-cli"),
+            ToolConfig(name="finish"),
+        ]
+    )
+)
 
-out = env.communicate("which lark-cli")
-print(f"[tool] which lark-cli\n  -> {out.strip()}\n")
-
-# --- skills (entirely user-managed) ----------------------------------------
-# Drop the SKILL.md packs you want exposed under one directory; the tool
-# itself ships none. Override with $LARK_SKILLS_DIR if you want a custom path.
-skills_dir = Path(os.getenv("LARK_SKILLS_DIR", str(Path.home() / ".uni-agent" / "skills")))
+# --- skills ----------------------------------------------------------------
 skills_manager = SkillsManager.from_config(
     SkillsManagerConfig(skills_dir=skills_dir),
 )
-print(f"[skills] skills_dir={skills_dir} (exists={skills_dir.is_dir()})")
-print(f"[skills] discovered {len(skills_manager.skills)} skill(s): {[s.name for s in skills_manager.skills]}\n")
+print(f"\n[skills] discovered {len(skills_manager.skills)} skill(s): "
+      f"{[s.name for s in skills_manager.skills]}\n")
 
-# For local_native runtime, env.install_skills is a no-op (skills are read
-# in place from the host filesystem). For container runtimes it copies
-# each skill dir to ``/opt/uni-agent/skills/<name>/``.
+# --- model -----------------------------------------------------------------
+model = OpenAICompatibleChatModel(
+    base_url=model_base_url,
+    api_key=model_api_key,
+    model_name=model_name,
+    sampling_params={
+        "temperature": 1.0,
+        "top_p": 0.95,
+        "presence_penalty": 1.5,
+        "top_k": 20,
+        "repetition_penalty": 1.0,
+    },
+)
+model.set_tools_schemas(tools_manager.tools_schemas)
+
+# --- messages --------------------------------------------------------------
+SYSTEM_PROMPT = """You are an agent that helps the user accomplish tasks by calling tools.
+
+# Tools and skills
+
+You have a fixed set of tools available (see the function-calling schema). \
+You also have a library of *skills* -- task-specific instruction packs -- \
+listed under <available_skills> in this system message. Each skill ships \
+with a SKILL.md file describing its command vocabulary, parameters, edge \
+cases, and formatting requirements for a particular domain.
+
+When deciding how to act:
+
+- Inspect <available_skills> first. If a skill's description matches the \
+  user's intent, read its SKILL.md (e.g. `cat <location>`) BEFORE \
+  invoking related commands. SKILL.md is the source of truth for that \
+  domain -- do not guess command syntax, flags, or output formatting.
+- Prefer the most specific skill over generic shell commands. Only fall \
+  back to plain `execute_bash` when no skill applies.
+- Run one command at a time, observe its output, then decide the next \
+  step. Do not assume what an unread command will return.
+
+# Tool-calling discipline
+
+- Every assistant response MUST contain EXACTLY ONE tool call. Never \
+  reply with plain text only, and never emit more than one tool call \
+  per response.
+- When the user's request is fully satisfied, call `finish` with a \
+  short markdown summary of what was done and where the result lives \
+  (e.g. "sent DM to self at 14:32").
+
+# Identity
+
+You are the **bot** in this system. The human you are talking to is the \
+**user**. When a tool exposes an identity flag (e.g. `lark-cli ... --as \
+{bot|user}`):
+
+- Default to `--as bot` for any action that produces output *for* the \
+  user (sending them a DM, posting to a chat the user reads, creating \
+  files the user will consume, etc.). Sending "as user" in those cases \
+  means impersonating the user, which is almost never what they want.
+- Use `--as user` only when the action genuinely requires the user's \
+  own identity / personal scope (e.g. reading the user's private \
+  calendar, mailbox, drafts, drive, OKRs) or when the user explicitly \
+  asks you to act as them.
+- If unsure which identity to use, prefer `--as bot` first; fall back \
+  to `--as user` only after a bot-identity attempt fails with a scope \
+  or visibility error.
+
+# Behavior
+
+- Think briefly before each action; keep tool arguments focused on a \
+  single concrete step.
+- If a command fails with a permission / scope / authentication / \
+  missing-credential error, do NOT retry or attempt to re-authenticate. \
+  Stop, and call `finish` reporting the error so the user can fix \
+  credentials manually.
+- Side-effecting actions (sending messages, writing files, deleting \
+  data, etc.) must stay within the scope of what the user explicitly \
+  asked for. When in doubt, do the read-only version first and confirm \
+  before writing.
+
+# Tone
+
+- Be concise. The user wants results, not narration.
+- Match the user's language (e.g. reply in Chinese if they wrote in \
+  Chinese).
+- Final summaries: short, no preambles like "Sure!" or "Of course".
+"""
+
+messages = [
+    {"role": "system", "content": SYSTEM_PROMPT},
+    {"role": "user", "content": user_request},
+]
+
+# --- interaction -----------------------------------------------------------
+interaction = AgentInteraction(
+    run_id=run_id,
+    env=env,
+    model=model,
+    tools_manager=tools_manager,
+    messages=messages,
+    skills_manager=skills_manager,
+    action_timeout=60,
+    max_turns=100,
+)
+
+
+# --- run -------------------------------------------------------------------
+print("[1/5] Starting environment...")
+env.start()
+
+print("[2/5] Installing tools...")
+env.install_tools(tools_manager.tools)
+tool_check = env.communicate("which lark-cli execute_bash finish")
+print(tool_check.strip())
+
+print("\n[3/5] Installing skills + injecting manifest...")
 env.install_skills(skills_manager)
+interaction.inject_skills_manifest()
 
-print("=" * 60)
-print("  Skills manifest (this goes into the system prompt)")
-print("=" * 60)
-print(skills_manager.build_manifest())
-print()
+print("\n" + "=" * 80)
+print("  Full prompt sent to the model (after manifest injection)")
+print("=" * 80)
+for i, msg in enumerate(interaction.messages):
+    role = msg.get("role", "?")
+    content = msg.get("content", "")
+    header = f"[message #{i}] role={role}  ({len(content):,} chars)"
+    print(f"\n{header}\n{'-' * len(header)}")
+    print(content)
+print("\n" + "=" * 80)
 
-if skills_manager.skills:
-    first = skills_manager.skills[0]
-    skill_md = skills_manager.runtime_paths[first.name].as_posix() + "/SKILL.md"
-    print(f"[skills] runtime path for {first.name!r} -> {skill_md}")
-    print("[skills] first 6 lines of SKILL.md:\n")
-    head = env.communicate(f"head -n 6 {skill_md}")
-    print(head)
+print("\n[4/5] Running interaction loop...")
+result = interaction.run()
+trajectory = result["trajectory"]
 
-# --- run a couple of lark-cli commands -------------------------------------
-print("=" * 60)
-print("  lark-cli smoke test")
-print("=" * 60)
+print("\n[5/5] Final status:")
+last_step = trajectory[-1] if trajectory else None
+if last_step is not None:
+    print(f"  steps:        {len(trajectory)}")
+    print(f"  exit_reason:  {last_step.exit_reason}")
+    print(f"  done:         {last_step.done}")
+else:
+    print("  No step output found.")
 
-print("\n[lark-cli] --version")
-print(env.communicate("lark-cli --version").strip())
-
-# Comment out if auth is not set up.
-print("\n[lark-cli] calendar +agenda (today)")
-print(env.communicate("lark-cli calendar +agenda 2>&1 | head -n 40").strip())
+print("\nFinal result:")
+print(last_step.observation if last_step is not None else "(empty)")
 
 env.close()
 print("\n[env] closed")

--- a/examples/lark/demo.py
+++ b/examples/lark/demo.py
@@ -80,8 +80,7 @@ skills_manager = SkillsManager.from_config(
     SkillsManagerConfig(skills_dir=skills_dir),
 )
 print(f"[skills] skills_dir={skills_dir} (exists={skills_dir.is_dir()})")
-print(f"[skills] discovered {len(skills_manager.skills)} skill(s): "
-      f"{[s.name for s in skills_manager.skills]}\n")
+print(f"[skills] discovered {len(skills_manager.skills)} skill(s): {[s.name for s in skills_manager.skills]}\n")
 
 # For local_native runtime, env.install_skills is a no-op (skills are read
 # in place from the host filesystem). For container runtimes it copies

--- a/examples/lark/demo.py
+++ b/examples/lark/demo.py
@@ -38,7 +38,7 @@ vllm serve /mnt/hdfs/yyding/models/Qwen3.6-35B-A3B \
 Run:
 
     BASE_URL=http://localhost:8000/v1 \
-    MODEL_NAME=Qwen/Qwen3-Coder-30B-A3B-Instruct \
+    MODEL_NAME=Qwen/Qwen3.6-35B-A3B \
     python examples/lark/demo.py
 """
 

--- a/examples/lark/demo.py
+++ b/examples/lark/demo.py
@@ -117,8 +117,7 @@ tools_manager = ToolsManager(
 skills_manager = SkillsManager.from_config(
     SkillsManagerConfig(skills_dir=skills_dir),
 )
-print(f"\n[skills] discovered {len(skills_manager.skills)} skill(s): "
-      f"{[s.name for s in skills_manager.skills]}\n")
+print(f"\n[skills] discovered {len(skills_manager.skills)} skill(s): {[s.name for s in skills_manager.skills]}\n")
 
 # --- model -----------------------------------------------------------------
 model = OpenAICompatibleChatModel(

--- a/examples/lark/demo.py
+++ b/examples/lark/demo.py
@@ -1,0 +1,118 @@
+# ruff: noqa: E501
+"""Demo: run the ``lark-cli`` tool + user-managed skills on a local runtime.
+
+Mirrors ``examples/agent_env/demo.py`` but:
+
+- uses the ``local_native`` deployment (pexpect bash session on the host,
+  no container) so the already-authenticated ``lark-cli`` Just Works;
+- installs the ``lark-cli`` tool (the install step is now an *assertion*
+  -- you must have ``npm install -g @larksuite/cli`` + ``lark-cli auth
+  login`` done beforehand);
+- points ``SkillsManagerConfig.skills_dir`` at a host-side directory you
+  curate (here: ``~/.agents/skills`` since that's where ``npx skills add
+  larksuite/cli -y -g`` lays out the 27 lark-* SKILL.md packs);
+- prints the skills manifest that would be injected into the system
+  prompt and ``cat``s one SKILL.md to show progressive disclosure;
+- runs a couple of ``lark-cli`` commands through the env.
+
+Prereqs (on the host, all one-time):
+
+1. ``npm install -g @larksuite/cli``
+2. ``lark-cli auth login --recommend``
+3. (Optional, for skills) ``npx skills add larksuite/cli -y -g`` -- drops
+   ~27 ``lark-*`` SKILL.md dirs into ``~/.agents/skills/``. Substitute
+   any other dir you want; just point ``skills_dir`` at it below.
+
+Run:
+
+    python examples/lark/demo.py
+"""
+
+import os
+import sys
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from uni_agent.interaction import AgentEnv, AgentEnvConfig
+from uni_agent.skills import SkillsManager, SkillsManagerConfig
+from uni_agent.tools import ToolConfig
+
+# --- env config ------------------------------------------------------------
+run_id = str(uuid.uuid4())
+
+deployment_config = {
+    "type": "local_native",
+    "startup_timeout": 60.0,
+}
+
+# /usr/local/bin usually needs sudo. Override to a user-writable dir.
+tool_install_dir = Path(os.getenv("LARK_TOOL_INSTALL_DIR", str(Path.home() / ".uni-agent" / "bin")))
+tool_install_dir.mkdir(parents=True, exist_ok=True)
+
+env_config = AgentEnvConfig(
+    deployment=deployment_config,
+    tool_install_dir=tool_install_dir,
+    env_variables={"NO_COLOR": "1", "TERM": "dumb"},
+)
+env = AgentEnv(run_id=run_id, env_config=env_config)
+env.start()
+
+print(f"[env] local_native runtime ready (tool_install_dir={tool_install_dir})\n")
+
+# --- tools -----------------------------------------------------------------
+tools_config = [
+    {"name": "execute_bash"},
+    {"name": "lark-cli"},
+]
+tools = [ToolConfig(**tc).get_tool() for tc in tools_config]
+env.install_tools(tools)
+
+out = env.communicate("which lark-cli")
+print(f"[tool] which lark-cli\n  -> {out.strip()}\n")
+
+# --- skills (entirely user-managed) ----------------------------------------
+# Drop the SKILL.md packs you want exposed under one directory; the tool
+# itself ships none. Override with $LARK_SKILLS_DIR if you want a custom path.
+skills_dir = Path(os.getenv("LARK_SKILLS_DIR", str(Path.home() / ".uni-agent" / "skills")))
+skills_manager = SkillsManager.from_config(
+    SkillsManagerConfig(skills_dir=skills_dir),
+)
+print(f"[skills] skills_dir={skills_dir} (exists={skills_dir.is_dir()})")
+print(f"[skills] discovered {len(skills_manager.skills)} skill(s): "
+      f"{[s.name for s in skills_manager.skills]}\n")
+
+# For local_native runtime, env.install_skills is a no-op (skills are read
+# in place from the host filesystem). For container runtimes it copies
+# each skill dir to ``/opt/uni-agent/skills/<name>/``.
+env.install_skills(skills_manager)
+
+print("=" * 60)
+print("  Skills manifest (this goes into the system prompt)")
+print("=" * 60)
+print(skills_manager.build_manifest())
+print()
+
+if skills_manager.skills:
+    first = skills_manager.skills[0]
+    skill_md = skills_manager.runtime_paths[first.name].as_posix() + "/SKILL.md"
+    print(f"[skills] runtime path for {first.name!r} -> {skill_md}")
+    print("[skills] first 6 lines of SKILL.md:\n")
+    head = env.communicate(f"head -n 6 {skill_md}")
+    print(head)
+
+# --- run a couple of lark-cli commands -------------------------------------
+print("=" * 60)
+print("  lark-cli smoke test")
+print("=" * 60)
+
+print("\n[lark-cli] --version")
+print(env.communicate("lark-cli --version").strip())
+
+# Comment out if auth is not set up.
+print("\n[lark-cli] calendar +agenda (today)")
+print(env.communicate("lark-cli calendar +agenda 2>&1 | head -n 40").strip())
+
+env.close()
+print("\n[env] closed")

--- a/uni_agent/agent_loop.py
+++ b/uni_agent/agent_loop.py
@@ -17,6 +17,7 @@ from uni_agent.interaction import (
     ToolsManagerConfig,
 )
 from uni_agent.reward import load_reward_spec
+from uni_agent.skills import SkillsManager, SkillsManagerConfig
 from verl.experimental.agent_loop.agent_loop import AgentLoopBase, AgentLoopOutput
 from verl.experimental.agent_loop.utils import resolve_config_path
 
@@ -60,6 +61,7 @@ class UniAgentLoop(AgentLoopBase):
             tools_config_list=config_dict["tools"],
             parser=config_dict.get("tool_parser", "qwen3_coder"),
         )
+        self.skills_manager = self._init_skills_manager(config_dict.get("skills"))
         self.env = self._init_env(config_dict["env"])
         self.output_dir = Path(config_dict["log_dir"]) / self.run_id
         self.interaction = AgentInteraction(
@@ -68,6 +70,7 @@ class UniAgentLoop(AgentLoopBase):
             model=self.chat_model,
             tools_manager=self.tools_manager,
             messages=list(kwargs["raw_prompt"]),
+            skills_manager=self.skills_manager,
             **config_dict["interaction"],
         )
         if config_dict["reward"] is not None:
@@ -98,6 +101,9 @@ class UniAgentLoop(AgentLoopBase):
                 # to generate correct tool call format in response
                 self.chat_model.set_tools_schemas(self.tools_manager.tools_schemas)
                 await self.env.install_tools(self.tools_manager.tools)
+                if self.skills_manager is not None:
+                    await self.env.install_skills(self.skills_manager)
+                    self.interaction.inject_skills_manifest()
 
                 interaction_result = await self.interaction.run()
                 interaction_result["metrics"] = dict(interaction_result.get("rollout_cache", {}).get("metrics", {}))
@@ -243,6 +249,19 @@ class UniAgentLoop(AgentLoopBase):
     def _init_tools_manager(self, tools_config_list: list[dict], parser: str = "qwen3_coder") -> ToolsManager:
         tools_manager_config = ToolsManagerConfig(tools=tools_config_list, parser=parser)
         return ToolsManager(tools_manager_config=tools_manager_config)
+
+    def _init_skills_manager(self, skills_config: dict | None) -> SkillsManager | None:
+        """Build a SkillsManager from per-run config.
+
+        - ``skills_config is None`` or missing: skills system disabled (no
+          manifest injection, no container push). Backward-compatible default.
+        - ``skills_config`` provided: build a ``SkillsManagerConfig`` and
+          scan its ``skills_dir`` for ``<name>/SKILL.md`` subdirectories.
+        """
+        if not skills_config:
+            return None
+        cfg = SkillsManagerConfig(**skills_config)
+        return SkillsManager.from_config(cfg)
 
     def _init_env(self, config_dict: dict) -> AgentEnv:
         env_config = AgentEnvConfig(**config_dict)

--- a/uni_agent/deployment/__init__.py
+++ b/uni_agent/deployment/__init__.py
@@ -4,6 +4,7 @@ from .config import (
     DeployConfig,
     HostDeploymentConfig,
     LocalDeploymentConfig,
+    LocalNativeDeploymentConfig,
     ModalDeploymentConfig,
     VefaasDeploymentConfig,
 )
@@ -11,6 +12,7 @@ from .config import (
 _LAZY_EXPORTS = {
     "HostDeployment": ".host.deployment",
     "LocalDeployment": ".local.deployment",
+    "LocalNativeDeployment": ".local_native.deployment",
     "ModalDeployment": ".modal.deployment",
     "VefaasDeployment": ".vefaas.deployment",
 }
@@ -19,10 +21,12 @@ __all__ = [
     "DeployConfig",
     "HostDeploymentConfig",
     "LocalDeploymentConfig",
+    "LocalNativeDeploymentConfig",
     "ModalDeploymentConfig",
     "VefaasDeploymentConfig",
     "HostDeployment",
     "LocalDeployment",
+    "LocalNativeDeployment",
     "ModalDeployment",
     "VefaasDeployment",
 ]

--- a/uni_agent/deployment/config.py
+++ b/uni_agent/deployment/config.py
@@ -26,6 +26,31 @@ class HostDeploymentConfig(BaseModel):
         return HostDeployment.from_config(self, run_id)
 
 
+class LocalNativeDeploymentConfig(BaseModel):
+    """Configuration for in-process pexpect-based host execution.
+
+    Like ``HostDeploymentConfig`` this runs commands directly on the host (no
+    container), but drives bash via ``pexpect`` / PTY rather than
+    ``asyncio.create_subprocess_exec``. Compatible with the framework's
+    sync-style ``auto_await`` API. See
+    ``uni_agent/deployment/local_native/runtime.py`` for details.
+    """
+
+    type: Literal["local_native"] = "local_native"
+    """Discriminator for (de)serialization. Do not change."""
+    timeout: float = 60.0
+    """Default timeout for runtime operations."""
+    startup_timeout: float = 120.0
+    """Timeout for the initial bash session handshake."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    def get_deployment(self, run_id: str):
+        from .local_native.deployment import LocalNativeDeployment
+
+        return LocalNativeDeployment.from_config(self, run_id)
+
+
 class LocalDeploymentConfig(BaseModel):
     """Configuration for a local sandbox."""
 
@@ -124,6 +149,10 @@ class VefaasDeploymentConfig(BaseModel):
 
 
 DeployConfig: TypeAlias = Annotated[
-    VefaasDeploymentConfig | LocalDeploymentConfig | HostDeploymentConfig | ModalDeploymentConfig,
+    VefaasDeploymentConfig
+    | LocalDeploymentConfig
+    | HostDeploymentConfig
+    | LocalNativeDeploymentConfig
+    | ModalDeploymentConfig,
     Field(discriminator="type"),
 ]

--- a/uni_agent/deployment/local_native/deployment.py
+++ b/uni_agent/deployment/local_native/deployment.py
@@ -1,0 +1,97 @@
+"""LocalNative deployment: pexpect-based, in-process bash runtime.
+
+Adapted from ``swerex.deployment.local.LocalDeployment``. Use this when you
+want to run tools / shell commands directly on the host (no container, no
+HTTP layer), and you call ``env.start()`` / ``env.communicate()`` from sync
+code via ``auto_await``. See ``runtime.py`` for the rationale.
+"""
+
+import uuid
+from typing import Any, Self
+
+from swerex.deployment.abstract import AbstractDeployment
+from swerex.deployment.hooks.abstract import CombinedDeploymentHook, DeploymentHook
+from swerex.exceptions import DeploymentNotStartedError
+from swerex.runtime.abstract import (
+    CreateBashSessionRequest,
+    IsAliveResponse,
+)
+
+from uni_agent.async_logging import get_logger
+from uni_agent.deployment.config import LocalNativeDeploymentConfig
+from uni_agent.deployment.local_native.runtime import LocalNativeRuntime
+
+
+class LocalNativeDeployment(AbstractDeployment):
+    """Deployment that runs tool scripts directly on the host machine.
+
+    Drives a single ``main`` bash session via pexpect, mirroring how SWE-ReX's
+    ``LocalRuntime`` is used in-process. Compatible with the framework's
+    ``auto_await`` sync-style API: each ``asyncio.run`` invocation can see a
+    fresh event loop without re-binding any pexpect state.
+    """
+
+    def __init__(self, run_id: str, **kwargs: Any):
+        self.run_id = run_id
+        self._config = LocalNativeDeploymentConfig(**kwargs)
+        self._runtime: LocalNativeRuntime | None = None
+        self.logger = get_logger("local-native-deployment", run_id)
+        self._hooks = CombinedDeploymentHook()
+        self._stopped = False
+
+    def add_hook(self, hook: DeploymentHook):
+        self._hooks.add_hook(hook)
+
+    @classmethod
+    def from_config(cls, config: LocalNativeDeploymentConfig, run_id: str | None = None) -> Self:
+        if not run_id:
+            run_id = str(uuid.uuid4())
+        return cls(run_id=run_id, **config.model_dump())
+
+    async def is_alive(self, *, timeout: float | None = None) -> IsAliveResponse:
+        if self._runtime is None:
+            return IsAliveResponse(is_alive=False, message="Runtime is None.")
+        return await self._runtime.is_alive(timeout=timeout)
+
+    async def start(self, max_retries: int = 5):
+        """Start the runtime and pre-create the default bash session.
+
+        Pre-creating the session whose name matches ``BashAction.session``'s
+        default lets callers issue ``BashAction(command=...)`` without
+        managing session names.
+        """
+        self._runtime = LocalNativeRuntime(run_id=self.run_id)
+        await self._runtime.create_session(
+            CreateBashSessionRequest(
+                session=CreateBashSessionRequest.model_fields["session"].default,
+                startup_source=[],
+                startup_timeout=self._config.startup_timeout,
+            )
+        )
+        self._stopped = False
+        self.logger.info("Local-native deployment started")
+
+    async def stop(self):
+        if self._stopped:
+            return
+        if self._runtime is not None:
+            try:
+                await self._runtime.close()
+            except Exception as exc:
+                self.logger.error(f"Failed to close local-native runtime: {exc}")
+            self._runtime = None
+        self._stopped = True
+        self.logger.info("Local-native deployment stopped")
+
+    @property
+    def runtime(self) -> LocalNativeRuntime:
+        if self._runtime is None:
+            raise DeploymentNotStartedError()
+        return self._runtime
+
+    async def __aenter__(self):
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.stop()

--- a/uni_agent/deployment/local_native/runtime.py
+++ b/uni_agent/deployment/local_native/runtime.py
@@ -89,7 +89,7 @@ def _split_bash_command(input: str) -> list[str]:
     - "cmd1<<EOF\na\nb\nEOF" is one command (heredoc)
     """
     input = input.strip()
-    if not input or all(l.strip().startswith("#") for l in input.splitlines()):
+    if not input or all(line.strip().startswith("#") for line in input.splitlines()):
         # bashlex can't deal with empty strings or the like.
         return []
     parsed = bashlex.parse(input)
@@ -225,7 +225,7 @@ class BashSession(Session):
             output = output.strip()
             return BashObservation(output=output, exit_code=0, expect_string=matched_expect_string)
         except pexpect.TIMEOUT:
-            raise pexpect.TIMEOUT("Failed to interrupt session")
+            raise pexpect.TIMEOUT("Failed to interrupt session") from None
 
     async def run(self, action: BashAction | BashInterruptAction) -> BashObservation:
         """Dispatch a bash action."""
@@ -252,7 +252,9 @@ class BashSession(Session):
             expect_index = self.shell.expect(expect_strings, timeout=action.timeout)  # type: ignore
             matched_expect_string = expect_strings[expect_index]
         except pexpect.TIMEOUT as e:
-            raise CommandTimeoutError(f"timeout after {action.timeout} seconds while running command {action.command!r}") from e
+            raise CommandTimeoutError(
+                f"timeout after {action.timeout} seconds while running command {action.command!r}"
+            ) from e
         output: str = _strip_control_chars(self.shell.before)  # type: ignore
         if action.is_interactive_quit:
             assert not action.is_interactive_command
@@ -295,7 +297,9 @@ class BashSession(Session):
             expect_index = self.shell.expect(expect_strings, timeout=action.timeout)  # type: ignore
             matched_expect_string = expect_strings[expect_index]
         except pexpect.TIMEOUT as e:
-            raise CommandTimeoutError(f"timeout after {action.timeout} seconds while running command {action.command!r}") from e
+            raise CommandTimeoutError(
+                f"timeout after {action.timeout} seconds while running command {action.command!r}"
+            ) from e
         output: str = _strip_control_chars(self.shell.before)  # type: ignore
 
         # 2. Capture exit code.
@@ -309,7 +313,7 @@ class BashSession(Session):
             try:
                 self.shell.expect(_exit_code_suffix, timeout=1)
             except pexpect.TIMEOUT:
-                raise NoExitCodeError("timeout while getting exit code")
+                raise NoExitCodeError("timeout while getting exit code") from None
             exit_code_raw: str = _strip_control_chars(self.shell.before)  # type: ignore
             exit_code = re.findall(f"{_exit_code_prefix}([0-9]+)", exit_code_raw)
             if len(exit_code) != 1:
@@ -323,7 +327,7 @@ class BashSession(Session):
             try:
                 self.shell.expect(self._ps1, timeout=0.1)
             except pexpect.TIMEOUT:
-                raise CommandTimeoutError("Timeout while getting PS1 after exit code extraction")
+                raise CommandTimeoutError("Timeout while getting PS1 after exit code extraction") from None
             output = output.replace(self._UNIQUE_STRING, "").replace(self._ps1, "")
         except Exception:
             if action.check == "raise":

--- a/uni_agent/deployment/local_native/runtime.py
+++ b/uni_agent/deployment/local_native/runtime.py
@@ -281,9 +281,10 @@ class BashSession(Session):
         try:
             individual_commands = _split_bash_command(action.command)
         except Exception as e:
-            # bashlex is buggy and can throw varied errors (Parsing, NotImplemented, TypeError, ...).
-            # Fall back to emitting a unique tail string and seeking on it.
-            self.logger.error("Bashlex fail: %s", e)
+            self.logger.debug(
+                f"bashlex could not split command (falling back to tail-marker mode): "
+                f"{type(e).__name__}: {e}"
+            )
             action.command += f"\n TMPEXITCODE=$? ; sleep 0.1; echo -n '{self._UNIQUE_STRING}' ; (exit $TMPEXITCODE)"
             fallback_terminator = True
         else:

--- a/uni_agent/deployment/local_native/runtime.py
+++ b/uni_agent/deployment/local_native/runtime.py
@@ -282,8 +282,7 @@ class BashSession(Session):
             individual_commands = _split_bash_command(action.command)
         except Exception as e:
             self.logger.debug(
-                f"bashlex could not split command (falling back to tail-marker mode): "
-                f"{type(e).__name__}: {e}"
+                f"bashlex could not split command (falling back to tail-marker mode): {type(e).__name__}: {e}"
             )
             action.command += f"\n TMPEXITCODE=$? ; sleep 0.1; echo -n '{self._UNIQUE_STRING}' ; (exit $TMPEXITCODE)"
             fallback_terminator = True

--- a/uni_agent/deployment/local_native/runtime.py
+++ b/uni_agent/deployment/local_native/runtime.py
@@ -1,0 +1,439 @@
+"""LocalNative runtime: pexpect-backed bash session, adapted from ``swerex.runtime.local``.
+
+Why a separate runtime from ``HostRuntime``?
+
+``HostRuntime`` builds the bash subprocess with ``asyncio.create_subprocess_exec``,
+which means the resulting stdin/stdout streams are bound to the event loop that
+created them. The framework's ``auto_await`` runs sync-style calls via
+``asyncio.run(coro)``, creating a fresh loop each time -- after the loop that
+``env.start()`` ran on closes, the next ``env.communicate()`` call lands on a
+new loop and asyncio raises "got Future attached to a different loop" trying to
+read from those stale streams.
+
+``LocalNativeRuntime`` sidesteps the problem by driving the bash session
+through ``pexpect``, which uses synchronous PTY I/O and holds no loop-bound
+state. The async methods are thin shells (``await asyncio.sleep(...)`` for
+pacing), so they run inside any loop. This mirrors how SWE-ReX's
+``LocalRuntime`` is used directly when the rest of the framework lives in the
+same process (i.e. without the HTTP layer).
+
+Code is a direct port of
+https://github.com/SWE-agent/SWE-ReX/blob/main/src/swerex/runtime/local.py
+with uni-agent's logger conventions and minor cleanups; see ``LocalDeployment``
+for the matching deployment wrapper.
+"""
+
+# ruff: noqa: E501
+import asyncio
+import os
+import re
+import shutil
+import subprocess
+import time
+from abc import ABC, abstractmethod
+from copy import deepcopy
+from pathlib import Path
+from typing import Self
+
+import bashlex
+import bashlex.ast
+import bashlex.errors
+import pexpect
+from swerex.exceptions import (
+    BashIncorrectSyntaxError,
+    CommandTimeoutError,
+    NoExitCodeError,
+    NonZeroExitCodeError,
+    SessionDoesNotExistError,
+    SessionExistsError,
+    SessionNotInitializedError,
+)
+from swerex.runtime.abstract import (
+    AbstractRuntime,
+    Action,
+    BashAction,
+    BashInterruptAction,
+    BashObservation,
+    CloseBashSessionResponse,
+    CloseResponse,
+    CloseSessionRequest,
+    CloseSessionResponse,
+    Command,
+    CommandResponse,
+    CreateBashSessionRequest,
+    CreateBashSessionResponse,
+    CreateSessionRequest,
+    CreateSessionResponse,
+    IsAliveResponse,
+    Observation,
+    ReadFileRequest,
+    ReadFileResponse,
+    UploadRequest,
+    UploadResponse,
+    WriteFileRequest,
+    WriteFileResponse,
+)
+
+from uni_agent.async_logging import get_logger
+
+__all__ = ["LocalNativeRuntime", "BashSession"]
+
+
+def _split_bash_command(input: str) -> list[str]:
+    r"""Split a bash command with linebreaks, escaped newlines, and heredocs into a list of
+    individual commands.
+
+    Examples:
+    - "cmd1\ncmd2" are two commands
+    - "cmd1\\\n asdf" is one command (linebreak is escaped)
+    - "cmd1<<EOF\na\nb\nEOF" is one command (heredoc)
+    """
+    input = input.strip()
+    if not input or all(l.strip().startswith("#") for l in input.splitlines()):
+        # bashlex can't deal with empty strings or the like.
+        return []
+    parsed = bashlex.parse(input)
+    cmd_strings = []
+
+    def find_range(cmd: bashlex.ast.node) -> tuple[int, int]:
+        start = cmd.pos[0]  # type: ignore
+        end = cmd.pos[1]  # type: ignore
+        for part in getattr(cmd, "parts", []):
+            part_start, part_end = find_range(part)
+            start = min(start, part_start)
+            end = max(end, part_end)
+        return start, end
+
+    for cmd in parsed:
+        start, end = find_range(cmd)
+        cmd_strings.append(input[start:end])
+    return cmd_strings
+
+
+def _strip_control_chars(s: str) -> str:
+    ansi_escape = re.compile(r"\x1B[@-_][0-?]*[ -/]*[@-~]")
+    return ansi_escape.sub("", s).replace("\r\n", "\n")
+
+
+def _check_bash_command(command: str) -> None:
+    """Check if a bash command is valid. Raises BashIncorrectSyntaxError if it's not."""
+    _unique_string = "SOUNIQUEEOF"
+    cmd = f"/usr/bin/env bash -n << '{_unique_string}'\n{command}\n{_unique_string}"
+    result = subprocess.run(cmd, shell=True, capture_output=True)
+    if result.returncode == 0:
+        return
+    stdout = result.stdout.decode(errors="backslashreplace")
+    stderr = result.stderr.decode(errors="backslashreplace")
+    msg = (
+        f"Error (exit code {result.returncode}) while checking bash command \n{command!r}\n"
+        f"---- Stderr ----\n{stderr}\n---- Stdout ----\n{stdout}"
+    )
+    raise BashIncorrectSyntaxError(msg, extra_info={"bash_stdout": stdout, "bash_stderr": stderr})
+
+
+class Session(ABC):
+    @abstractmethod
+    async def start(self) -> CreateSessionResponse: ...
+
+    @abstractmethod
+    async def run(self, action: Action) -> Observation: ...
+
+    @abstractmethod
+    async def close(self) -> CloseSessionResponse: ...
+
+
+class BashSession(Session):
+    """A persistent bash REPL controlled via pexpect (PTY-based)."""
+
+    _UNIQUE_STRING = "UNIQUESTRING29234"
+
+    def __init__(self, request: CreateBashSessionRequest, *, run_id: str):
+        self.request = request
+        self._ps1 = "SHELLPS1PREFIX"
+        self._shell: pexpect.spawn | None = None
+        self.logger = get_logger("local-native-session", run_id)
+
+    @property
+    def shell(self) -> pexpect.spawn:
+        if self._shell is None:
+            raise RuntimeError("shell not initialized")
+        return self._shell
+
+    def _get_reset_commands(self) -> list[str]:
+        """Commands that reset PS1/PS2/PS0 to known values."""
+        return [
+            f"export PS1='{self._ps1}'",
+            "export PS2=''",
+            "export PS0=''",
+        ]
+
+    async def start(self) -> CreateBashSessionResponse:
+        """Spawn the bash REPL, source startup files, and set the prompt."""
+        self._shell = pexpect.spawn(
+            "/usr/bin/env bash",
+            encoding="utf-8",
+            codec_errors="backslashreplace",
+            echo=False,
+            env=dict(os.environ.copy(), **{"PS1": self._ps1, "PS2": "", "PS0": ""}),  # type: ignore
+        )
+        await asyncio.sleep(0.3)
+        cmds = []
+        if self.request.startup_source:
+            cmds += [f"source {path}" for path in self.request.startup_source] + ["sleep 0.3"]
+        cmds += self._get_reset_commands()
+        cmd = " ; ".join(cmds)
+        self.shell.sendline(cmd)
+        self.shell.expect(self._ps1, timeout=self.request.startup_timeout)
+        output = _strip_control_chars(self.shell.before)  # type: ignore
+        return CreateBashSessionResponse(output=output)
+
+    def _eat_following_output(self, timeout: float = 0.5) -> str:
+        """Drain output for ``timeout`` seconds so the next command starts clean."""
+        time.sleep(timeout)
+        try:
+            output = self.shell.read_nonblocking(timeout=0.1)
+        except pexpect.TIMEOUT:
+            return ""
+        return _strip_control_chars(output)
+
+    async def interrupt(self, action: BashInterruptAction) -> BashObservation:
+        """SIGINT the running foreground command; fall back to background-and-kill."""
+        output = ""
+        for _ in range(action.n_retry):
+            self.shell.sendintr()
+            expect_strings = action.expect + [self._ps1]
+            try:
+                expect_index = self.shell.expect(expect_strings, timeout=action.timeout)  # type: ignore
+                matched_expect_string = expect_strings[expect_index]
+            except Exception:
+                await asyncio.sleep(0.2)
+                continue
+            output += _strip_control_chars(self.shell.before)  # type: ignore
+            output += self._eat_following_output()
+            output = output.strip()
+            return BashObservation(output=output, exit_code=0, expect_string=matched_expect_string)
+        # Last resort: stop the job, kill it in background.
+        try:
+            self.shell.sendcontrol("z")
+            self.shell.expect(expect_strings, timeout=action.timeout)
+            output += self.shell.before
+            self.shell.sendline("kill -9 %1")
+            expect_index = self.shell.expect(expect_strings, timeout=action.timeout)  # type: ignore
+            matched_expect_string = expect_strings[expect_index]
+            output += self.shell.before
+            output += self._eat_following_output()
+            output = output.strip()
+            return BashObservation(output=output, exit_code=0, expect_string=matched_expect_string)
+        except pexpect.TIMEOUT:
+            raise pexpect.TIMEOUT("Failed to interrupt session")
+
+    async def run(self, action: BashAction | BashInterruptAction) -> BashObservation:
+        """Dispatch a bash action."""
+        if self.shell is None:
+            raise SessionNotInitializedError("shell not initialized")
+        if isinstance(action, BashInterruptAction):
+            return await self.interrupt(action)
+        if action.is_interactive_command or action.is_interactive_quit:
+            return await self._run_interactive(action)
+        r = await self._run_normal(action)
+        if action.check == "raise" and r.exit_code != 0:
+            msg = f"Command {action.command!r} failed with exit code {r.exit_code}. Here is the output:\n{r.output!r}"
+            if action.error_msg:
+                msg = f"{action.error_msg}: {msg}"
+            raise NonZeroExitCodeError(msg)
+        return r
+
+    async def _run_interactive(self, action: BashAction) -> BashObservation:
+        """Run an interactive action: skip exit-code retrieval and PS1 reseeking."""
+        assert self.shell is not None
+        self.shell.sendline(action.command)
+        expect_strings = action.expect + [self._ps1]
+        try:
+            expect_index = self.shell.expect(expect_strings, timeout=action.timeout)  # type: ignore
+            matched_expect_string = expect_strings[expect_index]
+        except pexpect.TIMEOUT as e:
+            raise CommandTimeoutError(f"timeout after {action.timeout} seconds while running command {action.command!r}") from e
+        output: str = _strip_control_chars(self.shell.before)  # type: ignore
+        if action.is_interactive_quit:
+            assert not action.is_interactive_command
+            self.shell.setecho(False)
+            self.shell.waitnoecho()
+            self.shell.sendline(f"stty -echo; echo '{self._UNIQUE_STRING}'")
+            self.shell.expect(self._UNIQUE_STRING, timeout=1)
+            self.shell.expect(self._ps1, timeout=1)
+        else:
+            # Interactive command often turns echo back on inside the shell.
+            output = output.lstrip().removeprefix(action.command).strip()
+
+        return BashObservation(output=output, exit_code=0, expect_string=matched_expect_string)
+
+    async def _run_normal(self, action: BashAction) -> BashObservation:
+        """Run a normal bash action: syntax check -> execute -> capture exit code."""
+        action = deepcopy(action)
+
+        assert self.shell is not None
+        _check_bash_command(action.command)
+
+        # 1. Send the command (joined with ; to avoid PS1 noise between subcommands).
+        fallback_terminator = False
+        try:
+            individual_commands = _split_bash_command(action.command)
+        except Exception as e:
+            # bashlex is buggy and can throw varied errors (Parsing, NotImplemented, TypeError, ...).
+            # Fall back to emitting a unique tail string and seeking on it.
+            self.logger.error("Bashlex fail: %s", e)
+            action.command += f"\n TMPEXITCODE=$? ; sleep 0.1; echo -n '{self._UNIQUE_STRING}' ; (exit $TMPEXITCODE)"
+            fallback_terminator = True
+        else:
+            action.command = " ; ".join(individual_commands)
+        self.shell.sendline(action.command)
+        if not fallback_terminator:
+            expect_strings = action.expect + [self._ps1]
+        else:
+            expect_strings = [self._UNIQUE_STRING]
+        try:
+            expect_index = self.shell.expect(expect_strings, timeout=action.timeout)  # type: ignore
+            matched_expect_string = expect_strings[expect_index]
+        except pexpect.TIMEOUT as e:
+            raise CommandTimeoutError(f"timeout after {action.timeout} seconds while running command {action.command!r}") from e
+        output: str = _strip_control_chars(self.shell.before)  # type: ignore
+
+        # 2. Capture exit code.
+        if action.check == "ignore":
+            return BashObservation(output=output, exit_code=None, expect_string=matched_expect_string)
+
+        try:
+            _exit_code_prefix = "EXITCODESTART"
+            _exit_code_suffix = "EXITCODEEND"
+            self.shell.sendline(f"\necho {_exit_code_prefix}$?{_exit_code_suffix}")
+            try:
+                self.shell.expect(_exit_code_suffix, timeout=1)
+            except pexpect.TIMEOUT:
+                raise NoExitCodeError("timeout while getting exit code")
+            exit_code_raw: str = _strip_control_chars(self.shell.before)  # type: ignore
+            exit_code = re.findall(f"{_exit_code_prefix}([0-9]+)", exit_code_raw)
+            if len(exit_code) != 1:
+                raise NoExitCodeError(
+                    f"failed to parse exit code from output {exit_code_raw!r} "
+                    f"(command: {action.command!r}, matches: {exit_code})"
+                )
+            output += exit_code_raw.split(_exit_code_prefix)[0]
+            exit_code = int(exit_code[0])
+            # Drain the trailing PS1.
+            try:
+                self.shell.expect(self._ps1, timeout=0.1)
+            except pexpect.TIMEOUT:
+                raise CommandTimeoutError("Timeout while getting PS1 after exit code extraction")
+            output = output.replace(self._UNIQUE_STRING, "").replace(self._ps1, "")
+        except Exception:
+            if action.check == "raise":
+                raise
+            exit_code = None
+        return BashObservation(output=output, exit_code=exit_code, expect_string=matched_expect_string)
+
+    async def close(self) -> CloseSessionResponse:
+        if self._shell is None:
+            return CloseBashSessionResponse()
+        self.shell.close()
+        self._shell = None
+        return CloseBashSessionResponse()
+
+    def interact(self) -> None:
+        """Enter interactive mode."""
+        self.shell.interact()
+
+
+class LocalNativeRuntime(AbstractRuntime):
+    """In-process runtime that drives bash via pexpect, no event-loop binding.
+
+    This is the uni-agent flavored mirror of ``swerex.runtime.local.LocalRuntime``.
+    """
+
+    def __init__(self, *, run_id: str):
+        self.run_id = run_id
+        self._sessions: dict[str, Session] = {}
+        self.logger = get_logger("local-native-runtime", run_id)
+
+    @classmethod
+    def from_config(cls, run_id: str) -> Self:
+        return cls(run_id=run_id)
+
+    @property
+    def sessions(self) -> dict[str, Session]:
+        return self._sessions
+
+    async def is_alive(self, *, timeout: float | None = None) -> IsAliveResponse:
+        return IsAliveResponse(is_alive=True)
+
+    async def create_session(self, request: CreateSessionRequest) -> CreateSessionResponse:
+        if request.session in self.sessions:
+            raise SessionExistsError(f"session {request.session} already exists")
+        if isinstance(request, CreateBashSessionRequest):
+            session = BashSession(request, run_id=self.run_id)
+        else:
+            raise ValueError(f"unknown session type: {request!r}")
+        self.sessions[request.session] = session
+        return await session.start()
+
+    async def run_in_session(self, action: Action) -> Observation:
+        if action.session not in self.sessions:
+            raise SessionDoesNotExistError(f"session {action.session!r} does not exist")
+        return await self.sessions[action.session].run(action)
+
+    async def close_session(self, request: CloseSessionRequest) -> CloseSessionResponse:
+        if request.session not in self.sessions:
+            raise SessionDoesNotExistError(f"session {request.session!r} does not exist")
+        out = await self.sessions[request.session].close()
+        del self.sessions[request.session]
+        return out
+
+    async def execute(self, command: Command) -> CommandResponse:
+        """Execute a one-shot command (no session). Subprocess-based."""
+        try:
+            result = subprocess.run(
+                command.command,
+                shell=command.shell,
+                timeout=command.timeout,
+                env=command.env,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT if command.merge_output_streams else subprocess.PIPE,
+                cwd=command.cwd,
+            )
+            r = CommandResponse(
+                stdout=result.stdout.decode(errors="backslashreplace"),
+                stderr=result.stderr.decode(errors="backslashreplace") if result.stderr is not None else "",
+                exit_code=result.returncode,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise CommandTimeoutError(f"Timeout ({command.timeout}s) exceeded while running command") from e
+        if command.check and result.returncode != 0:
+            msg = (
+                f"Command {command.command!r} failed with exit code {result.returncode}. "
+                f"Stdout:\n{r.stdout!r}\nStderr:\n{r.stderr!r}"
+            )
+            if command.error_msg:
+                msg = f"{command.error_msg}: {msg}"
+            raise NonZeroExitCodeError(msg)
+        return r
+
+    async def read_file(self, request: ReadFileRequest) -> ReadFileResponse:
+        content = Path(request.path).read_text(encoding=request.encoding, errors=request.errors)
+        return ReadFileResponse(content=content)
+
+    async def write_file(self, request: WriteFileRequest) -> WriteFileResponse:
+        Path(request.path).parent.mkdir(parents=True, exist_ok=True)
+        Path(request.path).write_text(request.content)
+        return WriteFileResponse()
+
+    async def upload(self, request: UploadRequest) -> UploadResponse:
+        if Path(request.source_path).is_dir():
+            shutil.copytree(request.source_path, request.target_path, dirs_exist_ok=True)
+        else:
+            shutil.copy(request.source_path, request.target_path)
+        return UploadResponse()
+
+    async def close(self) -> CloseResponse:
+        for session in self.sessions.values():
+            await session.close()
+        return CloseResponse()

--- a/uni_agent/interaction/env.py
+++ b/uni_agent/interaction/env.py
@@ -1,7 +1,7 @@
 import re
 import shlex
 from pathlib import Path, PurePath
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 from swerex.exceptions import BashIncorrectSyntaxError, CommandTimeoutError
@@ -16,9 +16,9 @@ from swerex.runtime.abstract import (
 
 from uni_agent.async_logging import get_logger
 from uni_agent.deployment import DeployConfig
+from uni_agent.skills.manager import SkillsManager
 from uni_agent.tools.base import AbstractTool
 from uni_agent.utils import auto_await
-from uni_agent.skills.manager import SkillsManager
 
 
 class ActionTimeoutError(Exception):
@@ -132,9 +132,7 @@ class AgentEnv:
             for skill in skills_manager.skills:
                 skills_manager.runtime_paths[skill.name] = skill.source_dir
             names = "\n".join(s.name for s in skills_manager.skills)
-            self.logger.info(
-                f"Host runtime: {len(skills_manager.skills)} skill(s) read in place, no copy\n{names}"
-            )
+            self.logger.info(f"Host runtime: {len(skills_manager.skills)} skill(s) read in place, no copy\n{names}")
             return
 
         for skill in skills_manager.skills:

--- a/uni_agent/interaction/env.py
+++ b/uni_agent/interaction/env.py
@@ -1,7 +1,7 @@
 import re
 import shlex
 from pathlib import Path, PurePath
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 from swerex.exceptions import BashIncorrectSyntaxError, CommandTimeoutError
@@ -18,6 +18,7 @@ from uni_agent.async_logging import get_logger
 from uni_agent.deployment import DeployConfig
 from uni_agent.tools.base import AbstractTool
 from uni_agent.utils import auto_await
+from uni_agent.skills.manager import SkillsManager
 
 
 class ActionTimeoutError(Exception):
@@ -103,6 +104,45 @@ class AgentEnv:
     async def copy_to_container(self, src: Path, tgt: Path) -> None:
         await self.deployment.runtime.execute(Command(command=["mkdir", "-p", str(tgt.parent)]))
         await self.deployment.runtime.upload(UploadRequest(source_path=str(src), target_path=str(tgt)))
+
+    @auto_await
+    async def install_skills(self, skills_manager: "SkillsManager") -> None:
+        """Resolve each skill's runtime path and (if needed) copy it in.
+
+        Mutates ``skills_manager.runtime_paths`` so the subsequent
+        ``build_manifest`` call renders the right ``<location>`` for each
+        skill:
+
+        - **Host-style runtime** (``HostDeployment`` / ``LocalNativeDeployment``):
+          skills are read in place from their host ``source_dir``; no copy.
+        - **Container runtime** (everything else): each skill directory is
+          uploaded to ``/opt/uni-agent/skills/<name>``.
+        """
+        from uni_agent.deployment.host.deployment import HostDeployment
+
+        host_types: tuple[type, ...] = (HostDeployment,)
+        try:
+            from uni_agent.deployment.local_native.deployment import LocalNativeDeployment
+
+            host_types = host_types + (LocalNativeDeployment,)
+        except ImportError:
+            pass
+
+        if isinstance(self.deployment, host_types):
+            for skill in skills_manager.skills:
+                skills_manager.runtime_paths[skill.name] = skill.source_dir
+            names = "\n".join(s.name for s in skills_manager.skills)
+            self.logger.info(
+                f"Host runtime: {len(skills_manager.skills)} skill(s) read in place, no copy\n{names}"
+            )
+            return
+
+        for skill in skills_manager.skills:
+            tgt = Path("/opt/uni-agent/skills") / skill.name
+            await self.copy_to_container(src=skill.source_dir, tgt=tgt)
+            skills_manager.runtime_paths[skill.name] = tgt
+            self.logger.info(f"Skill {skill.name} installed at {tgt}")
+        self.logger.info(f"Installed {len(skills_manager.skills)} skill(s) into runtime")
 
     @auto_await
     async def close(self) -> None:

--- a/uni_agent/interaction/interaction.py
+++ b/uni_agent/interaction/interaction.py
@@ -62,8 +62,10 @@ class AgentInteraction:
         they live as real files on disk (read lazily, progressive
         disclosure).
 
-        Idempotent: a second call is a no-op (we re-render the manifest
-        but only append it once, using a sentinel marker).
+        Call this exactly once, after ``AgentEnv.install_skills`` has
+        populated ``runtime_paths``. The method is **not** idempotent --
+        calling it twice will append the manifest twice. The single
+        in-tree caller (``UniAgentLoop.run``) already enforces this.
         """
         if self.skills_manager is None:
             return

--- a/uni_agent/interaction/interaction.py
+++ b/uni_agent/interaction/interaction.py
@@ -4,6 +4,7 @@ import orjson
 from pydantic import BaseModel
 
 from uni_agent.async_logging import get_logger
+from uni_agent.skills.manager import SkillsManager
 from uni_agent.utils import auto_await
 from verl.tools.schemas import OpenAIFunctionToolCall
 from verl.utils.profiler import simple_timer
@@ -41,15 +42,45 @@ class AgentInteraction:
         action_timeout: int = 60,
         timeout_budget: int = 3,
         max_turns: int = 50,
+        skills_manager: SkillsManager | None = None,
     ):
         self.env = env
         self.model = model
         self.tools_manager = tools_manager
+        self.skills_manager = skills_manager
         self.messages = messages
         self.action_timeout = action_timeout
         self.timeout_budget = timeout_budget
         self.max_turns = max_turns
         self.logger = get_logger("interaction", run_id)
+
+    def inject_skills_manifest(self) -> None:
+        """Append the skills manifest to the first system message.
+
+        The manifest lists each discovered skill (name + description +
+        path to its SKILL.md) so the model knows what is available and
+        how to load it on demand. Skill *bodies* are not in the prompt --
+        they live as real files on disk (read lazily, progressive
+        disclosure).
+
+        Idempotent: a second call is a no-op (we re-render the manifest
+        but only append it once, using a sentinel marker).
+        """
+        if self.skills_manager is None:
+            return
+        manifest = self.skills_manager.build_manifest()
+        if not manifest:
+            return
+
+        block = "\n\n" + manifest
+        for msg in self.messages:
+            if msg.get("role") == "system":
+                content = msg.get("content") or ""
+                if "<available_skills>" in content:
+                    return
+                msg["content"] = content + block
+                return
+        self.messages.insert(0, {"role": "system", "content": manifest})
 
     async def step(self, step_idx: int):
         # step index start from 1

--- a/uni_agent/interaction/interaction.py
+++ b/uni_agent/interaction/interaction.py
@@ -5,12 +5,11 @@ from pydantic import BaseModel
 
 from uni_agent.async_logging import get_logger
 from uni_agent.skills.manager import SkillsManager
-from uni_agent.utils import auto_await
-from verl.tools.schemas import OpenAIFunctionToolCall
-from verl.utils.profiler import simple_timer
+from uni_agent.utils import auto_await, simple_timer
 
 from .env import ActionIncorrectSyntaxError, ActionTimeoutError, AgentEnv, TerminalNotAliveError
 from .model import AgentChatModel, MaxTokenExceededError
+from .tool_schemas import OpenAIFunctionToolCall
 from .tool_parser import FunctionCallFormatError
 from .tools_manager import ToolsManager
 
@@ -76,8 +75,6 @@ class AgentInteraction:
         for msg in self.messages:
             if msg.get("role") == "system":
                 content = msg.get("content") or ""
-                if "<available_skills>" in content:
-                    return
                 msg["content"] = content + block
                 return
         self.messages.insert(0, {"role": "system", "content": manifest})

--- a/uni_agent/interaction/interaction.py
+++ b/uni_agent/interaction/interaction.py
@@ -9,8 +9,8 @@ from uni_agent.utils import auto_await, simple_timer
 
 from .env import ActionIncorrectSyntaxError, ActionTimeoutError, AgentEnv, TerminalNotAliveError
 from .model import AgentChatModel, MaxTokenExceededError
-from .tool_schemas import OpenAIFunctionToolCall
 from .tool_parser import FunctionCallFormatError
+from .tool_schemas import OpenAIFunctionToolCall
 from .tools_manager import ToolsManager
 
 

--- a/uni_agent/interaction/model.py
+++ b/uni_agent/interaction/model.py
@@ -223,6 +223,7 @@ class OpenAICompatibleChatModel:
         self.loop = get_event_loop()
 
         from openai import AsyncOpenAI
+
         self.client = AsyncOpenAI(api_key=self.api_key, base_url=self.base_url, timeout=self.timeout)
 
     def set_tools_schemas(self, tools_schemas: list[dict]) -> None:

--- a/uni_agent/interaction/model.py
+++ b/uni_agent/interaction/model.py
@@ -278,21 +278,47 @@ class OpenAICompatibleChatModel:
             normalized_messages.append(normalized_message)
         return normalized_messages
 
+    # OpenAI ChatCompletion top-level sampling fields. Keys not in this set
+    # are forwarded via ``extra_body`` so vendor extensions (top_k,
+    # repetition_penalty, ...) still reach vLLM/SGLang-style endpoints
+    # without 400-ing real OpenAI for unknown top-level args.
+    _OPENAI_TOP_LEVEL_SAMPLING_FIELDS: frozenset[str] = frozenset(
+        {
+            "temperature",
+            "top_p",
+            "presence_penalty",
+            "frequency_penalty",
+            "max_tokens",
+            "max_completion_tokens",
+            "stop",
+            "n",
+            "seed",
+            "logprobs",
+            "top_logprobs",
+            "logit_bias",
+            "user",
+        }
+    )
+
     async def query(
         self,
         messages: list[dict[str, str]],
         rollout_cache: dict[str, Any] | None,
         **kwargs,
     ) -> list[dict] | dict:
-        sampling_params = kwargs.get("sampling_params", self.sampling_params)
+        sampling_params = kwargs.get("sampling_params", self.sampling_params) or {}
         api_messages = self._normalize_messages_for_api(rollout_cache["extra_fields"]["api_messages"])
+
+        top_level = {k: v for k, v in sampling_params.items() if k in self._OPENAI_TOP_LEVEL_SAMPLING_FIELDS}
+        extra_body = {k: v for k, v in sampling_params.items() if k not in self._OPENAI_TOP_LEVEL_SAMPLING_FIELDS}
 
         with simple_timer("generate_sequences", rollout_cache["metrics"]):
             chat_completion = await self.client.chat.completions.create(
                 model=self.model_name,
                 messages=api_messages,
                 tools=self.tools_schemas,
-                extra_body=dict(sampling_params),
+                extra_body=extra_body or None,
+                **top_level,
             )
 
         response_message = chat_completion.choices[0].message

--- a/uni_agent/interaction/model.py
+++ b/uni_agent/interaction/model.py
@@ -3,15 +3,7 @@ import uuid
 from functools import cached_property
 from typing import Any
 
-from uni_agent.utils import get_event_loop
-from verl.utils.chat_template import apply_chat_template
-from verl.utils.profiler import simple_timer
-from verl.utils.tokenizer import normalize_token_ids
-
-try:
-    from openai import AsyncOpenAI
-except ImportError:  # pragma: no cover - handled at runtime
-    AsyncOpenAI = None
+from uni_agent.utils import get_event_loop, simple_timer
 
 
 class MaxTokenExceededError(Exception):
@@ -42,6 +34,8 @@ class AgentChatModel:
         self.tools_schemas = tools_schemas
 
     async def prepare_rollout_cache(self, messages: list[dict[str, str]]) -> dict[str, Any]:
+        from verl.utils.tokenizer import normalize_token_ids
+
         prompt_ids = await self.loop.run_in_executor(
             None,
             lambda: self.tokenizer.apply_chat_template(
@@ -139,6 +133,9 @@ class AgentChatModel:
         return response_str, rollout_cache, generation_info
 
     async def _get_new_message_ids(self, new_messages: list[dict[str, Any]]) -> list[int]:
+        from verl.utils.chat_template import apply_chat_template
+        from verl.utils.tokenizer import normalize_token_ids
+
         tokenized_prompt = await self.loop.run_in_executor(
             None,
             lambda: apply_chat_template(
@@ -152,6 +149,9 @@ class AgentChatModel:
 
     @cached_property
     def message_boundary_tokens(self) -> list[int]:
+        from verl.utils.chat_template import apply_chat_template
+        from verl.utils.tokenizer import normalize_token_ids
+
         dummy_history = [
             {"role": "user", "content": "dummy user"},
             {"role": "assistant", "content": "dummy assistant"},
@@ -221,10 +221,8 @@ class OpenAICompatibleChatModel:
             self.timeout = 300
         self.base_url = self.base_url.rstrip("/")
         self.loop = get_event_loop()
-        if AsyncOpenAI is None:
-            raise ImportError(
-                "openai is required for OpenAICompatibleChatModel. Please install it with `pip install openai`."
-            )
+
+        from openai import AsyncOpenAI
         self.client = AsyncOpenAI(api_key=self.api_key, base_url=self.base_url, timeout=self.timeout)
 
     def set_tools_schemas(self, tools_schemas: list[dict]) -> None:
@@ -293,7 +291,7 @@ class OpenAICompatibleChatModel:
                 model=self.model_name,
                 messages=api_messages,
                 tools=self.tools_schemas,
-                temperature=sampling_params.get("temperature", 0.0),
+                extra_body=dict(sampling_params),
             )
 
         response_message = chat_completion.choices[0].message

--- a/uni_agent/interaction/tool_parser.py
+++ b/uni_agent/interaction/tool_parser.py
@@ -5,7 +5,11 @@ from typing import Any
 
 import regex
 
-from verl.tools.schemas import OpenAIFunctionCallSchema, OpenAIFunctionToolCall, OpenAIFunctionToolSchema
+from uni_agent.interaction.tool_schemas import (
+    OpenAIFunctionCallSchema,
+    OpenAIFunctionToolCall,
+    OpenAIFunctionToolSchema,
+)
 
 
 class FunctionCallFormatError(Exception):

--- a/uni_agent/interaction/tool_schemas.py
+++ b/uni_agent/interaction/tool_schemas.py
@@ -1,0 +1,145 @@
+# Copyright 2023-2024 SGLang Team
+# Copyright 2025 ModelBest Inc. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Ported from ``verl.tools.schemas`` so that the inference-side of
+# ``uni-agent`` (tools manager, tool parser, interaction loop) does not
+# need to import ``verl`` at module load time. Keep the public surface
+# byte-identical -- if these schemas drift, training-side code that
+# round-trips between ``verl`` and ``uni-agent`` will silently break.
+"""OpenAI function-calling pydantic schemas used by the agent loop."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class OpenAIFunctionPropertySchema(BaseModel):
+    """The schema of a parameter in OpenAI format."""
+
+    type: str
+    description: str | None = None
+    enum: list[str] | None = None
+
+
+class OpenAIFunctionParametersSchema(BaseModel):
+    """The schema of parameters in OpenAI format."""
+
+    type: str
+    properties: dict[str, OpenAIFunctionPropertySchema]
+    required: list[str]
+
+
+class OpenAIFunctionSchema(BaseModel):
+    """The schema of a function in OpenAI format."""
+
+    name: str
+    description: str
+    parameters: OpenAIFunctionParametersSchema = Field(
+        default_factory=lambda: OpenAIFunctionParametersSchema(type="object", properties={}, required=[])
+    )
+    strict: bool = False
+
+
+class OpenAIFunctionToolSchema(BaseModel):
+    """The schema of a tool in OpenAI format."""
+
+    type: str
+    function: OpenAIFunctionSchema
+
+
+class OpenAIFunctionParsedSchema(BaseModel):
+    """The parsed schema of a tool in OpenAI format."""
+
+    name: str
+    arguments: str  # JSON string
+
+
+class OpenAIFunctionCallSchema(BaseModel):
+    """The parsed schema of a tool in OpenAI format."""
+
+    name: str
+    arguments: dict[str, Any]
+
+    @staticmethod
+    def from_openai_function_parsed_schema(
+        parsed_schema: OpenAIFunctionParsedSchema,
+    ) -> tuple["OpenAIFunctionCallSchema", bool]:
+        has_decode_error = False
+        try:
+            arguments = json.loads(parsed_schema.arguments)
+        except json.JSONDecodeError:
+            arguments = {}
+            has_decode_error = True
+        # If the arguments is not a dict, it means the arguments is not a valid JSON string
+        if not isinstance(arguments, dict):
+            arguments = {}
+            has_decode_error = True
+
+        return OpenAIFunctionCallSchema(name=parsed_schema.name, arguments=arguments), has_decode_error
+
+
+class OpenAIFunctionToolCall(BaseModel):
+    """The tool call in OpenAI format."""
+
+    id: str
+    type: Literal["function"] = "function"
+    function: OpenAIFunctionCallSchema
+
+
+class ToolResponse(BaseModel):
+    """The response from a tool execution."""
+
+    text: str | None = None
+    image: list[Any] | None = None
+    video: list[Any] | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def initialize_request(cls, values):
+        if "image" in values and not isinstance(values["image"], list):
+            raise ValueError(
+                f"Image must be a list, but got {type(values['image'])}. Please check the tool.execute(). "
+                f"For single images, wrap in a list: [image]. "
+                f"Example: {{'image': [img1]}} or {{'image': [img1, img2, ...]}}."
+            )
+        if "video" in values and not isinstance(values["video"], list):
+            raise ValueError(
+                f"Video must be a list, but got {type(values['video'])}. Please check the tool.execute(). "
+                f"For single videos, wrap in a list: [video]. "
+                f"Example: {{'video': [video1]}} or {{'video': [video1, video2, ...]}}."
+            )
+
+        return values
+
+    def is_empty(self) -> bool:
+        return not self.text and not self.image and not self.video
+
+    def is_text_only(self) -> bool:
+        return self.text and not self.image and not self.video
+
+
+__all__ = [
+    "OpenAIFunctionPropertySchema",
+    "OpenAIFunctionParametersSchema",
+    "OpenAIFunctionSchema",
+    "OpenAIFunctionToolSchema",
+    "OpenAIFunctionParsedSchema",
+    "OpenAIFunctionCallSchema",
+    "OpenAIFunctionToolCall",
+    "ToolResponse",
+]

--- a/uni_agent/interaction/tool_schemas.py
+++ b/uni_agent/interaction/tool_schemas.py
@@ -78,7 +78,7 @@ class OpenAIFunctionCallSchema(BaseModel):
     @staticmethod
     def from_openai_function_parsed_schema(
         parsed_schema: OpenAIFunctionParsedSchema,
-    ) -> tuple["OpenAIFunctionCallSchema", bool]:
+    ) -> tuple[OpenAIFunctionCallSchema, bool]:
         has_decode_error = False
         try:
             arguments = json.loads(parsed_schema.arguments)

--- a/uni_agent/interaction/tools_manager.py
+++ b/uni_agent/interaction/tools_manager.py
@@ -33,7 +33,7 @@ class ToolsManager:
     async def parse_action(
         self,
         model_output: str,
-    ) -> dict:
+    ) -> tuple[str, list[OpenAIFunctionToolCall]]:
         tools = [OpenAIFunctionToolSchema(**schema) for schema in self.tools_schemas]
         content, tool_calls = self._tool_parser.extract_tool_calls(model_output, tools)
 

--- a/uni_agent/interaction/tools_manager.py
+++ b/uni_agent/interaction/tools_manager.py
@@ -3,9 +3,13 @@ import shlex
 
 from pydantic import BaseModel, ConfigDict
 
+from uni_agent.interaction.tool_schemas import (
+    OpenAIFunctionCallSchema,
+    OpenAIFunctionToolCall,
+    OpenAIFunctionToolSchema,
+)
 from uni_agent.interaction.tool_parser import FunctionCallFormatError, get_tool_parser
 from uni_agent.tools import ToolConfig
-from verl.tools.schemas import OpenAIFunctionCallSchema, OpenAIFunctionToolCall, OpenAIFunctionToolSchema
 
 
 class ToolsManagerConfig(BaseModel):

--- a/uni_agent/interaction/tools_manager.py
+++ b/uni_agent/interaction/tools_manager.py
@@ -90,7 +90,7 @@ class ToolsManager:
         if func_name == "execute_bash":
             return func_params.get("command", "")
 
-        if func_name in ["lark-cli"]:
+        if func_name == "lark-cli":
             command = func_params.get("command", "")
             return f"lark-cli {command}" if command else ""
 

--- a/uni_agent/interaction/tools_manager.py
+++ b/uni_agent/interaction/tools_manager.py
@@ -3,12 +3,12 @@ import shlex
 
 from pydantic import BaseModel, ConfigDict
 
+from uni_agent.interaction.tool_parser import FunctionCallFormatError, get_tool_parser
 from uni_agent.interaction.tool_schemas import (
     OpenAIFunctionCallSchema,
     OpenAIFunctionToolCall,
     OpenAIFunctionToolSchema,
 )
-from uni_agent.interaction.tool_parser import FunctionCallFormatError, get_tool_parser
 from uni_agent.tools import ToolConfig
 
 

--- a/uni_agent/interaction/tools_manager.py
+++ b/uni_agent/interaction/tools_manager.py
@@ -90,6 +90,10 @@ class ToolsManager:
         if func_name == "execute_bash":
             return func_params.get("command", "")
 
+        if func_name in ["lark-cli"]:
+            command = func_params.get("command", "")
+            return f"lark-cli {command}" if command else ""
+
         # Start building the command
         cmd_parts = [shlex.quote(func_name)]
 

--- a/uni_agent/skills/__init__.py
+++ b/uni_agent/skills/__init__.py
@@ -1,0 +1,12 @@
+# ruff: noqa
+"""Agent Skills subsystem (progressive disclosure, Claude Code / Qwen Code style)."""
+
+from .base import Skill, parse_skill_md
+from .manager import SkillsManager, SkillsManagerConfig
+
+__all__ = [
+    "Skill",
+    "parse_skill_md",
+    "SkillsManager",
+    "SkillsManagerConfig",
+]

--- a/uni_agent/skills/base.py
+++ b/uni_agent/skills/base.py
@@ -67,7 +67,12 @@ def _split_frontmatter(text: str) -> tuple[str, str, str]:
     Returns ``(description, name, body)``. Missing fields come back as ``""``.
     Only ``name`` and ``description`` are recognised today; ``paths:`` and
     other Qwen / Claude fields are silently ignored for forward compatibility.
+
+    Uses ``yaml.safe_load`` so block scalars (``description: |``), quoted
+    values containing colons, and other valid YAML constructs all work.
     """
+    import yaml
+
     stripped = text.lstrip()
     if not stripped.startswith("---"):
         # No frontmatter -- treat the whole file as body, no metadata.
@@ -80,12 +85,14 @@ def _split_frontmatter(text: str) -> tuple[str, str, str]:
 
     frontmatter = stripped[3:end].strip()
     body = stripped[end + 4 :].lstrip("\n")
-    description = ""
-    name = ""
-    for line in frontmatter.splitlines():
-        bare = line.lstrip()
-        if bare.lower().startswith("description:"):
-            description = bare.split(":", 1)[1].strip().strip("'\"")
-        elif bare.lower().startswith("name:"):
-            name = bare.split(":", 1)[1].strip().strip("'\"")
+
+    try:
+        meta = yaml.safe_load(frontmatter)
+    except yaml.YAMLError:
+        meta = None
+    if not isinstance(meta, dict):
+        meta = {}
+
+    description = str(meta.get("description") or "").strip()
+    name = str(meta.get("name") or "").strip()
     return description, name, body

--- a/uni_agent/skills/base.py
+++ b/uni_agent/skills/base.py
@@ -1,0 +1,91 @@
+"""Skill abstraction: one ``SKILL.md`` + its sibling files on disk.
+
+A skill is a *directory* on the host filesystem containing:
+
+- ``SKILL.md`` (required): YAML frontmatter (``name``, ``description``) plus
+  markdown body. Auto-read by the model on demand via ``cat``.
+- Any number of sibling files (``reference.md``, ``examples.md``,
+  ``scripts/...``, ``templates/...``): NOT pre-loaded; SKILL.md references
+  them by relative path and the model decides when to read or execute them.
+
+This module only parses skills off disk; pushing them into the container
+and assembling the manifest prompt live in ``manager.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Skill:
+    """One discovered skill directory.
+
+    Attributes:
+        name: canonical identifier, falls back to the directory name if
+            no ``name:`` field is present in frontmatter.
+        description: from ``description:`` in frontmatter. Should describe
+            *what* the skill is and *when* to use it -- this is what the
+            model sees in the manifest.
+        body: SKILL.md markdown body after the frontmatter block. Loaded
+            on demand by the model, not pushed into the system prompt.
+        source_dir: host-side directory holding SKILL.md and its siblings.
+        origin: short tag describing where the skill came from (e.g.
+            ``"tool:lark-cli"``, ``"user"``), used purely for logging /
+            ordering in the manifest.
+    """
+
+    name: str
+    description: str
+    body: str
+    source_dir: Path
+    origin: str = ""
+
+    @property
+    def skill_md_path(self) -> Path:
+        return self.source_dir / "SKILL.md"
+
+
+def parse_skill_md(skill_md_path: Path, origin: str = "") -> Skill:
+    """Load and parse a single ``SKILL.md`` file from disk."""
+    text = skill_md_path.read_text(encoding="utf-8")
+    description, name_override, body = _split_frontmatter(text)
+    name = name_override or skill_md_path.parent.name
+    return Skill(
+        name=name,
+        description=description,
+        body=body,
+        source_dir=skill_md_path.parent,
+        origin=origin,
+    )
+
+
+def _split_frontmatter(text: str) -> tuple[str, str, str]:
+    """Parse the YAML frontmatter at the top of ``text``.
+
+    Returns ``(description, name, body)``. Missing fields come back as ``""``.
+    Only ``name`` and ``description`` are recognised today; ``paths:`` and
+    other Qwen / Claude fields are silently ignored for forward compatibility.
+    """
+    stripped = text.lstrip()
+    if not stripped.startswith("---"):
+        # No frontmatter -- treat the whole file as body, no metadata.
+        return "", "", text.lstrip("\n")
+
+    end = stripped.find("\n---", 3)
+    if end == -1:
+        # Malformed frontmatter (no closing ---); treat as body, log nothing.
+        return "", "", text.lstrip("\n")
+
+    frontmatter = stripped[3:end].strip()
+    body = stripped[end + 4 :].lstrip("\n")
+    description = ""
+    name = ""
+    for line in frontmatter.splitlines():
+        bare = line.lstrip()
+        if bare.lower().startswith("description:"):
+            description = bare.split(":", 1)[1].strip().strip("'\"")
+        elif bare.lower().startswith("name:"):
+            name = bare.split(":", 1)[1].strip().strip("'\"")
+    return description, name, body

--- a/uni_agent/skills/manager.py
+++ b/uni_agent/skills/manager.py
@@ -1,0 +1,124 @@
+"""SkillsManager: discover skills and build the system-prompt manifest.
+
+Mirrors Claude Code / Qwen Code's progressive disclosure model:
+
+- The system prompt only sees a lightweight **manifest** (skill name +
+  description + path to its ``SKILL.md``).
+- Skill bodies live as real files on disk. The model reads them on demand
+  using ``execute_bash`` (e.g. ``cat /opt/uni-agent/skills/<name>/SKILL.md``).
+- Each ``SKILL.md`` may reference sibling files (``reference.md``,
+  ``examples.md``, ``scripts/...``); those are pushed into the container
+  alongside ``SKILL.md`` and read lazily by the model.
+
+Skills are fully **user-managed**: drop the directories you want exposed
+into a single host-side dir (e.g. ``~/.uni-agent/skills/``) and point
+``SkillsManagerConfig.skills_dir`` at it. Tools themselves bundle no
+skills. Path resolution and per-deployment transfer are owned by
+``AgentEnv`` (see ``env.install_skills``): host deployments keep skills
+in place, container deployments copy them under ``/opt/uni-agent/skills/<name>/``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from uni_agent.skills.base import Skill, parse_skill_md
+
+
+class SkillsManagerConfig(BaseModel):
+    """Configuration for the SkillsManager."""
+
+    skills_dir: Path | None = Field(
+        default=None,
+        description=(
+            "Host-side directory holding ``<skill-name>/SKILL.md`` subdirs. "
+            "All discovered skills come from here -- tools ship no skills "
+            "of their own. ``~`` is expanded. Example: ``~/.uni-agent/skills``."
+        ),
+    )
+    model_config = ConfigDict(extra="forbid")
+
+
+class SkillsManager:
+    """Skill discovery and manifest assembly. Install is owned by ``AgentEnv``."""
+
+    def __init__(self, config: SkillsManagerConfig, skills: list[Skill]):
+        self.config = config
+        self.skills: list[Skill] = sorted(skills, key=lambda s: s.name)
+        # Populated by ``AgentEnv.install_skills``: skill name -> path inside
+        # the runtime (the original host source dir for host runtimes;
+        # ``/opt/uni-agent/skills/<name>`` for container runtimes). Empty
+        # until install_skills runs; ``build_manifest`` falls back to the
+        # host source dir so it stays correct even if called early.
+        self.runtime_paths: dict[str, Path] = {}
+
+    @classmethod
+    def from_config(cls, config: SkillsManagerConfig) -> "SkillsManager":
+        """Scan ``config.skills_dir`` for ``<name>/SKILL.md`` subdirs."""
+        skills: list[Skill] = []
+        if config.skills_dir is not None:
+            root = Path(config.skills_dir).expanduser()
+            skills = _scan_skills_root(root)
+        return cls(config=config, skills=skills)
+
+    def build_manifest(self) -> str:
+        """System-prompt block listing every discovered skill.
+
+        XML layout aligned with Claude Code's upstream Agent Skills
+        formatter (and OpenClaw's port of it) so models trained against
+        either system find it familiar. Empty string when no skills were
+        discovered so callers can do ``if manifest: ...``.
+
+        Reads ``self.runtime_paths`` (populated by
+        ``AgentEnv.install_skills``) for each skill's in-runtime path,
+        falling back to ``skill.source_dir`` if install_skills hasn't run
+        yet -- correct for host runtimes, an acceptable best-effort
+        otherwise.
+        """
+        if not self.skills:
+            return ""
+
+        lines = [
+            "The following skills provide specialized instructions for specific tasks.",
+            "Use the read tool to load a skill's file when the task matches its description.",
+            "When a skill file references a relative path, resolve it against the skill "
+            "directory (parent of SKILL.md / dirname of the path) and use that absolute path "
+            "in tool commands.",
+            "",
+            "<available_skills>",
+        ]
+        for s in self.skills:
+            skill_md = self.runtime_paths.get(s.name, s.source_dir) / "SKILL.md"
+            desc = s.description.strip() or "(no description)"
+            lines.append("  <skill>")
+            lines.append(f"    <name>{_xml_escape(s.name)}</name>")
+            lines.append(f"    <description>{_xml_escape(desc)}</description>")
+            lines.append(f"    <location>{_xml_escape(skill_md.as_posix())}</location>")
+            lines.append("  </skill>")
+        lines.append("</available_skills>")
+        return "\n".join(lines)
+
+
+def _scan_skills_root(root: Path) -> list[Skill]:
+    """Find every ``<root>/<name>/SKILL.md`` and parse it."""
+    if not root.is_dir():
+        return []
+    found: list[Skill] = []
+    for skill_md in sorted(root.glob("*/SKILL.md")):
+        if not skill_md.is_file():
+            continue
+        found.append(parse_skill_md(skill_md))
+    return found
+
+
+def _xml_escape(value: str) -> str:
+    """Escape the five XML special characters in a manifest field."""
+    return (
+        value.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&apos;")
+    )

--- a/uni_agent/skills/manager.py
+++ b/uni_agent/skills/manager.py
@@ -55,7 +55,7 @@ class SkillsManager:
         self.runtime_paths: dict[str, Path] = {}
 
     @classmethod
-    def from_config(cls, config: SkillsManagerConfig) -> "SkillsManager":
+    def from_config(cls, config: SkillsManagerConfig) -> SkillsManager:
         """Scan ``config.skills_dir`` for ``<name>/SKILL.md`` subdirs."""
         skills: list[Skill] = []
         if config.skills_dir is not None:

--- a/uni_agent/tools/__init__.py
+++ b/uni_agent/tools/__init__.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from .finish import FinishTool
 from .registry import get_tool, AbstractTool
 from .execute_bash import ExecuteBashTool
+from .lark_cli import LarkCliTool
 from .search_arxiv import SearchArxivTool
 from .search import SearchWikiTool
 from .str_replace_editor import StrReplaceEditorTool
@@ -26,6 +27,7 @@ __all__ = [
     "ToolConfig",
     "ExecuteBashTool",
     "FinishTool",
+    "LarkCliTool",
     "SearchArxivTool",
     "SearchWikiTool",
     "StrReplaceEditorTool",

--- a/uni_agent/tools/lark_cli/__init__.py
+++ b/uni_agent/tools/lark_cli/__init__.py
@@ -93,8 +93,8 @@ class LarkCliTool(AbstractTool):
 
     def get_install_command(self) -> str | None:
         return (
-            "lark-cli --version >/dev/null 2>&1 || { "
+            "lark-cli --version >/dev/null 2>&1 || ( "
             "echo 'lark-cli not found in PATH. Install with: "
             "npm install -g @larksuite/cli && lark-cli auth login --recommend' >&2; "
-            "exit 1; }"
+            "exit 1 )"
         )

--- a/uni_agent/tools/lark_cli/__init__.py
+++ b/uni_agent/tools/lark_cli/__init__.py
@@ -55,8 +55,9 @@ Tips:
 - Most commands return JSON on stdout. Use `--format pretty|table|csv|ndjson`
   to switch formatting if needed.
 - Send messages only with `--as bot`; user-identity send is not supported.
-- Refer to the bundled Skills (lark-calendar, lark-docs, lark-im, lark-vc, ...)
-  for the exact command vocabulary and recommended workflows.
+- If the system prompt lists ``lark-*`` Skills (lark-calendar, lark-doc,
+  lark-im, lark-vc, ...), `cat` them on demand for the exact command
+  vocabulary and recommended workflows.
 """.strip()
 
 
@@ -84,35 +85,6 @@ class LarkCliTool(AbstractTool):
     def local_path(self) -> Path:
         return Path(__file__).parent / "lark-cli"
 
-    @property
-    def skills_dir(self) -> Path:
-        """Local directory holding bundled SKILL.md files for this tool.
-
-        Skills are NOT pushed into the container. They are loaded by the agent
-        loop on the host side and injected into the model's system prompt
-        (see ``get_skills`` below). This mirrors how Claude Code consumes the
-        upstream `larksuite/cli` skills under ``~/.claude/skills/``.
-        """
-        return Path(__file__).parent / "skills"
-
-    def get_skills(self) -> list[dict]:
-        """Load bundled SKILL.md files for prompt injection.
-
-        Returns a list of ``{"name": str, "description": str, "body": str}``
-        dicts, one per skill, sorted by filename for determinism.
-        Returns an empty list if the skills directory does not exist yet.
-        """
-        skills: list[dict] = []
-        if not self.skills_dir.is_dir():
-            return skills
-
-        for skill_path in sorted(self.skills_dir.glob("*/SKILL.md")):
-            name = skill_path.parent.name
-            text = skill_path.read_text(encoding="utf-8")
-            description, body = _split_skill_frontmatter(text)
-            skills.append({"name": name, "description": description, "body": body})
-        return skills
-
     def get_tool_schema(self) -> dict:
         return self.build_tool_schema(
             description=DESCRIPTION,
@@ -120,35 +92,9 @@ class LarkCliTool(AbstractTool):
         )
 
     def get_install_command(self) -> str | None:
-        # Best-effort install. Assumes the runtime has node/npm available.
-        # Authentication (`lark-cli auth login`) must be performed beforehand
-        # on the host, and ~/.config/larksuite (or equivalent) must already be
-        # populated when the tool is invoked.
         return (
-            "lark-cli --version >/dev/null 2>&1 "
-            "|| (npm install -g @larksuite/cli "
-            "&& chmod +x \"$(npm root -g)/@larksuite/cli/scripts/run.js\" 2>/dev/null || true)"
+            "lark-cli --version >/dev/null 2>&1 || { "
+            "echo 'lark-cli not found in PATH. Install with: "
+            "npm install -g @larksuite/cli && lark-cli auth login --recommend' >&2; "
+            "exit 1; }"
         )
-
-
-def _split_skill_frontmatter(text: str) -> tuple[str, str]:
-    """Parse a SKILL.md file into (description, body).
-
-    Supports both Claude-Code-style YAML frontmatter
-    (``---\\ndescription: ...\\n---\\n<body>``) and a fallback where the first
-    non-empty line is treated as the description.
-    """
-    stripped = text.lstrip()
-    if stripped.startswith("---"):
-        end = stripped.find("\n---", 3)
-        if end != -1:
-            frontmatter = stripped[3:end].strip()
-            body = stripped[end + 4 :].lstrip("\n")
-            description = ""
-            for line in frontmatter.splitlines():
-                if line.lower().startswith("description:"):
-                    description = line.split(":", 1)[1].strip().strip("'\"")
-                    break
-            return description, body
-    first_line, _, rest = text.partition("\n")
-    return first_line.strip("# ").strip(), rest.lstrip("\n")

--- a/uni_agent/tools/lark_cli/__init__.py
+++ b/uni_agent/tools/lark_cli/__init__.py
@@ -1,0 +1,154 @@
+# ruff: noqa: E501
+"""Lark/Feishu CLI tool definition.
+
+Thin wrapper around the official ``lark-cli`` binary
+(https://github.com/larksuite/cli). The actual command string the model
+emits is forwarded through the shell verbatim (see the ``lark-cli`` case in
+``uni_agent/interaction/tools_manager.py``), so any feature ``lark-cli``
+supports on a regular shell -- shortcuts, API commands, raw API, plus
+heredocs, command substitution, pipes -- works here too.
+
+The tool is registered under the name ``lark-cli`` (matching the upstream
+binary). The containing Python package directory stays ``lark_cli`` because
+hyphens are not valid in Python module names.
+
+Authentication is expected to be done *outside* the container by the user
+(``lark-cli auth login --recommend``). The local credential file is then
+mounted/copied into the runtime environment.
+"""
+
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from uni_agent.tools.base import AbstractTool
+from uni_agent.tools.registry import register_tool
+
+DESCRIPTION = """
+Run a Lark / Feishu CLI command. The string you put in `command` is what
+would follow `lark-cli` on the shell, and is executed *through* the shell --
+heredocs, command substitution (`$(...)`), pipes and redirects all work.
+
+`lark-cli` exposes Lark/Feishu (calendar, docs, IM, video conference, drive,
+bitable, sheets, wiki, contact, mail, task, ...) through three layers:
+
+1. **Shortcuts** (prefixed with `+`, e.g. `calendar +agenda`, `docs +fetch`)
+   — high-level, zero-config commands for common scenarios.
+2. **API Commands** — `<resource> <action>` style, parameters via `--params`
+   (JSON). Mirrors the Lark Open Platform REST endpoints.
+3. **Raw API** — `api <METHOD> <PATH> --params <json> --data <json>` for any
+   of the 2500+ Lark OpenAPI endpoints.
+
+Examples:
+- command = "calendar +agenda"
+- command = "docs +fetch --doc \\"https://bytedance.larkoffice.com/docx/...\\""
+- command = "api GET /open-apis/calendar/v4/calendars/primary/events"
+- command = "calendar events instance_view --params '{\\"calendar_id\\":\\"primary\\",\\"start_time\\":\\"1700000000\\",\\"end_time\\":\\"1700086400\\"}'"
+- command = "docs +create --title \\"Draft\\" --markdown \\"$(cat /tmp/draft.md)\\""
+  (use `execute_bash` first to write the file to /tmp)
+
+Tips:
+- For long markdown bodies, prefer the two-step pattern:
+  1) `execute_bash` to write the body to `/tmp/x.md`
+  2) `lark-cli docs +create --title ... --markdown "$(cat /tmp/x.md)"`
+  This avoids escaping a multi-line string inside JSON.
+- Most commands return JSON on stdout. Use `--format pretty|table|csv|ndjson`
+  to switch formatting if needed.
+- Send messages only with `--as bot`; user-identity send is not supported.
+- Refer to the bundled Skills (lark-calendar, lark-docs, lark-im, lark-vc, ...)
+  for the exact command vocabulary and recommended workflows.
+""".strip()
+
+
+class LarkCliArguments(BaseModel):
+    command: str = Field(
+        description=(
+            "Arguments to pass to `lark-cli`, written exactly as you would on "
+            "the shell. The command is executed through the shell, so `$(...)`, "
+            "heredocs, pipes and redirects are all available. "
+            "Examples: `calendar +agenda`, "
+            '`docs +fetch --doc "https://bytedance.larkoffice.com/docx/..."`, '
+            "`api GET /open-apis/calendar/v4/calendars`. "
+            "Do NOT include the leading `lark-cli` token; the framework adds it."
+        ),
+    )
+
+
+@register_tool("lark-cli")
+class LarkCliTool(AbstractTool):
+    @property
+    def name(self) -> str:
+        return "lark-cli"
+
+    @property
+    def local_path(self) -> Path:
+        return Path(__file__).parent / "lark-cli"
+
+    @property
+    def skills_dir(self) -> Path:
+        """Local directory holding bundled SKILL.md files for this tool.
+
+        Skills are NOT pushed into the container. They are loaded by the agent
+        loop on the host side and injected into the model's system prompt
+        (see ``get_skills`` below). This mirrors how Claude Code consumes the
+        upstream `larksuite/cli` skills under ``~/.claude/skills/``.
+        """
+        return Path(__file__).parent / "skills"
+
+    def get_skills(self) -> list[dict]:
+        """Load bundled SKILL.md files for prompt injection.
+
+        Returns a list of ``{"name": str, "description": str, "body": str}``
+        dicts, one per skill, sorted by filename for determinism.
+        Returns an empty list if the skills directory does not exist yet.
+        """
+        skills: list[dict] = []
+        if not self.skills_dir.is_dir():
+            return skills
+
+        for skill_path in sorted(self.skills_dir.glob("*/SKILL.md")):
+            name = skill_path.parent.name
+            text = skill_path.read_text(encoding="utf-8")
+            description, body = _split_skill_frontmatter(text)
+            skills.append({"name": name, "description": description, "body": body})
+        return skills
+
+    def get_tool_schema(self) -> dict:
+        return self.build_tool_schema(
+            description=DESCRIPTION,
+            arguments_model=LarkCliArguments,
+        )
+
+    def get_install_command(self) -> str | None:
+        # Best-effort install. Assumes the runtime has node/npm available.
+        # Authentication (`lark-cli auth login`) must be performed beforehand
+        # on the host, and ~/.config/larksuite (or equivalent) must already be
+        # populated when the tool is invoked.
+        return (
+            "command -v lark-cli >/dev/null 2>&1 "
+            "|| (npm install -g @larksuite/cli "
+            "&& chmod +x \"$(npm root -g)/@larksuite/cli/scripts/run.js\" 2>/dev/null || true)"
+        )
+
+
+def _split_skill_frontmatter(text: str) -> tuple[str, str]:
+    """Parse a SKILL.md file into (description, body).
+
+    Supports both Claude-Code-style YAML frontmatter
+    (``---\\ndescription: ...\\n---\\n<body>``) and a fallback where the first
+    non-empty line is treated as the description.
+    """
+    stripped = text.lstrip()
+    if stripped.startswith("---"):
+        end = stripped.find("\n---", 3)
+        if end != -1:
+            frontmatter = stripped[3:end].strip()
+            body = stripped[end + 4 :].lstrip("\n")
+            description = ""
+            for line in frontmatter.splitlines():
+                if line.lower().startswith("description:"):
+                    description = line.split(":", 1)[1].strip().strip("'\"")
+                    break
+            return description, body
+    first_line, _, rest = text.partition("\n")
+    return first_line.strip("# ").strip(), rest.lstrip("\n")

--- a/uni_agent/tools/lark_cli/__init__.py
+++ b/uni_agent/tools/lark_cli/__init__.py
@@ -125,7 +125,7 @@ class LarkCliTool(AbstractTool):
         # on the host, and ~/.config/larksuite (or equivalent) must already be
         # populated when the tool is invoked.
         return (
-            "command -v lark-cli >/dev/null 2>&1 "
+            "lark-cli --version >/dev/null 2>&1 "
             "|| (npm install -g @larksuite/cli "
             "&& chmod +x \"$(npm root -g)/@larksuite/cli/scripts/run.js\" 2>/dev/null || true)"
         )

--- a/uni_agent/tools/lark_cli/lark-cli
+++ b/uni_agent/tools/lark_cli/lark-cli
@@ -45,7 +45,6 @@ def main() -> int:
         return 127
 
     os.execv(real, ["lark-cli", *sys.argv[1:]])
-    return 0  # unreachable
 
 
 if __name__ == "__main__":

--- a/uni_agent/tools/lark_cli/lark-cli
+++ b/uni_agent/tools/lark_cli/lark-cli
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+Debug-only wrapper that exec()s straight into the real `lark-cli` binary.
+
+The uni-agent framework special-cases ``lark-cli`` in
+``uni_agent/interaction/tools_manager.py`` and emits a bash command like
+``lark-cli <command>``. PATH resolution lands on this script first (the
+uni-agent ``install_dir`` is prepended to PATH), so this wrapper must locate
+the *real* ``lark-cli`` (installed by ``npm install -g @larksuite/cli``,
+typically at ``/opt/homebrew/bin/lark-cli`` or ``$(npm root -g)/...``) and
+exec into it -- otherwise we would recurse infinitely into ourselves.
+
+This wrapper also lets ``which lark-cli`` succeed during tool installation
+and lets developers manually run ``lark-cli <args>`` for parity with the
+agent path.
+"""
+
+import os
+import sys
+
+
+def _find_real_lark_cli() -> str | None:
+    """Walk PATH and return the first ``lark-cli`` that is not this script."""
+    self_real = os.path.realpath(sys.argv[0])
+    for path_dir in os.environ.get("PATH", "").split(os.pathsep):
+        if not path_dir:
+            continue
+        candidate = os.path.join(path_dir, "lark-cli")
+        if not (os.path.isfile(candidate) and os.access(candidate, os.X_OK)):
+            continue
+        if os.path.realpath(candidate) == self_real:
+            continue
+        return candidate
+    return None
+
+
+def main() -> int:
+    real = _find_real_lark_cli()
+    if real is None:
+        sys.stderr.write(
+            "Error: `lark-cli` is not installed or not on PATH.\n"
+            "Install: npm install -g @larksuite/cli\n"
+            "Auth:    lark-cli auth login --recommend\n"
+        )
+        return 127
+
+    os.execv(real, ["lark-cli", *sys.argv[1:]])
+    return 0  # unreachable
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/uni_agent/tools/lark_cli/lark-cli
+++ b/uni_agent/tools/lark_cli/lark-cli
@@ -21,7 +21,7 @@ import sys
 
 def _find_real_lark_cli() -> str | None:
     """Walk PATH and return the first ``lark-cli`` that is not this script."""
-    self_real = os.path.realpath(sys.argv[0])
+    self_real = os.path.realpath(__file__)
     for path_dir in os.environ.get("PATH", "").split(os.pathsep):
         if not path_dir:
             continue

--- a/uni_agent/utils.py
+++ b/uni_agent/utils.py
@@ -2,6 +2,25 @@ import asyncio
 import concurrent.futures
 import functools
 import inspect
+import time
+from contextlib import contextmanager
+
+
+@contextmanager
+def simple_timer(name: str, timing_raw: dict[str, float]):
+    """Accumulate the elapsed wall time of the ``with`` block into ``timing_raw[name]``.
+
+    Drop-in replacement for ``verl.utils.profiler.simple_timer`` -- same
+    signature and accumulation semantics, but uses ``time.perf_counter``
+    directly so we don't have to drag in ``codetiming`` (or ``verl``)
+    just to time a block of code.
+    """
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        elapsed = time.perf_counter() - start
+        timing_raw[name] = timing_raw.get(name, 0.0) + elapsed
 
 
 def get_event_loop():


### PR DESCRIPTION
### What does this PR do?

Adds an end-to-end Lark/Feishu agent demo and the supporting plumbing: a
new `local_native` deployment (in-process pexpect bash, no container), a
`SkillsManager` that injects a progressive-disclosure manifest into the
system prompt, a `lark-cli` tool, and a small refactor that pushes
`verl` imports from module load time down to call time so the
inference-only path no longer needs `verl` installed.

### Checklist Before Starting

- [x] Search for similar PRs or issues and paste at least one relevant link here: n/a (new subsystem)
- [x] Format the PR title as `[{modules}] {type}: {description}` (checked by CI)

### Test

- Manual: `BASE_URL=... MODEL_NAME=Qwen/Qwen3.6-35B-A3B python examples/lark/demo.py`
  end-to-end against a vLLM endpoint serving Qwen3.6-35B-A3B; the agent
  reads `lark-*` SKILL.md files on demand and drives `lark-cli` to
  complete a "summarise last 7 days of mail and DM me" task.
- Smoke import test on all touched modules.
- Unit-style sanity checks on `_split_frontmatter` (single-line, block
  scalar `description: |`, quoted-with-colon, no frontmatter, malformed
  closing `---`, malformed YAML body).
- No automated tests added; the new pieces are exercised by the demo and
  will get coverage when we wire CI for the rollout/agent-loop side.

### API and Usage Example

New public surface:

- `LocalNativeDeploymentConfig(type="local_native", ...)` — in-process
  pexpect runtime, compatible with `auto_await`'s fresh-loop semantics.
- `SkillsManager.from_config(SkillsManagerConfig(skills_dir=...))` plus
  `AgentEnv.install_skills(...)` and `AgentInteraction.inject_skills_manifest()`.
- `ToolConfig(name="lark-cli")` — thin wrapper that forwards the
  model-emitted `command` string to the upstream `lark-cli` binary.

```python
from uni_agent.interaction import AgentEnv, AgentEnvConfig, AgentInteraction, ToolsManager, ToolsManagerConfig
from uni_agent.skills import SkillsManager, SkillsManagerConfig
from uni_agent.tools import ToolConfig

env = AgentEnv(run_id=run_id, env_config=AgentEnvConfig(
    deployment={"type": "local_native"},
    tool_install_dir=Path.home() / ".uni-agent" / "bin",
    env_variables={"NO_COLOR": "1", "TERM": "dumb"},
))
tools = ToolsManager(ToolsManagerConfig(tools=[
    ToolConfig(name="execute_bash"),
    ToolConfig(name="lark-cli"),
    ToolConfig(name="finish"),
]))
skills = SkillsManager.from_config(SkillsManagerConfig(
    skills_dir=Path.home() / ".uni-agent" / "skills",
))

env.start()
env.install_tools(tools.tools)
env.install_skills(skills)

interaction = AgentInteraction(run_id=run_id, env=env, model=model,
                               tools_manager=tools, messages=messages,
                               skills_manager=skills)
interaction.inject_skills_manifest()
result = interaction.run()