### PR TITLE
[tools] feat: support multi-tool calling per turn

### DIFF
--- a/examples/lark/demo.py
+++ b/examples/lark/demo.py
@@ -333,7 +333,12 @@ else:
     print("  No step output found.")
 
 print("\nFinal result:")
-print(last_step.observation if last_step is not None else "(empty)")
+if last_step is None:
+    print("(empty)")
+elif last_step.tool_results:
+    print(last_step.tool_results[-1].observation)
+else:
+    print(last_step.response or "(empty)")
 
 env.close()
 print("\n[env] closed")

--- a/examples/search_arxiv/demo.py
+++ b/examples/search_arxiv/demo.py
@@ -117,6 +117,11 @@ else:
     print("No step output found.")
 
 print("\nFinal result:")
-print(last_step.observation)
+if last_step is None:
+    print("(empty)")
+elif last_step.tool_results:
+    print(last_step.tool_results[-1].observation)
+else:
+    print(last_step.response or "(empty)")
 
 env.close()

--- a/uni_agent/interaction/interaction.py
+++ b/uni_agent/interaction/interaction.py
@@ -1,7 +1,8 @@
 import time
+from typing import Literal
 
 import orjson
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from uni_agent.async_logging import get_logger
 from uni_agent.skills.manager import SkillsManager
@@ -13,15 +14,32 @@ from .tool_parser import FunctionCallFormatError
 from .tool_schemas import OpenAIFunctionToolCall
 from .tools_manager import ToolsManager
 
+ToolStatus = Literal["ok", "timeout", "syntax_error", "skipped"]
+
+
+class ToolResult(BaseModel):
+    """Per-tool-call result inside a single step.
+
+    Status is the *tool-level* outcome; the *step-level* outcome lives in
+    :attr:`StepOutput.exit_reason`. ``observation`` always carries what
+    was sent back to the model as the ``role="tool"`` message content (so
+    error tools also carry their error text here).
+    """
+
+    tool_call_id: str
+    name: str
+    action: str = ""
+    observation: str = ""
+    status: ToolStatus
+    execution_time: float | None = None
+
 
 class StepOutput(BaseModel):
     step_idx: int
 
     response: str = ""
     thought: str = ""
-    action: str = ""
-    observation: str = ""
-    execution_time: float | None = None
+    tool_results: list[ToolResult] = Field(default_factory=list)
     done: bool = False
     exit_reason: str = ""
 
@@ -82,6 +100,38 @@ class AgentInteraction:
         self.messages.insert(0, {"role": "system", "content": manifest})
 
     async def step(self, step_idx: int):
+        """Run one model-call + tool-execution cycle.
+
+        Supports **multiple tool calls per assistant message** (executed
+        sequentially in the shared bash session, results appended in
+        order) and treats a model response **without any tool calls** as
+        a turn-final assistant reply (``done=True`` with
+        ``exit_reason="turn_done"``) -- which is what enables long-running
+        chat use cases on top of the same loop.
+
+        Single-shot scripts that rely on the legacy "exactly one tool
+        call per response, terminate on ``finish``/``submit``" pattern
+        keep working unchanged: the model still returns one tool call,
+        ``finish`` still flips ``done=True`` with
+        ``exit_reason="finished"``.
+
+        Two levels of outcome are reported:
+
+        * **Tool level** -- per-call :class:`ToolResult` records on
+          ``step_output.tool_results`` (``status`` is one of ``ok``,
+          ``timeout``, ``syntax_error``, ``skipped``).
+        * **Step level** -- a single ``step_output.exit_reason`` string
+          plus ``step_output.done``:
+
+          - terminal (``done=True``):
+            ``finished``, ``turn_done``, ``token_limit``,
+            ``terminal_dead``, ``timeout_budget_exhausted``.
+          - non-terminal (``done=False``):
+            ``completed``, ``completed_with_tool_errors``,
+            ``format_error``.
+          - set by :meth:`run` outer loop:
+            ``max_step_limit``, ``unknown_error``.
+        """
         # step index start from 1
         step_output = StepOutput(step_idx=step_idx)
         self.logger.info(f"{'=' * 25} STEP {step_idx} {'=' * 25}")
@@ -91,7 +141,7 @@ class AgentInteraction:
 
         # step 2: generate response and update rollout cache
         try:
-            model_output, rollout_cache, generation_info = await self.model.query(
+            model_output, tool_calls, rollout_cache, generation_info = await self.model.query(
                 messages=self.messages,
                 rollout_cache=self.rollout_cache,
             )
@@ -109,20 +159,38 @@ class AgentInteraction:
 
         # step 3: parse model response to actions
         self.rollout_cache = rollout_cache
-        self.messages.append({"role": "assistant", "content": model_output})  # tool call message
+
+        # Mirror api-shaped assistant message into self.messages: keep
+        # tool_calls when present so persistence/replay keeps the
+        # assistant<->tool linkage intact across runs.
+        assistant_msg: dict[str, object] = {"role": "assistant", "content": model_output}
+        if tool_calls:
+            assistant_msg["tool_calls"] = tool_calls
+        self.messages.append(assistant_msg)
+
         try:
-            structured_tool_calls = self.rollout_cache.get("extra_fields", {}).get("last_tool_calls", [])
-            if structured_tool_calls:
+            if tool_calls:
                 content, tool_calls = await self.tools_manager.parse_structured_action(
                     content=model_output,
-                    tool_calls_data=structured_tool_calls,
+                    tool_calls_data=tool_calls,
                 )
             else:
                 content, tool_calls = await self.tools_manager.parse_action(model_output=model_output)
         except FunctionCallFormatError as e:
-            user_message = {"role": "tool", "content": str(e)}
-            self.messages.append(user_message)  # error message
-            self.rollout_cache = await self.model.append_messages_to_rollout_cache([user_message], self.rollout_cache)
+            if tool_calls:
+                error_msgs: list[dict[str, object]] = [
+                    {
+                        "role": "tool",
+                        "tool_call_id": tc["id"],
+                        "name": tc["function"]["name"],
+                        "content": str(e),
+                    }
+                    for tc in tool_calls
+                ]
+            else:
+                error_msgs = [{"role": "tool", "content": str(e)}]
+            self.messages.extend(error_msgs)
+            self.rollout_cache = await self.model.append_messages_to_rollout_cache(error_msgs, self.rollout_cache)
             step_output.exit_reason = "format_error"
             model_output_preview = "\n".join(model_output.splitlines()[:20])
             self.logger.error(
@@ -132,68 +200,135 @@ class AgentInteraction:
             )
             return step_output
 
-        # step 4: run action in the environment
-        tool_call: OpenAIFunctionToolCall = tool_calls[0]
-        action_cmd = self.tools_manager.get_tool_bash_command(tool_call)
         step_output.thought = content
-        step_output.action = action_cmd
-        self.logger.info(f"💭 THOUGHT:\n{content}")
-        self.logger.info(f"🎬 ACTION:\n{action_cmd}")
-        execution_t0 = time.perf_counter()
-        with simple_timer("tool_calls", self.rollout_cache["metrics"]):
-            try:
-                observation = await self.env.run_action(action_cmd, action_timeout=self.action_timeout)
-                tool_message = {"role": "tool", "content": observation}
-                self.messages.append(tool_message)  # tool response message
-                self.rollout_cache = await self.model.append_messages_to_rollout_cache(
-                    [tool_message], self.rollout_cache
-                )
-                step_output.observation = observation
-            except ActionTimeoutError as e:
-                self.logger.error(str(e))
-                user_message = {"role": "tool", "content": str(e)}
-                self.messages.append(user_message)
-                self.rollout_cache = await self.model.append_messages_to_rollout_cache(
-                    [user_message], self.rollout_cache
-                )
-                step_output.exit_reason = "timeout_error"
-                self.logger.info(f"Existing timeout budget: {self.timeout_budget}")
-                if self.timeout_budget > 0:
-                    self.timeout_budget -= 1
-                    return step_output
-                else:
-                    step_output.done = True
-                    return step_output
-            except ActionIncorrectSyntaxError as e:
-                self.logger.error(str(e))
-                user_message = {"role": "tool", "content": str(e)}
-                self.messages.append(user_message)
-                self.rollout_cache = await self.model.append_messages_to_rollout_cache(
-                    [user_message], self.rollout_cache
-                )
-                step_output.exit_reason = "syntax_error"
-                return step_output
-            except TerminalNotAliveError as e:
-                self.logger.error(str(e))
-                user_message = {"role": "tool", "content": str(e)}
-                self.messages.append(user_message)
-                self.rollout_cache = await self.model.append_messages_to_rollout_cache(
-                    [user_message], self.rollout_cache
-                )
-                step_output.exit_reason = "terminal_not_alive"
-                step_output.done = True
-                return step_output
 
-        # step 5: finalize step output
-        execution_time = time.perf_counter() - execution_t0
-        step_output.execution_time = execution_time
-        if tool_call.function.name in ["finish", "submit"]:
+        # step 4: no tool calls -> turn-final assistant reply (chat mode)
+        if not tool_calls:
+            step_output.done = True
+            step_output.exit_reason = "turn_done"
+            self.logger.info(f"💬 TURN DONE (no tool call): {model_output}")
+            return step_output
+
+        # step 5: execute every tool call sequentially in the shared bash session
+        tool_results: list[ToolResult] = []
+        tool_messages: list[dict[str, object]] = []
+        saw_finish = False
+        terminal_dead = False
+
+        with simple_timer("tool_calls", self.rollout_cache["metrics"]):
+            for idx, tool_call in enumerate(tool_calls):
+                tool_call: OpenAIFunctionToolCall  # type: ignore[no-redef]
+                action_cmd = self.tools_manager.get_tool_bash_command(tool_call)
+                self.logger.info(f"🎬 ACTION ({tool_call.function.name}):\n{action_cmd}")
+
+                tool_t0 = time.perf_counter()
+                status: ToolStatus
+                try:
+                    observation = await self.env.run_action(action_cmd, action_timeout=self.action_timeout)
+                    status = "ok"
+                    if tool_call.function.name in ("finish", "submit"):
+                        saw_finish = True
+                except ActionTimeoutError as e:
+                    observation = str(e)
+                    status = "timeout"
+                    self.timeout_budget -= 1
+                    self.logger.error(f"{observation} (timeout_budget left: {self.timeout_budget})")
+                except ActionIncorrectSyntaxError as e:
+                    observation = str(e)
+                    status = "syntax_error"
+                    self.logger.error(observation)
+                except TerminalNotAliveError as e:
+                    observation = str(e)
+                    status = "skipped"
+                    terminal_dead = True
+                    self.logger.error(observation)
+                elapsed = time.perf_counter() - tool_t0
+
+                tool_results.append(
+                    ToolResult(
+                        tool_call_id=tool_call.id,
+                        name=tool_call.function.name,
+                        action=action_cmd,
+                        observation=observation,
+                        status=status,
+                        execution_time=elapsed,
+                    )
+                )
+
+                tool_messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_call.id,
+                        "name": tool_call.function.name,
+                        "content": observation,
+                    }
+                )
+
+                # Stop the in-step loop and synthesize skipped results
+                # for the remaining tool calls when (a) the bash session
+                # is gone, or (b) the timeout budget is now exhausted.
+                budget_exhausted = self.timeout_budget < 0
+                if terminal_dead or budget_exhausted:
+                    if terminal_dead:
+                        skipped_reason = (
+                            "Skipped: the bash session died while running a previous "
+                            "tool call in this step. No further tool calls in this "
+                            "assistant response were executed."
+                        )
+                    else:
+                        skipped_reason = (
+                            "Skipped: timeout budget exhausted while running a previous "
+                            "tool call in this step. No further tool calls in this "
+                            "assistant response were executed."
+                        )
+                    for remaining in tool_calls[idx + 1 :]:
+                        tool_results.append(
+                            ToolResult(
+                                tool_call_id=remaining.id,
+                                name=remaining.function.name,
+                                action="",
+                                observation=skipped_reason,
+                                status="skipped",
+                                execution_time=None,
+                            )
+                        )
+                        tool_messages.append(
+                            {
+                                "role": "tool",
+                                "tool_call_id": remaining.id,
+                                "name": remaining.function.name,
+                                "content": skipped_reason,
+                            }
+                        )
+                    break
+
+        # step 6: commit collected tool messages to both histories
+        self.messages.extend(tool_messages)
+        self.rollout_cache = await self.model.append_messages_to_rollout_cache(tool_messages, self.rollout_cache)
+        step_output.tool_results = tool_results
+
+        # step 7: finalize step-level outcome (precedence: terminal_dead >
+        # timeout_budget_exhausted > finished > completed_with_tool_errors >
+        # completed). Tool-level statuses are already on tool_results.
+        if terminal_dead:
+            step_output.done = True
+            step_output.exit_reason = "terminal_dead"
+            return step_output
+        if self.timeout_budget < 0:
+            step_output.done = True
+            step_output.exit_reason = "timeout_budget_exhausted"
+            self.logger.info("Exit step: timeout budget exhausted.")
+            return step_output
+        if saw_finish:
             step_output.done = True
             step_output.exit_reason = "finished"
-        else:
+            return step_output
+        if any(tr.status in ("timeout", "syntax_error") for tr in tool_results):
             step_output.done = False
-            step_output.exit_reason = "completed"
-
+            step_output.exit_reason = "completed_with_tool_errors"
+            return step_output
+        step_output.done = False
+        step_output.exit_reason = "completed"
         return step_output
 
     @auto_await

--- a/uni_agent/interaction/interaction.py
+++ b/uni_agent/interaction/interaction.py
@@ -18,12 +18,8 @@ ToolStatus = Literal["ok", "timeout", "syntax_error", "skipped"]
 
 
 class ToolResult(BaseModel):
-    """Per-tool-call result inside a single step.
-
-    Status is the *tool-level* outcome; the *step-level* outcome lives in
-    :attr:`StepOutput.exit_reason`. ``observation`` always carries what
-    was sent back to the model as the ``role="tool"`` message content (so
-    error tools also carry their error text here).
+    """Per-tool-call result inside a single step. ``observation`` is what was
+    sent back to the model as the ``role="tool"`` content (error text included).
     """
 
     tool_call_id: str
@@ -60,7 +56,13 @@ class AgentInteraction:
         timeout_budget: int = 3,
         max_turns: int = 50,
         skills_manager: SkillsManager | None = None,
+        chat_mode: bool = False,
     ):
+        """:param chat_mode: how to treat an assistant message with **no** tool
+        calls. ``False`` (default, single-shot / training / code-eval):
+        ``format_error``, loop continues. ``True`` (long-running chat):
+        ``turn_done``, loop returns to wait for the next user message.
+        """
         self.env = env
         self.model = model
         self.tools_manager = tools_manager
@@ -69,6 +71,7 @@ class AgentInteraction:
         self.action_timeout = action_timeout
         self.timeout_budget = timeout_budget
         self.max_turns = max_turns
+        self.chat_mode = chat_mode
         self.logger = get_logger("interaction", run_id)
 
     def inject_skills_manifest(self) -> None:
@@ -102,35 +105,19 @@ class AgentInteraction:
     async def step(self, step_idx: int):
         """Run one model-call + tool-execution cycle.
 
-        Supports **multiple tool calls per assistant message** (executed
-        sequentially in the shared bash session, results appended in
-        order) and treats a model response **without any tool calls** as
-        a turn-final assistant reply (``done=True`` with
-        ``exit_reason="turn_done"``) -- which is what enables long-running
-        chat use cases on top of the same loop.
+        Outcome is reported at two levels:
 
-        Single-shot scripts that rely on the legacy "exactly one tool
-        call per response, terminate on ``finish``/``submit``" pattern
-        keep working unchanged: the model still returns one tool call,
-        ``finish`` still flips ``done=True`` with
-        ``exit_reason="finished"``.
+        * **Tool**: per-call :class:`ToolResult` on ``step_output.tool_results``
+          with ``status`` in ``{ok, timeout, syntax_error, skipped}``.
+        * **Step**: ``step_output.exit_reason`` + ``done``:
 
-        Two levels of outcome are reported:
+          - terminal (``done=True``): ``finished``, ``turn_done``,
+            ``token_limit``, ``terminal_dead``, ``timeout_budget_exhausted``.
+          - non-terminal (``done=False``): ``completed``,
+            ``completed_with_tool_errors``, ``format_error``.
+          - set by :meth:`run`: ``max_step_limit``, ``unknown_error``.
 
-        * **Tool level** -- per-call :class:`ToolResult` records on
-          ``step_output.tool_results`` (``status`` is one of ``ok``,
-          ``timeout``, ``syntax_error``, ``skipped``).
-        * **Step level** -- a single ``step_output.exit_reason`` string
-          plus ``step_output.done``:
-
-          - terminal (``done=True``):
-            ``finished``, ``turn_done``, ``token_limit``,
-            ``terminal_dead``, ``timeout_budget_exhausted``.
-          - non-terminal (``done=False``):
-            ``completed``, ``completed_with_tool_errors``,
-            ``format_error``.
-          - set by :meth:`run` outer loop:
-            ``max_step_limit``, ``unknown_error``.
+        ``turn_done`` is gated on ``self.chat_mode`` (see ``__init__``).
         """
         # step index start from 1
         step_output = StepOutput(step_idx=step_idx)
@@ -160,9 +147,8 @@ class AgentInteraction:
         # step 3: parse model response to actions
         self.rollout_cache = rollout_cache
 
-        # Mirror api-shaped assistant message into self.messages: keep
-        # tool_calls when present so persistence/replay keeps the
-        # assistant<->tool linkage intact across runs.
+        # Mirror api-shaped assistant message into self.messages so
+        # persistence/replay keeps the assistant<->tool linkage.
         assistant_msg: dict[str, object] = {"role": "assistant", "content": model_output}
         if tool_calls:
             assistant_msg["tool_calls"] = tool_calls
@@ -176,6 +162,8 @@ class AgentInteraction:
                 )
             else:
                 content, tool_calls = await self.tools_manager.parse_action(model_output=model_output)
+            if not tool_calls and not self.chat_mode:
+                raise FunctionCallFormatError("No function call found in the response.")
         except FunctionCallFormatError as e:
             if tool_calls:
                 error_msgs: list[dict[str, object]] = [
@@ -202,7 +190,8 @@ class AgentInteraction:
 
         step_output.thought = content
 
-        # step 4: no tool calls -> turn-final assistant reply (chat mode)
+        # step 4: chat_mode only -- no tool call = turn-final reply.
+        # (Single-shot mode already raised FunctionCallFormatError above.)
         if not tool_calls:
             step_output.done = True
             step_output.exit_reason = "turn_done"
@@ -264,9 +253,9 @@ class AgentInteraction:
                     }
                 )
 
-                # Stop the in-step loop and synthesize skipped results
-                # for the remaining tool calls when (a) the bash session
-                # is gone, or (b) the timeout budget is now exhausted.
+                # Stop the loop and synthesize `skipped` results for the
+                # rest when the session is gone or timeout budget is out
+                # (keeps the assistant<->tool N:N invariant).
                 budget_exhausted = self.timeout_budget < 0
                 if terminal_dead or budget_exhausted:
                     if terminal_dead:
@@ -307,9 +296,9 @@ class AgentInteraction:
         self.rollout_cache = await self.model.append_messages_to_rollout_cache(tool_messages, self.rollout_cache)
         step_output.tool_results = tool_results
 
-        # step 7: finalize step-level outcome (precedence: terminal_dead >
+        # step 7: pick step-level exit_reason (precedence: terminal_dead >
         # timeout_budget_exhausted > finished > completed_with_tool_errors >
-        # completed). Tool-level statuses are already on tool_results.
+        # completed).
         if terminal_dead:
             step_output.done = True
             step_output.exit_reason = "terminal_dead"

--- a/uni_agent/interaction/model.py
+++ b/uni_agent/interaction/model.py
@@ -83,7 +83,20 @@ class AgentChatModel:
         messages: list[dict[str, str]],
         rollout_cache: dict[str, Any] | None,
         **kwargs,
-    ) -> list[dict] | dict:
+    ) -> tuple[str, list[dict], dict[str, Any], dict[str, int]]:
+        """Run one model call.
+
+        Returns ``(text, tool_calls, rollout_cache, generation_info)``:
+
+        - ``text``: decoded assistant text (raw model output -- may
+          contain XML/Hermes-style tool-call markers that downstream
+          parsers will extract).
+        - ``tool_calls``: always ``[]`` on this training path. Verl's
+          rollout server returns token ids (no structured tool calls),
+          so callers always fall back to parsing ``text`` via the
+          registered tool parser.
+        - ``rollout_cache`` / ``generation_info``: as before.
+        """
         request_id = rollout_cache["request_id"]
         prompt_ids = rollout_cache["prompt_ids"]
         metrics = rollout_cache["metrics"]
@@ -130,7 +143,8 @@ class AgentChatModel:
                 f"prompt_ids length {len(rollout_cache['prompt_ids'])} exceeds max_model_len {self.max_model_len}\n"
                 f"Generated response:\n{response_str}"
             )
-        return response_str, rollout_cache, generation_info
+
+        return response_str, [], rollout_cache, generation_info
 
     async def _get_new_message_ids(self, new_messages: list[dict[str, Any]]) -> list[int]:
         from verl.utils.chat_template import apply_chat_template
@@ -230,58 +244,55 @@ class OpenAICompatibleChatModel:
         self.tools_schemas = tools_schemas
 
     async def prepare_rollout_cache(self, messages: list[dict[str, str]]) -> dict[str, Any]:
-        return {
-            "metrics": {},
-            "extra_fields": {
-                "backend": "openai-compatible",
-                "api_messages": [dict(message) for message in messages],
-                "last_tool_calls": [],
-            },
-        }
+        """The OpenAI path is stateless across calls except for metrics
+        accumulation -- the conversation history is owned and passed in
+        explicitly by the caller (``AgentInteraction.messages``), so
+        nothing else needs to live in ``rollout_cache``.
+        """
+        return {"metrics": {}}
 
     async def append_messages_to_rollout_cache(
         self,
-        new_messages: list[dict[str, str]],
+        new_messages: list[dict[str, Any]],
         rollout_cache: dict[str, Any] | None,
     ):
-        api_messages = rollout_cache["extra_fields"]["api_messages"]
-        last_tool_calls = rollout_cache["extra_fields"].get("last_tool_calls", [])
-        last_tool_call = last_tool_calls[0] if last_tool_calls else None
+        """No-op on the OpenAI path.
 
-        for message in new_messages:
-            if message["role"] == "tool":
-                tool_message = {
-                    "role": "tool",
-                    "content": message["content"],
-                }
-                if last_tool_call is not None:
-                    tool_message["tool_call_id"] = last_tool_call["id"]
-                    tool_message["name"] = last_tool_call["function"]["name"]
-                api_messages.append(tool_message)
-            else:
-                api_messages.append(dict(message))
-
+        The training counterpart (:class:`AgentChatModel`) uses this to
+        tokenize and accumulate ``prompt_ids``; here the caller owns
+        the message list (`AgentInteraction.messages`) and re-passes it
+        on every :meth:`query` call, so there's nothing to stash.
+        Method is kept so :meth:`AgentInteraction.step` can dispatch
+        uniformly over both model classes.
+        """
         return rollout_cache
 
-    def _normalize_messages_for_api(self, api_messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def _normalize_messages_for_api(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Strip locally-added fields the OpenAI API doesn't accept.
+
+        Tolerates ``role=tool`` messages that lack ``tool_call_id``
+        (e.g. error-path messages produced when parsing failed before
+        a specific tool call could be identified) -- they're forwarded
+        without the field; OpenAI will likely reject them but that's
+        a caller-side correctness issue, not something to swallow here.
+        """
         normalized_messages = []
-        for message in api_messages:
+        for message in messages:
             normalized_message = {"role": message["role"]}
             if message.get("content") is not None:
                 normalized_message["content"] = message["content"]
             if message["role"] == "assistant" and message.get("tool_calls"):
                 normalized_message["tool_calls"] = message["tool_calls"]
             if message["role"] == "tool":
-                normalized_message["tool_call_id"] = message["tool_call_id"]
+                tool_call_id = message.get("tool_call_id")
+                if tool_call_id is not None:
+                    normalized_message["tool_call_id"] = tool_call_id
                 if message.get("name") is not None:
                     normalized_message["name"] = message["name"]
             normalized_messages.append(normalized_message)
         return normalized_messages
 
-    # OpenAI ChatCompletion top-level sampling fields. Keys not in this set
-    # are forwarded via ``extra_body`` so vendor extensions (top_k,
-    # repetition_penalty, ...) still reach vLLM/SGLang-style endpoints
-    # without 400-ing real OpenAI for unknown top-level args.
+    # OpenAI ChatCompletion top-level sampling fields.
     _OPENAI_TOP_LEVEL_SAMPLING_FIELDS: frozenset[str] = frozenset(
         {
             "temperature",
@@ -305,9 +316,25 @@ class OpenAICompatibleChatModel:
         messages: list[dict[str, str]],
         rollout_cache: dict[str, Any] | None,
         **kwargs,
-    ) -> list[dict] | dict:
+    ) -> tuple[str, list[dict], dict[str, Any], dict[str, int]]:
+        """Run one chat-completion call.
+
+        Returns ``(text, tool_calls, rollout_cache, generation_info)``:
+
+        - ``text``: assistant ``content`` from the response (may be ``""``
+          when the model only emits tool calls).
+        - ``tool_calls``: structured list (OpenAI shape:
+          ``{"id", "type", "function": {"name", "arguments"}}``) -- one
+          entry per parallel tool call. ``[]`` if the model returned
+          plain text only.
+        - ``rollout_cache``: unchanged except for ``metrics`` timing
+          accumulation. The OpenAI path is stateless across calls;
+          ``messages`` is read directly from the input arg and the
+          caller owns the running history.
+        - ``generation_info``: ``prompt_tokens`` / ``completion_tokens``.
+        """
         sampling_params = kwargs.get("sampling_params", self.sampling_params) or {}
-        api_messages = self._normalize_messages_for_api(rollout_cache["extra_fields"]["api_messages"])
+        api_messages = self._normalize_messages_for_api(messages)
 
         top_level = {k: v for k, v in sampling_params.items() if k in self._OPENAI_TOP_LEVEL_SAMPLING_FIELDS}
         extra_body = {k: v for k, v in sampling_params.items() if k not in self._OPENAI_TOP_LEVEL_SAMPLING_FIELDS}
@@ -325,41 +352,24 @@ class OpenAICompatibleChatModel:
         response_content = response_message.content or ""
         response_tool_calls = list(response_message.tool_calls or [])
 
-        if response_tool_calls:
-            serialized_tool_calls = []
-            for tool_call in response_tool_calls:
-                serialized_tool_calls.append(
-                    {
-                        "id": tool_call.id,
-                        "type": tool_call.type,
-                        "function": {
-                            "name": tool_call.function.name,
-                            "arguments": tool_call.function.arguments,
-                        },
-                    }
-                )
-            rollout_cache["extra_fields"]["last_tool_calls"] = serialized_tool_calls
-            rollout_cache["extra_fields"]["api_messages"].append(
-                {
-                    "role": "assistant",
-                    "content": response_content,
-                    "tool_calls": serialized_tool_calls,
-                }
-            )
-        else:
-            rollout_cache["extra_fields"]["last_tool_calls"] = []
-            rollout_cache["extra_fields"]["api_messages"].append(
-                {
-                    "role": "assistant",
-                    "content": response_content,
-                }
-            )
+        serialized_tool_calls: list[dict] = [
+            {
+                "id": tool_call.id,
+                "type": tool_call.type,
+                "function": {
+                    "name": tool_call.function.name,
+                    "arguments": tool_call.function.arguments,
+                },
+            }
+            for tool_call in response_tool_calls
+        ]
 
         usage = chat_completion.usage
         completion_tokens = usage.completion_tokens if usage is not None else max(len(response_content.split()), 1)
         prompt_tokens = usage.prompt_tokens if usage is not None else 0
         return (
             response_content,
+            serialized_tool_calls,
             rollout_cache,
             {
                 "prompt_tokens": prompt_tokens,

--- a/uni_agent/interaction/model.py
+++ b/uni_agent/interaction/model.py
@@ -84,18 +84,9 @@ class AgentChatModel:
         rollout_cache: dict[str, Any] | None,
         **kwargs,
     ) -> tuple[str, list[dict], dict[str, Any], dict[str, int]]:
-        """Run one model call.
-
-        Returns ``(text, tool_calls, rollout_cache, generation_info)``:
-
-        - ``text``: decoded assistant text (raw model output -- may
-          contain XML/Hermes-style tool-call markers that downstream
-          parsers will extract).
-        - ``tool_calls``: always ``[]`` on this training path. Verl's
-          rollout server returns token ids (no structured tool calls),
-          so callers always fall back to parsing ``text`` via the
-          registered tool parser.
-        - ``rollout_cache`` / ``generation_info``: as before.
+        """Run one model call. Returns ``(text, tool_calls, rollout_cache,
+        generation_info)``. ``tool_calls`` is always ``[]`` on the training
+        path -- verl returns token ids, so callers must parse ``text``.
         """
         request_id = rollout_cache["request_id"]
         prompt_ids = rollout_cache["prompt_ids"]
@@ -244,10 +235,8 @@ class OpenAICompatibleChatModel:
         self.tools_schemas = tools_schemas
 
     async def prepare_rollout_cache(self, messages: list[dict[str, str]]) -> dict[str, Any]:
-        """The OpenAI path is stateless across calls except for metrics
-        accumulation -- the conversation history is owned and passed in
-        explicitly by the caller (``AgentInteraction.messages``), so
-        nothing else needs to live in ``rollout_cache``.
+        """OpenAI path is stateless; the caller owns ``messages`` and
+        re-passes it every :meth:`query`. Only metrics live in the cache.
         """
         return {"metrics": {}}
 
@@ -256,25 +245,15 @@ class OpenAICompatibleChatModel:
         new_messages: list[dict[str, Any]],
         rollout_cache: dict[str, Any] | None,
     ):
-        """No-op on the OpenAI path.
-
-        The training counterpart (:class:`AgentChatModel`) uses this to
-        tokenize and accumulate ``prompt_ids``; here the caller owns
-        the message list (`AgentInteraction.messages`) and re-passes it
-        on every :meth:`query` call, so there's nothing to stash.
-        Method is kept so :meth:`AgentInteraction.step` can dispatch
-        uniformly over both model classes.
+        """No-op. Kept so :class:`AgentInteraction` can dispatch uniformly
+        over training (:class:`AgentChatModel`) and inference paths.
         """
         return rollout_cache
 
     def _normalize_messages_for_api(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Strip locally-added fields the OpenAI API doesn't accept.
-
-        Tolerates ``role=tool`` messages that lack ``tool_call_id``
-        (e.g. error-path messages produced when parsing failed before
-        a specific tool call could be identified) -- they're forwarded
-        without the field; OpenAI will likely reject them but that's
-        a caller-side correctness issue, not something to swallow here.
+        Tool messages missing ``tool_call_id`` (e.g. format-error fallbacks)
+        are forwarded as-is.
         """
         normalized_messages = []
         for message in messages:
@@ -317,21 +296,10 @@ class OpenAICompatibleChatModel:
         rollout_cache: dict[str, Any] | None,
         **kwargs,
     ) -> tuple[str, list[dict], dict[str, Any], dict[str, int]]:
-        """Run one chat-completion call.
-
-        Returns ``(text, tool_calls, rollout_cache, generation_info)``:
-
-        - ``text``: assistant ``content`` from the response (may be ``""``
-          when the model only emits tool calls).
-        - ``tool_calls``: structured list (OpenAI shape:
-          ``{"id", "type", "function": {"name", "arguments"}}``) -- one
-          entry per parallel tool call. ``[]`` if the model returned
-          plain text only.
-        - ``rollout_cache``: unchanged except for ``metrics`` timing
-          accumulation. The OpenAI path is stateless across calls;
-          ``messages`` is read directly from the input arg and the
-          caller owns the running history.
-        - ``generation_info``: ``prompt_tokens`` / ``completion_tokens``.
+        """Run one chat-completion call. Returns ``(text, tool_calls,
+        rollout_cache, generation_info)``. ``tool_calls`` is the OpenAI
+        ``{"id", "type", "function": {"name", "arguments"}}`` shape (one
+        entry per parallel call; ``[]`` if the model returned plain text).
         """
         sampling_params = kwargs.get("sampling_params", self.sampling_params) or {}
         api_messages = self._normalize_messages_for_api(messages)

--- a/uni_agent/interaction/tools_manager.py
+++ b/uni_agent/interaction/tools_manager.py
@@ -34,13 +34,9 @@ class ToolsManager:
         self,
         model_output: str,
     ) -> tuple[str, list[OpenAIFunctionToolCall]]:
-        """Parse tool calls from raw text via the registered tool parser.
-
-        Returns ``(content, tool_calls)``. ``tool_calls`` may be **empty**
-        -- callers (e.g. the agent loop) decide what that means (e.g.
-        turn-final assistant message in chat mode, vs. format error in
-        single-shot mode that requires a tool call). Malformed tool calls
-        still raise :class:`FunctionCallFormatError`.
+        """Parse tool calls from raw text. Returns ``(content, tool_calls)``;
+        ``tool_calls`` may be empty (callers decide what that means).
+        Malformed calls raise :class:`FunctionCallFormatError`.
         """
         tools = [OpenAIFunctionToolSchema(**schema) for schema in self.tools_schemas]
         content, tool_calls = self._tool_parser.extract_tool_calls(model_output, tools)
@@ -51,11 +47,9 @@ class ToolsManager:
         content: str,
         tool_calls_data: list[dict],
     ) -> tuple[str, list[OpenAIFunctionToolCall]]:
-        """Parse tool calls from an OpenAI-style structured ``tool_calls`` list.
-
-        Like :meth:`parse_action`, the returned list may be empty
-        (callers decide). Unknown tool names and invalid JSON arguments
-        still raise :class:`FunctionCallFormatError`.
+        """Parse OpenAI-style structured tool calls. May return an empty list
+        (callers decide); unknown names / invalid JSON args raise
+        :class:`FunctionCallFormatError`.
         """
         tool_calls = []
         valid_names = {schema["function"]["name"] for schema in self.tools_schemas}

--- a/uni_agent/interaction/tools_manager.py
+++ b/uni_agent/interaction/tools_manager.py
@@ -34,14 +34,16 @@ class ToolsManager:
         self,
         model_output: str,
     ) -> tuple[str, list[OpenAIFunctionToolCall]]:
+        """Parse tool calls from raw text via the registered tool parser.
+
+        Returns ``(content, tool_calls)``. ``tool_calls`` may be **empty**
+        -- callers (e.g. the agent loop) decide what that means (e.g.
+        turn-final assistant message in chat mode, vs. format error in
+        single-shot mode that requires a tool call). Malformed tool calls
+        still raise :class:`FunctionCallFormatError`.
+        """
         tools = [OpenAIFunctionToolSchema(**schema) for schema in self.tools_schemas]
         content, tool_calls = self._tool_parser.extract_tool_calls(model_output, tools)
-
-        if len(tool_calls) == 0:
-            raise FunctionCallFormatError("No function call found in the response.")
-        elif len(tool_calls) > 1:
-            raise FunctionCallFormatError(f"Number of tool calls {len(tool_calls)} exceeds max_parallel_calls 1.")
-
         return content, tool_calls
 
     async def parse_structured_action(
@@ -49,6 +51,12 @@ class ToolsManager:
         content: str,
         tool_calls_data: list[dict],
     ) -> tuple[str, list[OpenAIFunctionToolCall]]:
+        """Parse tool calls from an OpenAI-style structured ``tool_calls`` list.
+
+        Like :meth:`parse_action`, the returned list may be empty
+        (callers decide). Unknown tool names and invalid JSON arguments
+        still raise :class:`FunctionCallFormatError`.
+        """
         tool_calls = []
         valid_names = {schema["function"]["name"] for schema in self.tools_schemas}
         for tool_call_data in tool_calls_data:
@@ -76,11 +84,6 @@ class ToolsManager:
                     function=function_call,
                 )
             )
-
-        if len(tool_calls) == 0:
-            raise FunctionCallFormatError("No function call found in the response.")
-        if len(tool_calls) > 1:
-            raise FunctionCallFormatError(f"Number of tool calls {len(tool_calls)} exceeds max_parallel_calls 1.")
         return content, tool_calls
 
     def get_tool_bash_command(self, tool_call: OpenAIFunctionToolCall) -> str:

--- a/uni_agent/reward/search.py
+++ b/uni_agent/reward/search.py
@@ -29,7 +29,8 @@ def _extract_answer_from_trajectory(trajectory: list, messages: list[dict]) -> s
     Looks for the last trajectory step with exit_reason == "finished" and tries,
     in order:
     1. JSON-parse the <tool_call> block from the model response (most reliable).
-    2. Fallback: use the observation (finish script echoes the answer to stdout).
+    2. Fallback: use the finish/submit tool observation
+       (the finish script echoes the answer to stdout).
     """
     for step in reversed(trajectory):
         if getattr(step, "exit_reason", None) != "finished":
@@ -56,11 +57,13 @@ def _extract_answer_from_trajectory(trajectory: list, messages: list[dict]) -> s
                 pass
 
         # Fallback: the finish script prints the answer to stdout
-        obs = getattr(step, "observation", "")
-        if obs:
-            cleaned = obs.strip()
-            if cleaned:
-                return cleaned
+        tool_results = getattr(step, "tool_results", []) or []
+        for tr in reversed(tool_results):
+            if getattr(tr, "name", "") in ("finish", "submit") and getattr(tr, "status", "") == "ok":
+                obs = (getattr(tr, "observation", "") or "").strip()
+                if obs:
+                    return obs
+                break
 
     return None
 


### PR DESCRIPTION
# Support multi tool-call per turn + per-tool result tracking

## Summary
- Allow the model to emit **0..N** tool calls in a single assistant message; the loop no longer hard-rejects multi or empty.
  - N calls → executed sequentially in the shared bash session, each producing its own `role="tool"` reply (OpenAI N:N invariant preserved).
  - 0 calls → behavior is gated on `AgentInteraction(chat_mode=...)` (see below).
- Split outcomes into **tool-level vs step-level** so multi-tool failures don't lose fidelity:
  - `StepOutput.tool_results: list[ToolResult]` — `status ∈ {ok, timeout, syntax_error, skipped}` per call.
  - `StepOutput.exit_reason` — clean step-level enum (see table).
- Slim down `OpenAICompatibleChatModel`: drops `rollout_cache["extra_fields"]` (`api_messages`, `last_tool_calls`, `backend`). `AgentInteraction.messages` is the single source of truth; `model.query()` returns structured `tool_calls` directly as a 4-tuple.

## `chat_mode` flag (back-compat for training / code-eval)
`AgentInteraction(chat_mode=False)` (default, training / code-eval):
an assistant message with no tool call is a **format_error**, loop continues, terminates via `finish`/`submit` or `max_step_limit` — matches pre-PR behavior.

`AgentInteraction(chat_mode=True)` (`app/lark_chat`):
no tool call = **turn_done**, `done=True`; outer loop waits for next user message.

## `exit_reason` enum
| done | values |
|---|---|
| True  | `finished`, `turn_done`, `token_limit`, `terminal_dead`, `timeout_budget_exhausted` |
| False | `completed`, `completed_with_tool_errors`, `format_error` |
| outer loop | `max_step_limit`, `unknown_error` |

Renamed: `terminal_not_alive` → `terminal_dead`. Demoted to `tool_results[i].status` (no longer at step level): `timeout_error`, `syntax_error`. Only `"finished"` is special-cased downstream (`should_mask_traj`, `search` reward) — unchanged.

## Other behavior tweaks worth a glance
1. **Timeout budget is now per-tool** (each `ActionTimeoutError` decrements once). When it drops below 0 mid-step, remaining tools are synthesized as `status="skipped"` and the step ends `done=True, exit_reason="timeout_budget_exhausted"`. Same `skipped` synthesis on `TerminalNotAliveError` to keep the OpenAI N:N invariant.
2. **`StepOutput` schema** dropped top-level `action` / `observation` / `execution_time` (now per-tool inside `tool_results`). Saved `interaction_result.json` shape changes accordingly. In-tree consumers updated: `uni_agent/reward/search.py`, `examples/lark/demo.py`, `examples/search_arxiv/demo.py`.

## Training-path compat
- `AgentChatModel.query()` returns `tool_calls=[]` (verl returns token ids, not structured calls) → text-parsing path unchanged.
- Tool messages now always carry `tool_call_id` / `name`. Verified on Qwen2.5-7B, Qwen3-8B, Qwen3-30B-A3B that `apply_chat_template` produces byte-identical tokens with vs without these fields.
- `tool_results` and the new `exit_reason` strings are dump-only metadata; `prompt_ids` / `response_mask` pipeline is untouched.

## Test plan
- [x] `chat_mode=False` + zero tool call → `(done=False, exit_reason="format_error")` (verified with stub).
- [x] `chat_mode=True` + zero tool call → `(done=True, exit_reason="turn_done")` (verified with stub).
- [ ] `examples/search_arxiv/demo.py` completes with `exit_reason="finished"`; reward extracts the answer.
- [ ] `examples/lark/demo.py` runs end-to-end on `local_attach`.
- [ ] Handcrafted prompt eliciting 2 parallel tool calls executes both with matching `tool_call_id`s in the resulting `role="tool"` messages.
- [ ] One Qwen3 training rollout — `prompt_ids` length + decoded transcript visually identical to a pre-PR run.