### PR TITLE
[BREAKING][interaction,examples] feat: multi-tool steps, chat mode, and lark_chat app

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""User-facing applications built on top of the uni-agent framework."""

--- a/app/lark_chat/README.md
+++ b/app/lark_chat/README.md
@@ -1,0 +1,157 @@
+# `lark_chat` — long-running Lark chat agent
+
+A long-running process that listens for IM messages on Lark / Feishu,
+dispatches each user message to a multi-step agent loop running on a
+shared sandbox env, and replies back through `lark-cli`. Each chat is a
+real **ongoing conversation**: history is persisted per `chat_id` and
+trimmed on a sliding window so you can talk to the same bot across many
+turns and across process restarts.
+
+Sits on top of the same `AgentInteraction` loop as `examples/lark/demo.py`,
+but evolves it from "one user request → one run → exit" to
+"listener → many turns → many runs". The framework loop itself was
+extended to support **multiple tool calls per assistant response** and
+to recognize **`finish` (preferred) or a tool-call-less assistant
+response (fallback)** as end-of-turn — see
+`uni_agent/interaction/interaction.py`.
+
+## Architecture
+
+```
+                ┌─────────────────────────────────────────────────────────┐
+                │  host process: app.lark_chat.main                       │
+                │                                                         │
+   Lark IM ───► │  LarkEventListener                                      │
+                │      └─ docker exec -i <container> lark-cli event       │
+                │            consume im.message.receive_v1                │
+                │      │   NDJSON over stdout                             │
+                │      ▼                                                  │
+                │  async for event:                                       │
+                │     handle_one_message(event)                           │
+                │       1. ConversationStore.load(chat_id)                │
+                │       2. trim_history(...) + append user msg            │
+                │       3. AgentInteraction.run()  ──────────────┐        │
+                │       4. ConversationStore.save(messages)      │        │
+                │                                                ▼        │
+                │  shared AgentEnv (local_attach)                         │
+                │      └─ swerex.server in <container>                    │
+                │            execute_bash / lark-cli / str_replace_editor │
+                │            / finish                                     │
+                └─────────────────────────────────────────────────────────┘
+                                          ▲
+                                          │ HTTPS
+                                          ▼
+                                   Lark Open API
+```
+
+- **One container, one bash session, one model client** for the lifetime of the process.
+- Inbound messages are handled **serially** (the bash session is single-threaded — running two agent turns in parallel through it is pointless). If the user sends two messages back-to-back, the second is queued.
+- **Single lark identity, single auth.** Both the listener AND the agent's replies route through the container's `lark-cli` (via `docker exec -i <container>`). You auth `lark-cli` **once**, inside the container — no host/container identity drift.
+- Per-chat history is one JSON file per `chat_id` under `~/.uni-agent/app/lark_chat/conversations/`. We persist the **OpenAI-shaped** history (`tool_calls` on assistant messages, `tool_call_id` on tool responses) so re-feeding it preserves the assistant↔tool linkage.
+- The agent's **long-term notes** live at `/workspace/history/` inside the container, which is bind-mounted to a host directory — so notes survive container / process restarts. The system prompt nudges the model to read this on demand and write *digested* context there (decisions, preferences, pending tasks), not raw transcripts.
+
+## Setup
+
+### 1. An OpenAI-compatible chat-completions endpoint
+
+For example vLLM serving a tool-calling model:
+
+```bash
+vllm serve /path/to/Qwen3.6-35B-A3B \
+  --served-model-name Qwen/Qwen3.6-35B-A3B \
+  --tensor-parallel-size 4 \
+  --enable-auto-tool-choice \
+  --tool-call-parser qwen3_coder \
+  --port 8000
+```
+
+### 2. Lark / Feishu Developer Console
+
+The bot must be subscribed to `im.message.receive_v1` (application-identity event) in the [Lark / Feishu Developer Console](https://open.feishu.cn), with event delivery mode set to **WebSocket / long-link** (so `lark-cli event consume` can attach as a client).
+
+### 3. Sandbox container (one-time bootstrap)
+
+```bash
+docker rm -f lark-chat-sandbox 2>/dev/null
+docker run -d --name lark-chat-sandbox -p 18000:18000 \
+  -v ~/.uni-agent/app/lark_chat/workspace:/workspace \
+  nikolaik/python-nodejs:python3.12-nodejs22-bookworm tail -f /dev/null
+
+docker exec -it lark-chat-sandbox bash -lc '
+  set -e
+  npm install -g @larksuite/cli
+  pip install swe-rex
+  lark-cli config init --new
+  lark-cli auth login        # complete OAuth inside the container
+  lark-cli auth status'
+
+docker exec -d lark-chat-sandbox bash -lc '
+  python3 -m swerex.server --host 0.0.0.0 --port 18000 --auth-token CHANGEME'
+```
+
+On the host you only need Python + `docker`. `lark-cli` lives in the container.
+
+### 4. (Optional) Skills
+
+Drop SKILL.md packs under `~/.uni-agent/skills/` (override with `LARK_SKILLS_DIR=...`). The skill manifest is injected into the system prompt on the first turn of each chat, so the model knows it can `cat <path>/SKILL.md` for things like `lark-im`, `lark-calendar`, `lark-doc`, etc.
+
+### 5. Run
+
+```bash
+LOCAL_ATTACH_CONTAINER=lark-chat-sandbox \
+LOCAL_ATTACH_PORT=18000 \
+LOCAL_ATTACH_AUTH_TOKEN=CHANGEME \
+BASE_URL=http://localhost:8000/v1 \
+MODEL_NAME=Qwen/Qwen3.6-35B-A3B \
+python -m app.lark_chat.main
+```
+
+Send a message to the bot in Lark; the trace prints per-turn step / tool / status info. Ctrl+C to shut down (the listener stops cleanly via stdin EOF, the env is closed).
+
+## Configuration (env vars)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `LOCAL_ATTACH_CONTAINER` | `lark-chat-sandbox` | Container name the listener `docker exec`s into and `swerex.server` runs in |
+| `LOCAL_ATTACH_HOST` | `http://127.0.0.1` | swerex.server host |
+| `LOCAL_ATTACH_PORT` | `18000` | swerex.server port |
+| `LOCAL_ATTACH_AUTH_TOKEN` | *(required)* | swerex.server `--auth-token` |
+| `BASE_URL` | `http://localhost:8000/v1` | OpenAI-compatible endpoint |
+| `API_KEY` | `EMPTY` | API key for the endpoint |
+| `MODEL_NAME` | `Qwen/Qwen3.6-35B-A3B` | Model name sent to endpoint |
+| `MODEL_TEMPERATURE` / `MODEL_TOP_P` / `MODEL_TOP_K` / `MODEL_PRESENCE_PENALTY` / `MODEL_REPETITION_PENALTY` | sensible defaults | Sampling overrides |
+| `LARK_SKILLS_DIR` | `~/.uni-agent/skills` | Skill packs directory |
+| `LARK_CHAT_HISTORY_DIR` | `~/.uni-agent/app/lark_chat` | Persisted conversations root |
+| `LARK_CHAT_ACTION_TIMEOUT` | `60` | Seconds per single tool call |
+| `LARK_CHAT_MAX_STEPS_PER_TURN` | `20` | Agent steps before forcing turn end (hard cap; `finish` should land it well under this) |
+| `LARK_CHAT_MAX_HISTORY_TURNS` | `30` | Trim history to last N user-anchored turns |
+
+## What happens per user message
+
+1. **Filter at the source.** `lark-cli event consume` is launched with a `--jq` filter that drops events from the bot itself (`sender_id == <bot_open_id>`) and any non-text/post message types, so they never reach the Python loop.
+2. **Load + trim history.** `ConversationStore.load(chat_id)` returns the persisted message list; `trim_history` keeps the system message + the last `LARK_CHAT_MAX_HISTORY_TURNS` user-anchored chunks intact (never strips a `role=tool` away from its parent `role=assistant`).
+3. **Append the new user message.** Includes a structured Lark metadata block (`chat_id`, `message_id`, `sender_open_id`, `chat_type`, `message_type`, `create_time`) above the content so the agent can call `lark-cli im +messages-reply --message-id <om_...>` directly without parsing IDs out of prose.
+4. **Run one turn.** `AgentInteraction.run()` loops: model call → parse 0..N tool calls → execute each sequentially → repeat. The turn ends when the model calls `finish` (preferred end-of-turn signal) or returns plain text with no tool call (fallback). `max_steps_per_turn` is a hard safety cap.
+5. **Persist.** `result["messages"]` (the OpenAI-shape conversation) is saved atomically back to the chat's JSON file.
+
+## Long-term memory contract
+
+The container's `/workspace` is bind-mounted to `~/.uni-agent/app/lark_chat/workspace` on the host (per the bootstrap above). The agent's notes at `/workspace/history/` therefore survive container restarts.
+
+The system prompt instructs the model to:
+
+- `ls /workspace/history/` at the start of a turn IF the request hints at long-term context (skip for greetings / one-shot questions).
+- Write **digested** context (decisions, preferences, pending work) — not chat transcripts — using `str_replace_editor` or `execute_bash`.
+- Re-read relevant files before deciding how to act.
+
+## Files
+
+```
+app/lark_chat/
+├── __init__.py
+├── README.md              ← this file
+├── main.py                ← entrypoint: bootstrap + listener loop
+├── prompts.py             ← SYSTEM_PROMPT + format_user_message
+├── conversation.py        ← ConversationStore (JSON per chat_id)
+└── listener.py            ← LarkEventListener + fetch_bot_open_id
+```

--- a/app/lark_chat/__init__.py
+++ b/app/lark_chat/__init__.py
@@ -1,0 +1,20 @@
+"""Long-running Lark chat agent.
+
+Listens for inbound IM messages on Lark, dispatches each message to a
+multi-step ``AgentInteraction`` loop running on a shared sandbox env,
+and replies back to the user via ``lark-cli``. Conversation history is
+persisted per-chat so the agent can hold a real, ongoing conversation
+across many turns and process restarts.
+
+See ``app/lark_chat/README.md`` for setup and run instructions.
+"""
+
+from .conversation import ConversationStore
+from .listener import LarkEventListener, LarkEventListenerError, fetch_bot_open_id
+
+__all__ = [
+    "ConversationStore",
+    "LarkEventListener",
+    "LarkEventListenerError",
+    "fetch_bot_open_id",
+]

--- a/app/lark_chat/conversation.py
+++ b/app/lark_chat/conversation.py
@@ -1,0 +1,56 @@
+"""JSON-backed per-chat conversation store.
+
+One JSON file per ``chat_id`` at ``<base_dir>/<sanitized_chat_id>.json``
+holding the OpenAI-shaped message history (with ``tool_calls`` on
+assistant entries and matching ``tool_call_id`` on tool responses).
+Writes are atomic (write tmp + ``os.replace``) so an interrupted
+process never leaves a half-written file.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_SAFE_CHARS = re.compile(r"[^a-zA-Z0-9_\-]")
+
+
+def _safe_filename(chat_id: str) -> str:
+    """Sanitize a Lark chat_id (``oc_<hex>``) into a filesystem-safe name."""
+    name = _SAFE_CHARS.sub("_", chat_id).strip("_")
+    return name or "default"
+
+
+class ConversationStore:
+    """Per-``chat_id`` persistent message store on local disk."""
+
+    def __init__(self, base_dir: Path):
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def path(self, chat_id: str) -> Path:
+        return self.base_dir / f"{_safe_filename(chat_id)}.json"
+
+    def load(self, chat_id: str) -> list[dict]:
+        """Return the persisted message list, or ``[]`` if none / unreadable."""
+        p = self.path(chat_id)
+        if not p.exists():
+            return []
+        try:
+            data = json.loads(p.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return []
+        if not isinstance(data, list):
+            return []
+        return data
+
+    def save(self, chat_id: str, messages: list[dict]) -> None:
+        """Atomically replace the conversation file with ``messages``."""
+        p = self.path(chat_id)
+        tmp = p.with_suffix(p.suffix + ".tmp")
+        tmp.write_text(
+            json.dumps(messages, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        tmp.replace(p)

--- a/app/lark_chat/listener.py
+++ b/app/lark_chat/listener.py
@@ -20,8 +20,7 @@ from __future__ import annotations
 import asyncio
 import json
 import sys
-from collections.abc import AsyncIterator
-from collections.abc import Sequence
+from collections.abc import AsyncIterator, Sequence
 
 _READY_MARKER = b"[event] ready"
 
@@ -91,8 +90,7 @@ class LarkEventListener:
             if not line:
                 rc = await self.proc.wait()
                 raise LarkEventListenerError(
-                    f"`lark-cli event consume {self.event_key}` exited "
-                    f"before becoming ready (rc={rc})"
+                    f"`lark-cli event consume {self.event_key}` exited before becoming ready (rc={rc})"
                 )
             _write_stderr(line)
             if _READY_MARKER in line:
@@ -188,9 +186,7 @@ async def fetch_bot_open_id(command_prefix: Sequence[str] | None = None) -> str:
         data = json.loads(out)
     except json.JSONDecodeError as e:
         preview = out[:300].decode("utf-8", errors="replace")
-        raise LarkEventListenerError(
-            f"could not parse bot info JSON: {e}\noutput preview: {preview!r}"
-        ) from e
+        raise LarkEventListenerError(f"could not parse bot info JSON: {e}\noutput preview: {preview!r}") from e
     for path in (("bot", "open_id"), ("data", "bot", "open_id"), ("open_id",)):
         cur = data
         ok = True
@@ -202,6 +198,4 @@ async def fetch_bot_open_id(command_prefix: Sequence[str] | None = None) -> str:
                 break
         if ok and isinstance(cur, str) and cur.startswith("ou_"):
             return cur
-    raise LarkEventListenerError(
-        f"could not find bot.open_id in `lark-cli` response: {data!r}"
-    )
+    raise LarkEventListenerError(f"could not find bot.open_id in `lark-cli` response: {data!r}")

--- a/app/lark_chat/listener.py
+++ b/app/lark_chat/listener.py
@@ -1,0 +1,207 @@
+"""Async wrapper around ``lark-cli event consume <EventKey>``.
+
+Spawns the consumer as a subprocess and exposes it as an async iterator
+of decoded JSON events. Honours the lark-event subprocess contract:
+
+- Wait for ``[event] ready event_key=<key>`` on stderr in ``start()``
+  before iteration begins.
+- Keep stdin open via an unclosed pipe; ``lark-cli`` treats stdin EOF
+  as a graceful shutdown trigger.
+- Stop via stdin close → SIGTERM → SIGKILL ladder so the server-side
+  subscription unsubscribes cleanly.
+
+``command_prefix`` (e.g. ``["docker", "exec", "-i", "<container>"]``)
+lets us call a containerised ``lark-cli`` so the lark identity matches
+the one the agent uses to reply.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from collections.abc import AsyncIterator
+from collections.abc import Sequence
+
+_READY_MARKER = b"[event] ready"
+
+
+class LarkEventListenerError(RuntimeError):
+    """Raised when the underlying ``lark-cli event consume`` subprocess
+    fails to start, never becomes ready, or exits abnormally.
+    """
+
+
+class LarkEventListener:
+    """Async iterator over decoded events from a single ``EventKey``."""
+
+    def __init__(
+        self,
+        event_key: str,
+        *,
+        as_identity: str = "bot",
+        jq: str | None = None,
+        command_prefix: Sequence[str] | None = None,
+    ):
+        self.event_key = event_key
+        self.as_identity = as_identity
+        self.jq = jq
+        self.command_prefix: list[str] = list(command_prefix) if command_prefix else []
+        self.proc: asyncio.subprocess.Process | None = None
+        self._stderr_pump_task: asyncio.Task | None = None
+
+    async def start(self, *, ready_timeout: float = 30.0) -> None:
+        """Spawn ``lark-cli event consume`` and block until ready."""
+        argv = [
+            *self.command_prefix,
+            "lark-cli",
+            "event",
+            "consume",
+            self.event_key,
+            "--as",
+            self.as_identity,
+        ]
+        if self.jq:
+            argv.extend(["--jq", self.jq])
+        self.proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        ready_wait = asyncio.create_task(self._await_ready())
+        try:
+            await asyncio.wait_for(ready_wait, timeout=ready_timeout)
+        except asyncio.TimeoutError:
+            await self.stop()
+            raise LarkEventListenerError(
+                f"`lark-cli event consume {self.event_key}` did not emit "
+                f"'[event] ready' within {ready_timeout}s. Check "
+                f"`lark-cli auth status --as {self.as_identity}` and that "
+                f"the bot is subscribed to {self.event_key}."
+            ) from None
+
+        self._stderr_pump_task = asyncio.create_task(self._pump_stderr())
+
+    async def _await_ready(self) -> None:
+        assert self.proc is not None and self.proc.stderr is not None
+        while True:
+            line = await self.proc.stderr.readline()
+            if not line:
+                rc = await self.proc.wait()
+                raise LarkEventListenerError(
+                    f"`lark-cli event consume {self.event_key}` exited "
+                    f"before becoming ready (rc={rc})"
+                )
+            _write_stderr(line)
+            if _READY_MARKER in line:
+                return
+
+    async def _pump_stderr(self) -> None:
+        assert self.proc is not None and self.proc.stderr is not None
+        while True:
+            line = await self.proc.stderr.readline()
+            if not line:
+                return
+            _write_stderr(line)
+
+    def __aiter__(self) -> AsyncIterator[dict]:
+        return self._iter_events()
+
+    async def _iter_events(self) -> AsyncIterator[dict]:
+        assert self.proc is not None and self.proc.stdout is not None
+        while True:
+            line = await self.proc.stdout.readline()
+            if not line:
+                return
+            text = line.decode("utf-8", errors="replace").strip()
+            if not text:
+                continue
+            try:
+                event = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(event, dict):
+                yield event
+
+    async def stop(self) -> None:
+        """Shut the consumer down cleanly (stdin close → SIGTERM → SIGKILL)."""
+        if self.proc is None:
+            return
+        if self.proc.returncode is None:
+            if self.proc.stdin is not None and not self.proc.stdin.is_closing():
+                try:
+                    self.proc.stdin.close()
+                except Exception:
+                    pass
+            try:
+                await asyncio.wait_for(self.proc.wait(), timeout=5)
+            except asyncio.TimeoutError:
+                self.proc.terminate()
+                try:
+                    await asyncio.wait_for(self.proc.wait(), timeout=5)
+                except asyncio.TimeoutError:
+                    self.proc.kill()
+                    await self.proc.wait()
+        if self._stderr_pump_task is not None:
+            self._stderr_pump_task.cancel()
+            try:
+                await self._stderr_pump_task
+            except asyncio.CancelledError:
+                pass
+        self.proc = None
+
+
+def _write_stderr(b: bytes) -> None:
+    try:
+        sys.stderr.write(b.decode("utf-8", errors="replace"))
+        sys.stderr.flush()
+    except Exception:
+        pass
+
+
+async def fetch_bot_open_id(command_prefix: Sequence[str] | None = None) -> str:
+    """Resolve the bot's own ``open_id`` via the Lark Open API.
+
+    Used to build the jq filter that drops the bot's own reply messages
+    (the platform may re-deliver them as ``im.message.receive_v1`` events)
+    before they reach the agent loop. ``command_prefix`` mirrors
+    :class:`LarkEventListener` so we resolve the id with the same
+    lark-cli identity that subscribes events.
+    """
+    prefix = list(command_prefix) if command_prefix else []
+    argv = [*prefix, "lark-cli", "api", "GET", "/open-apis/bot/v3/info", "--as", "bot"]
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    out, err = await proc.communicate()
+    if proc.returncode != 0:
+        raise LarkEventListenerError(
+            f"`lark-cli api GET /open-apis/bot/v3/info --as bot` failed "
+            f"(rc={proc.returncode}):\n"
+            f"{err.decode('utf-8', errors='replace')}"
+        )
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError as e:
+        preview = out[:300].decode("utf-8", errors="replace")
+        raise LarkEventListenerError(
+            f"could not parse bot info JSON: {e}\noutput preview: {preview!r}"
+        ) from e
+    for path in (("bot", "open_id"), ("data", "bot", "open_id"), ("open_id",)):
+        cur = data
+        ok = True
+        for key in path:
+            if isinstance(cur, dict) and key in cur:
+                cur = cur[key]
+            else:
+                ok = False
+                break
+        if ok and isinstance(cur, str) and cur.startswith("ou_"):
+            return cur
+    raise LarkEventListenerError(
+        f"could not find bot.open_id in `lark-cli` response: {data!r}"
+    )

--- a/app/lark_chat/main.py
+++ b/app/lark_chat/main.py
@@ -23,6 +23,9 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
+from app.lark_chat import prompts  # noqa: E402
+from app.lark_chat.conversation import ConversationStore  # noqa: E402
+from app.lark_chat.listener import LarkEventListener, fetch_bot_open_id  # noqa: E402
 from uni_agent.interaction import (  # noqa: E402
     AgentEnv,
     AgentEnvConfig,
@@ -33,10 +36,6 @@ from uni_agent.interaction import (  # noqa: E402
 )
 from uni_agent.skills import SkillsManager, SkillsManagerConfig  # noqa: E402
 from uni_agent.tools import ToolConfig  # noqa: E402
-
-from app.lark_chat import prompts  # noqa: E402
-from app.lark_chat.conversation import ConversationStore  # noqa: E402
-from app.lark_chat.listener import LarkEventListener, fetch_bot_open_id  # noqa: E402
 
 
 @dataclass
@@ -66,7 +65,7 @@ class Settings:
     max_history_turns: int = 30
 
     @classmethod
-    def from_env(cls) -> "Settings":
+    def from_env(cls) -> Settings:
         auth_token = os.environ.get("LOCAL_ATTACH_AUTH_TOKEN")
         if not auth_token:
             raise RuntimeError(
@@ -218,9 +217,7 @@ async def handle_one_message(
         # run()'s synthetic terminator (max_step_limit / unknown_error)
         # has no matching assistant message -- skip the iterator advance.
         is_terminator = (
-            step.exit_reason in ("max_step_limit", "unknown_error")
-            and not step.tool_results
-            and not step.response
+            step.exit_reason in ("max_step_limit", "unknown_error") and not step.tool_results and not step.response
         )
         if is_terminator:
             print(f"   [step {step.step_idx}] exit={step.exit_reason} (loop terminator)")
@@ -240,16 +237,11 @@ async def handle_one_message(
         else:
             preview = (step.response or "").strip().splitlines()
             preview_str = preview[0][:120] if preview else "(empty)"
-            print(
-                f"   [step {step.step_idx}] no tool_call, exit={step.exit_reason or '?'} "
-                f"→ {preview_str}"
-            )
+            print(f"   [step {step.step_idx}] no tool_call, exit={step.exit_reason or '?'} → {preview_str}")
 
     last_step = trajectory[-1] if trajectory else None
     if last_step is not None:
-        print(
-            f"   ✓ turn done in {len(trajectory)} step(s); exit={last_step.exit_reason}"
-        )
+        print(f"   ✓ turn done in {len(trajectory)} step(s); exit={last_step.exit_reason}")
 
 
 async def main() -> None:
@@ -312,18 +304,13 @@ async def main() -> None:
     listener = LarkEventListener(
         event_key="im.message.receive_v1",
         as_identity="bot",
-        jq=(
-            f'select(.sender_id != "{bot_open_id}") | '
-            'select(.message_type == "text" or .message_type == "post")'
-        ),
+        jq=(f'select(.sender_id != "{bot_open_id}") | select(.message_type == "text" or .message_type == "post")'),
         command_prefix=lark_cli_prefix,
     )
     await listener.start()
     print("  listener ready")
 
-    print(
-        "\n[6/6] Entering chat loop. Send a Lark message to the bot. Ctrl+C to stop.\n"
-    )
+    print("\n[6/6] Entering chat loop. Send a Lark message to the bot. Ctrl+C to stop.\n")
 
     try:
         async for event in listener:

--- a/app/lark_chat/main.py
+++ b/app/lark_chat/main.py
@@ -1,0 +1,362 @@
+# ruff: noqa: E501
+"""Long-running Lark chat agent — entrypoint.
+
+Bootstraps a single sandbox env + model client, then enters a loop that
+consumes inbound IM events from ``lark-cli event consume
+im.message.receive_v1`` and dispatches each non-self message to a
+multi-step ``AgentInteraction`` run. Conversation history is persisted
+per ``chat_id`` so each chat is a real ongoing conversation across
+turns and process restarts.
+
+See ``app/lark_chat/README.md`` for setup, env vars, and run examples.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import traceback
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from uni_agent.interaction import (  # noqa: E402
+    AgentEnv,
+    AgentEnvConfig,
+    AgentInteraction,
+    OpenAICompatibleChatModel,
+    ToolsManager,
+    ToolsManagerConfig,
+)
+from uni_agent.skills import SkillsManager, SkillsManagerConfig  # noqa: E402
+from uni_agent.tools import ToolConfig  # noqa: E402
+
+from app.lark_chat import prompts  # noqa: E402
+from app.lark_chat.conversation import ConversationStore  # noqa: E402
+from app.lark_chat.listener import LarkEventListener, fetch_bot_open_id  # noqa: E402
+
+
+@dataclass
+class Settings:
+    """Runtime config sourced from environment variables.
+
+    Deployment is always ``local_attach`` -- the agent's bash session +
+    its ``lark-cli`` both live inside a user-managed Docker container,
+    so identity stays consistent between event subscription and reply.
+    """
+
+    container: str
+    swerex_host: str
+    swerex_port: int
+    swerex_auth_token: str
+
+    model_base_url: str
+    model_api_key: str
+    model_name: str
+    sampling_params: dict
+
+    skills_dir: Path
+    history_dir: Path
+
+    action_timeout: int = 60
+    max_steps_per_turn: int = 20
+    max_history_turns: int = 30
+
+    @classmethod
+    def from_env(cls) -> "Settings":
+        auth_token = os.environ.get("LOCAL_ATTACH_AUTH_TOKEN")
+        if not auth_token:
+            raise RuntimeError(
+                "LOCAL_ATTACH_AUTH_TOKEN is required (matches the --auth-token "
+                "you started swerex.server with inside the container)."
+            )
+        return cls(
+            container=os.getenv("LOCAL_ATTACH_CONTAINER", "lark-chat-sandbox"),
+            swerex_host=os.getenv("LOCAL_ATTACH_HOST", "http://127.0.0.1"),
+            swerex_port=int(os.getenv("LOCAL_ATTACH_PORT", "18000")),
+            swerex_auth_token=auth_token,
+            model_base_url=os.getenv("BASE_URL", "http://localhost:8000/v1"),
+            model_api_key=os.getenv("API_KEY", "EMPTY"),
+            model_name=os.getenv("MODEL_NAME", "Qwen/Qwen3.6-35B-A3B"),
+            sampling_params={
+                "temperature": float(os.getenv("MODEL_TEMPERATURE", "1.0")),
+                "top_p": float(os.getenv("MODEL_TOP_P", "0.95")),
+                "presence_penalty": float(os.getenv("MODEL_PRESENCE_PENALTY", "1.5")),
+                "top_k": int(os.getenv("MODEL_TOP_K", "20")),
+                "repetition_penalty": float(os.getenv("MODEL_REPETITION_PENALTY", "1.0")),
+            },
+            skills_dir=Path(os.getenv("LARK_SKILLS_DIR", str(Path.home() / ".uni-agent" / "skills"))),
+            history_dir=Path(
+                os.getenv(
+                    "LARK_CHAT_HISTORY_DIR",
+                    str(Path.home() / ".uni-agent" / "app" / "lark_chat"),
+                )
+            ),
+            action_timeout=int(os.getenv("LARK_CHAT_ACTION_TIMEOUT", "60")),
+            max_steps_per_turn=int(os.getenv("LARK_CHAT_MAX_STEPS_PER_TURN", "20")),
+            max_history_turns=int(os.getenv("LARK_CHAT_MAX_HISTORY_TURNS", "30")),
+        )
+
+    def lark_cli_prefix(self) -> list[str]:
+        """argv prefix routing host-side ``lark-cli`` calls (listener +
+        bot open_id lookup) into the same container the agent uses, so
+        every lark-cli call shares one identity / one auth.
+        """
+        return ["docker", "exec", "-i", self.container]
+
+    def build_env_config(self) -> AgentEnvConfig:
+        return AgentEnvConfig(
+            deployment={
+                "type": "local_attach",
+                "host": self.swerex_host,
+                "port": self.swerex_port,
+                "auth_token": self.swerex_auth_token,
+                "timeout": 300.0,
+                "startup_timeout": 30.0,
+            },
+            env_variables={"NO_COLOR": "1", "TERM": "dumb"},
+            post_setup_cmd="cd /workspace",
+        )
+
+
+def trim_history(messages: list[dict], max_user_turns: int) -> list[dict]:
+    """Keep the system message + the most-recent ``max_user_turns``
+    user-anchored chunks. Trimming respects chunk boundaries so a
+    ``role=tool`` is never separated from its parent ``role=assistant``
+    (the OpenAI API rejects that with a 400 on ``tool_call_id`` linkage).
+    """
+    user_idxs = [i for i, m in enumerate(messages) if m.get("role") == "user"]
+    if len(user_idxs) <= max_user_turns:
+        return messages
+    cutoff = user_idxs[-max_user_turns]
+    head = [m for m in messages[:cutoff] if m.get("role") == "system"]
+    return head + messages[cutoff:]
+
+
+async def handle_one_message(
+    event: dict,
+    *,
+    env: AgentEnv,
+    model: OpenAICompatibleChatModel,
+    tools_manager: ToolsManager,
+    skills_manager: SkillsManager,
+    store: ConversationStore,
+    settings: Settings,
+) -> None:
+    chat_id = event.get("chat_id")
+    message_id = event.get("message_id")
+    sender_id = event.get("sender_id")
+    if not (chat_id and message_id and sender_id):
+        print(f"⚠️  skipping malformed event (missing chat_id/message_id/sender_id): {event!r}")
+        return
+
+    chat_type = event.get("chat_type", "?")
+    message_type = event.get("message_type", "?")
+    content = event.get("content", "")
+    create_time = event.get("create_time")
+
+    print(f"\n{'━' * 70}")
+    print(f"📨 [{chat_id}] msg={message_id} from={sender_id} {chat_type}/{message_type}")
+    preview = content.strip().splitlines()[0] if content.strip() else "(empty)"
+    print(f"   {preview[:120]}")
+
+    persisted = store.load(chat_id)
+    first_turn = not persisted
+
+    if first_turn:
+        messages: list[dict] = [{"role": "system", "content": prompts.SYSTEM_PROMPT}]
+    else:
+        messages = trim_history(persisted, max_user_turns=settings.max_history_turns)
+
+    messages.append(
+        {
+            "role": "user",
+            "content": prompts.format_user_message(
+                chat_id=chat_id,
+                message_id=message_id,
+                sender_id=sender_id,
+                chat_type=chat_type,
+                message_type=message_type,
+                content=content,
+                create_time=create_time,
+            ),
+        }
+    )
+
+    run_id = str(uuid.uuid4())
+    interaction = AgentInteraction(
+        run_id=run_id,
+        env=env,
+        model=model,
+        tools_manager=tools_manager,
+        messages=messages,
+        skills_manager=skills_manager if first_turn else None,
+        action_timeout=settings.action_timeout,
+        max_turns=settings.max_steps_per_turn,
+        chat_mode=True,
+    )
+    if first_turn:
+        interaction.inject_skills_manifest()
+
+    pre_run_len = len(messages)
+    try:
+        result = await interaction.run()
+    except Exception:
+        # interaction.messages is mutated in place; persist what we have
+        store.save(chat_id, interaction.messages)
+        raise
+
+    store.save(chat_id, result["messages"])
+
+    trajectory = result["trajectory"]
+    new_asst_msgs = [m for m in result["messages"][pre_run_len:] if m.get("role") == "assistant"]
+    asst_iter = iter(new_asst_msgs)
+    for step in trajectory:
+        # run()'s synthetic terminator (max_step_limit / unknown_error)
+        # has no matching assistant message -- skip the iterator advance.
+        is_terminator = (
+            step.exit_reason in ("max_step_limit", "unknown_error")
+            and not step.tool_results
+            and not step.response
+        )
+        if is_terminator:
+            print(f"   [step {step.step_idx}] exit={step.exit_reason} (loop terminator)")
+            continue
+
+        asst = next(asst_iter, None)
+        attempted = asst.get("tool_calls", []) if asst else []
+        # Anything in `attempted` missing from executed_status was
+        # rejected by parse_structured_action (unknown name / bad args).
+        executed_status = {tr.tool_call_id: tr.status for tr in step.tool_results}
+
+        if attempted:
+            for tc in attempted:
+                name = tc["function"]["name"]
+                status = executed_status.get(tc["id"], "rejected")
+                print(f"   [step {step.step_idx}] tool={name}, status={status}")
+        else:
+            preview = (step.response or "").strip().splitlines()
+            preview_str = preview[0][:120] if preview else "(empty)"
+            print(
+                f"   [step {step.step_idx}] no tool_call, exit={step.exit_reason or '?'} "
+                f"→ {preview_str}"
+            )
+
+    last_step = trajectory[-1] if trajectory else None
+    if last_step is not None:
+        print(
+            f"   ✓ turn done in {len(trajectory)} step(s); exit={last_step.exit_reason}"
+        )
+
+
+async def main() -> None:
+    settings = Settings.from_env()
+
+    print("=" * 80)
+    print("Lark chat agent (multi-turn, multi-tool)")
+    print("=" * 80)
+    print(f"container:     {settings.container}")
+    print(f"swerex:        {settings.swerex_host}:{settings.swerex_port}")
+    print(f"model:         {settings.model_name} @ {settings.model_base_url}")
+    print(f"skills dir:    {settings.skills_dir} (exists={settings.skills_dir.is_dir()})")
+    print(f"history dir:   {settings.history_dir}")
+
+    lark_cli_prefix = settings.lark_cli_prefix()
+    print(f"lark-cli via:  {' '.join(lark_cli_prefix)} lark-cli ...")
+
+    print("\n[1/6] Resolving bot open_id via Lark Open API...")
+    bot_open_id = await fetch_bot_open_id(command_prefix=lark_cli_prefix)
+    print(f"  bot open_id: {bot_open_id}")
+
+    print("\n[2/6] Starting sandbox env...")
+    run_id = str(uuid.uuid4())
+    env = AgentEnv(run_id=run_id, env_config=settings.build_env_config())
+    await env.start()
+    print("  env started")
+
+    print("\n[3/6] Installing tools + skills...")
+    tools_manager = ToolsManager(
+        ToolsManagerConfig(
+            tools=[
+                ToolConfig(name="execute_bash"),
+                ToolConfig(name="lark-cli"),
+                ToolConfig(name="str_replace_editor"),
+                ToolConfig(name="finish"),
+            ]
+        )
+    )
+    await env.install_tools(tools_manager.tools)
+
+    skills_manager = SkillsManager.from_config(SkillsManagerConfig(skills_dir=settings.skills_dir))
+    await env.install_skills(skills_manager)
+    print(f"  {len(skills_manager.skills)} skill(s): {[s.name for s in skills_manager.skills]}")
+
+    await env.communicate("mkdir -p /workspace/history", check="raise")
+
+    print("\n[4/6] Wiring model client...")
+    model = OpenAICompatibleChatModel(
+        base_url=settings.model_base_url,
+        api_key=settings.model_api_key,
+        model_name=settings.model_name,
+        sampling_params=settings.sampling_params,
+    )
+    model.set_tools_schemas(tools_manager.tools_schemas)
+
+    store = ConversationStore(base_dir=settings.history_dir / "conversations")
+    print(f"  conversation store: {store.base_dir}")
+
+    print("\n[5/6] Starting Lark event listener...")
+    listener = LarkEventListener(
+        event_key="im.message.receive_v1",
+        as_identity="bot",
+        jq=(
+            f'select(.sender_id != "{bot_open_id}") | '
+            'select(.message_type == "text" or .message_type == "post")'
+        ),
+        command_prefix=lark_cli_prefix,
+    )
+    await listener.start()
+    print("  listener ready")
+
+    print(
+        "\n[6/6] Entering chat loop. Send a Lark message to the bot. Ctrl+C to stop.\n"
+    )
+
+    try:
+        async for event in listener:
+            try:
+                await handle_one_message(
+                    event,
+                    env=env,
+                    model=model,
+                    tools_manager=tools_manager,
+                    skills_manager=skills_manager,
+                    store=store,
+                    settings=settings,
+                )
+            except Exception:
+                print("✗ message handler failed:")
+                print(traceback.format_exc())
+                continue
+    except KeyboardInterrupt:
+        print("\n[shutdown] keyboard interrupt")
+    finally:
+        print("\n[shutdown] stopping listener and env...")
+        try:
+            await listener.stop()
+        except Exception as e:
+            print(f"  listener stop error: {e}")
+        try:
+            await env.close()
+        except Exception as e:
+            print(f"  env close error: {e}")
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/app/lark_chat/prompts.py
+++ b/app/lark_chat/prompts.py
@@ -1,7 +1,6 @@
 # ruff: noqa: E501
 """System prompt + user-message formatter for the Lark chat agent."""
 
-
 SYSTEM_PROMPT = """You are an agent embedded in a Lark / Feishu chat. You help the user by calling tools, including `lark-cli` to actually send messages back to them.
 
 # The shape of one user turn

--- a/app/lark_chat/prompts.py
+++ b/app/lark_chat/prompts.py
@@ -1,0 +1,107 @@
+# ruff: noqa: E501
+"""System prompt + user-message formatter for the Lark chat agent."""
+
+
+SYSTEM_PROMPT = """You are an agent embedded in a Lark / Feishu chat. You help the user by calling tools, including `lark-cli` to actually send messages back to them.
+
+# The shape of one user turn
+
+The shape of every turn is FIXED and SHORT. Do not deviate.
+
+1. (optional) Load context: at most ONE bash to peek at `/workspace/history/`, and at most ONE `cat` of one relevant SKILL.md if the request needs it. Skip both if the request is trivial (greeting, small-talk, a question you can already answer from the chat history).
+2. Do the work: the minimum number of tool calls needed to fulfill the user's actual request.
+3. **Send exactly ONE user-facing reply** via `lark-cli im +messages-reply --message-id <om_...> --text "..." --as bot` (preserves threading) or `im +messages-send --chat-id <oc_...> --text "..." --as bot`. Both accept `--markdown` for rich content. The user sees ONLY this reply — never your thinking, tool calls, or tool outputs.
+4. **End the turn by calling `finish`** with a one-line internal summary (the user does NOT see this; it's just a log marker).
+
+That's it. Most simple turns are: send reply → call `finish`. Two tool calls total.
+
+# Ending a turn — `finish` is mandatory
+
+- After you've sent your user-facing reply, your very next assistant response MUST call `finish` with a brief summary of what you just did (e.g. `{"answer": "greeted the user back"}`). This is how you yield control back to the user.
+- Do NOT keep exploring, re-reading SKILL.md, re-checking history, or sending follow-up replies "just in case" after the work is done. Call `finish`.
+- If for any reason you cannot complete the work, still send the user a short failure reply via `lark-cli`, then call `finish`.
+- (Fallback: a plain-text assistant response with NO tool call also ends the turn, but `finish` is the preferred, explicit signal.)
+
+# Hard rules (read carefully)
+
+- **One reply per turn.** Never send the user multiple `lark-cli` reply messages for a single inbound message. No "let me check…" + "done!" pattern — just do the work silently, then send one final reply.
+- **No exploration loops.** Never call `--help`, never re-read the same SKILL.md you read earlier in the conversation (it's still in your context), never retry the same failing command with cosmetic variations.
+- **Trust the context.** If the chat history already tells you something (user's name, prior preferences, what you did last turn), don't re-derive it with tool calls.
+- **Fail fast.** If a command fails with a permission / scope / auth / missing-credential error, do NOT retry or attempt to re-auth. Send the user a clear short error reply via `lark-cli`, then `finish`.
+
+# Tool calls
+
+- You may emit ONE OR MORE tool calls per assistant response. Multiple calls in one response run sequentially in the same bash session and results come back in the same order. Use this for **independent** read-only steps (e.g. `ls /workspace/history` + `cat /workspace/history/user-profile.md` at once); for dependent steps, separate responses.
+- Available tools (see the function-calling schemas):
+  - `execute_bash` — run a shell command in the sandbox.
+  - `lark-cli` — Lark / Feishu CLI (IM, calendar, docs, contacts, ...).
+  - `str_replace_editor` — read / create / edit files (preferred for `/workspace/history/*.md`).
+  - `finish` — end the current turn. ALWAYS the last tool call of every turn.
+
+# Long-term memory (`/workspace/history/`)
+
+Your context window holds only a recent slice of this conversation. `/workspace/history/` is persisted on the host (survives container / process restarts and history trimming) — use it for anything that must outlive the in-context window.
+
+- At the start of a turn, `ls /workspace/history/` once **only if** the request hints at long-term context (preferences, past decisions, ongoing work). Skip for greetings and one-shot questions.
+- Write notes only when you learn something durable: preferences, decisions, pending work, user identity / role / timezone, project context. One focused topic per file: `/workspace/history/<short-slug>.md`. Use `str_replace_editor`.
+- **Do NOT mirror the chat transcript here.** Save *digested* context — decisions, summaries, structured state — not raw chat dumps.
+
+# Skills
+
+You have a library of *skills* (task-specific instruction packs) listed under <available_skills>. Each ships a SKILL.md describing its command vocabulary.
+
+- Read a SKILL.md (via `cat`) **at most once per conversation** before invoking its commands for the first time. Once read it stays in your context.
+- Common skills: `lark-im` (IM send/search), `lark-calendar` (events, RSVP, rooms), `lark-doc` / `lark-sheets` / `lark-base`, `lark-contact` (name ↔ open_id), `lark-mail`, `lark-task`, `lark-vc`, `lark-minutes`, etc.
+- Prefer the most specific skill over generic shell.
+
+# Identity (`--as bot` vs `--as user`)
+
+When a tool exposes an identity flag (e.g. `lark-cli ... --as {bot|user}`):
+
+- DEFAULT to `--as bot` for any action that produces output *for* the user (replying to them, posting to chats they read, creating files they consume). "as user" in those cases means impersonating the user.
+- Use `--as user` only when the action genuinely requires the user's own identity / personal scope (their private calendar, mailbox, drafts, drive, OKRs) or when the user explicitly asks you to act as them.
+- If unsure, try `--as bot` first; fall back to `--as user` only on a scope / visibility error.
+
+# Tone
+
+- Be concise. The user wants results, not narration.
+- Match the user's language (reply in Chinese if they wrote in Chinese; English if English).
+- No preambles like "Sure!" or "Of course". Get to the point.
+"""
+
+
+def format_user_message(
+    *,
+    chat_id: str,
+    message_id: str,
+    sender_id: str,
+    chat_type: str,
+    message_type: str,
+    content: str,
+    create_time: str | None = None,
+) -> str:
+    """Format an inbound Lark IM event into the user message text seen by the agent.
+
+    The structured metadata block at the top is what lets the agent
+    call ``lark-cli im +messages-reply --message-id <om_...>`` without
+    needing to extract IDs from prose.
+    """
+    meta_lines = [
+        "[New Lark message]",
+        f"  chat_id:        {chat_id}",
+        f"  chat_type:      {chat_type}",
+        f"  message_id:     {message_id}",
+        f"  sender_open_id: {sender_id}",
+        f"  message_type:   {message_type}",
+    ]
+    if create_time:
+        meta_lines.append(f"  create_time_ms: {create_time}")
+    return (
+        "\n".join(meta_lines)
+        + "\n\nContent:\n"
+        + content.rstrip()
+        + "\n\nTo reply to this message (preferred — keeps threading):\n"
+        f'  lark-cli im +messages-reply --message-id {message_id} --text "..." --as bot\n'
+        + "To send a new (un-threaded) message in this chat instead:\n"
+        f'  lark-cli im +messages-send --chat-id {chat_id} --text "..." --as bot\n'
+    )

--- a/uni_agent/interaction/interaction.py
+++ b/uni_agent/interaction/interaction.py
@@ -18,8 +18,9 @@ ToolStatus = Literal["ok", "timeout", "syntax_error", "skipped"]
 
 
 class ToolResult(BaseModel):
-    """Per-tool-call result inside a single step. ``observation`` is what was
-    sent back to the model as the ``role="tool"`` content (error text included).
+    """Per-tool-call result inside a single step. ``observation`` is the
+    string sent back to the model as the ``role="tool"`` content (error
+    text included).
     """
 
     tool_call_id: str
@@ -58,10 +59,11 @@ class AgentInteraction:
         skills_manager: SkillsManager | None = None,
         chat_mode: bool = False,
     ):
-        """:param chat_mode: how to treat an assistant message with **no** tool
-        calls. ``False`` (default, single-shot / training / code-eval):
-        ``format_error``, loop continues. ``True`` (long-running chat):
-        ``turn_done``, loop returns to wait for the next user message.
+        """:param chat_mode: how to treat an assistant message with no
+        tool calls. ``False`` (default, training / code-eval) raises
+        ``format_error`` so the loop continues. ``True`` (long-running
+        chat) marks the step ``turn_done`` so the caller can wait for
+        the next user message.
         """
         self.env = env
         self.model = model
@@ -147,8 +149,8 @@ class AgentInteraction:
         # step 3: parse model response to actions
         self.rollout_cache = rollout_cache
 
-        # Mirror api-shaped assistant message into self.messages so
-        # persistence/replay keeps the assistant<->tool linkage.
+        # Persist the assistant message in api-shape (with tool_calls)
+        # so replay preserves the assistant<->tool linkage.
         assistant_msg: dict[str, object] = {"role": "assistant", "content": model_output}
         if tool_calls:
             assistant_msg["tool_calls"] = tool_calls
@@ -190,15 +192,14 @@ class AgentInteraction:
 
         step_output.thought = content
 
-        # step 4: chat_mode only -- no tool call = turn-final reply.
-        # (Single-shot mode already raised FunctionCallFormatError above.)
+        # step 4: chat_mode-only end-of-turn (single-shot already raised above).
         if not tool_calls:
             step_output.done = True
             step_output.exit_reason = "turn_done"
             self.logger.info(f"💬 TURN DONE (no tool call): {model_output}")
             return step_output
 
-        # step 5: execute every tool call sequentially in the shared bash session
+        # step 5: run each tool call sequentially in the shared bash session
         tool_results: list[ToolResult] = []
         tool_messages: list[dict[str, object]] = []
         saw_finish = False
@@ -253,23 +254,16 @@ class AgentInteraction:
                     }
                 )
 
-                # Stop the loop and synthesize `skipped` results for the
-                # rest when the session is gone or timeout budget is out
-                # (keeps the assistant<->tool N:N invariant).
+                # On hard failure (dead session / budget out), synthesize
+                # `skipped` results for remaining tool calls to keep the
+                # assistant<->tool N:N invariant, then break.
                 budget_exhausted = self.timeout_budget < 0
                 if terminal_dead or budget_exhausted:
-                    if terminal_dead:
-                        skipped_reason = (
-                            "Skipped: the bash session died while running a previous "
-                            "tool call in this step. No further tool calls in this "
-                            "assistant response were executed."
-                        )
-                    else:
-                        skipped_reason = (
-                            "Skipped: timeout budget exhausted while running a previous "
-                            "tool call in this step. No further tool calls in this "
-                            "assistant response were executed."
-                        )
+                    skipped_reason = (
+                        "Skipped: the bash session died mid-step; no further tool calls ran."
+                        if terminal_dead
+                        else "Skipped: timeout budget exhausted mid-step; no further tool calls ran."
+                    )
                     for remaining in tool_calls[idx + 1 :]:
                         tool_results.append(
                             ToolResult(
@@ -291,14 +285,13 @@ class AgentInteraction:
                         )
                     break
 
-        # step 6: commit collected tool messages to both histories
+        # step 6: commit collected tool messages
         self.messages.extend(tool_messages)
         self.rollout_cache = await self.model.append_messages_to_rollout_cache(tool_messages, self.rollout_cache)
         step_output.tool_results = tool_results
 
-        # step 7: pick step-level exit_reason (precedence: terminal_dead >
-        # timeout_budget_exhausted > finished > completed_with_tool_errors >
-        # completed).
+        # step 7: step-level exit_reason (precedence: terminal_dead >
+        # timeout_budget_exhausted > finished > completed_with_tool_errors > completed)
         if terminal_dead:
             step_output.done = True
             step_output.exit_reason = "terminal_dead"

--- a/uni_agent/interaction/model.py
+++ b/uni_agent/interaction/model.py
@@ -235,8 +235,8 @@ class OpenAICompatibleChatModel:
         self.tools_schemas = tools_schemas
 
     async def prepare_rollout_cache(self, messages: list[dict[str, str]]) -> dict[str, Any]:
-        """OpenAI path is stateless; the caller owns ``messages`` and
-        re-passes it every :meth:`query`. Only metrics live in the cache.
+        """Stateless: caller owns ``messages`` and re-passes them every
+        :meth:`query`. Cache holds only metrics.
         """
         return {"metrics": {}}
 
@@ -245,15 +245,15 @@ class OpenAICompatibleChatModel:
         new_messages: list[dict[str, Any]],
         rollout_cache: dict[str, Any] | None,
     ):
-        """No-op. Kept so :class:`AgentInteraction` can dispatch uniformly
-        over training (:class:`AgentChatModel`) and inference paths.
+        """No-op; kept so :class:`AgentInteraction` can dispatch uniformly
+        across training and inference paths.
         """
         return rollout_cache
 
     def _normalize_messages_for_api(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Strip locally-added fields the OpenAI API doesn't accept.
-        Tool messages missing ``tool_call_id`` (e.g. format-error fallbacks)
-        are forwarded as-is.
+        Tool messages missing ``tool_call_id`` (format-error fallbacks)
+        pass through as-is.
         """
         normalized_messages = []
         for message in messages:

--- a/uni_agent/interaction/tool_parser.py
+++ b/uni_agent/interaction/tool_parser.py
@@ -149,33 +149,36 @@ class XMLToolParser:
         return tool_call
 
     def _get_function_calls(self, model_output: str) -> list[str]:
-        # Find all tool calls
+        """Return ``<function=...>`` bodies found inside ``<tool_call>`` blocks.
+        Empty list = nothing recoverable (caller treats as "no tool calls").
+        """
         matched_ranges = self.tool_call_regex.findall(model_output)
         raw_tool_calls = [match[0] if match[0] else match[1] for match in matched_ranges]
-
-        # Back-off strategy if no tool_call tags found
-        if len(raw_tool_calls) == 0:
-            raise FunctionCallFormatError("No function call found in the response.")
-
         raw_function_calls = []
         for tool_call in raw_tool_calls:
             raw_function_calls.extend(self.tool_call_function_regex.findall(tool_call))
-
-        function_calls = [match[0] if match[0] else match[1] for match in raw_function_calls]
-        return function_calls
+        return [match[0] if match[0] else match[1] for match in raw_function_calls]
 
     def extract_tool_calls(
         self, model_output: str, tools: list[OpenAIFunctionToolSchema]
     ) -> tuple[str, list[OpenAIFunctionToolCall]]:
+        """Parse ``<tool_call>...</tool_call>`` blocks out of ``model_output``.
+
+        Returns ``(content_before_marker, tool_calls)``. ``tool_calls`` is
+        ``[]`` whenever nothing parseable comes out -- whether the marker
+        was absent or present-but-unrecoverable. Callers decide what to
+        do (single-shot raises, chat treats as turn-end). When a function
+        name IS recovered but invalid (unknown name, bad arg type, ...)
+        we still raise :class:`FunctionCallFormatError`.
+        """
         if self.tool_call_start_token not in model_output:
-            raise FunctionCallFormatError("No function call found in the response.")
+            return model_output, []
 
         function_calls = self._get_function_calls(model_output)
-        if len(function_calls) == 0:
-            raise FunctionCallFormatError("No function call found in the response.")
+        if not function_calls:
+            return model_output, []
         tool_calls = [self._parse_xml_function_call(function_call_str, tools) for function_call_str in function_calls]
 
-        # Extract content before tool calls
         content_index = model_output.find(self.tool_call_start_token)
         content_index = content_index if content_index >= 0 else model_output.find(self.tool_call_prefix)
         content = model_output[:content_index]
@@ -203,16 +206,25 @@ class HermesToolParser:
     def extract_tool_calls(
         self, model_output: str, tools: list[OpenAIFunctionToolSchema]
     ) -> tuple[str, list[OpenAIFunctionToolCall]]:
+        """Parse ``<tool_call>{...}</tool_call>`` JSON blocks out of ``model_output``.
+
+        Returns ``(content_before_marker, tool_calls)``. ``tool_calls`` is
+        ``[]`` when nothing parseable comes out (no marker, or marker
+        pair with empty body); callers decide. The "unclosed" case
+        (``<tool_call>`` opened with partial JSON, no closing tag) DOES
+        raise -- partial JSON is a clear formatting bug worth surfacing
+        back to the model.
+        """
         if self.tool_call_start_token not in model_output:
-            raise FunctionCallFormatError(f"No function call found in the response. {self._FORMAT_HINT}")
+            return model_output, []
         if self.tool_call_end_token not in model_output:
             raise FunctionCallFormatError(
                 f"Unclosed tool call: missing {self.tool_call_end_token}. {self._FORMAT_HINT}"
             )
 
-        matches = self.tool_call_regex.findall(model_output)
+        matches = [m for m in self.tool_call_regex.findall(model_output) if m.strip()]
         if not matches:
-            raise FunctionCallFormatError(f"No function call found in the response. {self._FORMAT_HINT}")
+            return model_output, []
 
         valid_names = {tool.function.name for tool in tools if tool.type == "function"}
 

--- a/uni_agent/interaction/tools_manager.py
+++ b/uni_agent/interaction/tools_manager.py
@@ -35,8 +35,10 @@ class ToolsManager:
         model_output: str,
     ) -> tuple[str, list[OpenAIFunctionToolCall]]:
         """Parse tool calls from raw text. Returns ``(content, tool_calls)``;
-        ``tool_calls`` may be empty (callers decide what that means).
-        Malformed calls raise :class:`FunctionCallFormatError`.
+        ``tool_calls`` is ``[]`` when the text contains no tool-call
+        marker (callers decide -- single-shot raises, chat_mode treats
+        as turn-end). Markers that ARE present but malformed raise
+        :class:`FunctionCallFormatError`.
         """
         tools = [OpenAIFunctionToolSchema(**schema) for schema in self.tools_schemas]
         content, tool_calls = self._tool_parser.extract_tool_calls(model_output, tools)


### PR DESCRIPTION
### What does this PR do?

Extend the agent loop to support **multiple tool calls per assistant
response** and add a `chat_mode` flag that recognizes plain-text /
`finish` as end-of-turn — both prerequisites for long-running multi-turn
chat agents. Build `app/lark_chat/` on top: a long-running Lark / Feishu
chat agent that persists per-chat history, executes tools inside an
attached Docker container, and replies via the same containerised
`lark-cli` it uses to subscribe events (single identity, single auth).

Builds on #38 (`local_attach` deployment). The branch was reset against
latest main; this PR's `interaction.py` / `model.py` / `tool_parser.py`
/ `tools_manager.py` supersedes the multi-tool implementation that
landed in #39.

### Checklist Before Starting

- [x] Related PRs: builds on #38, supersedes the multi-tool path from #39
- [x] PR title format

### Test

Manual:
- `examples/search_arxiv/demo.py` — full single-shot trajectory, finishes
  via `finish`, `_extract_answer_from_trajectory` still extracts the
  answer from the new `ToolResult` shape.
- `examples/lark/demo.py` (`local_native` + `local_attach`) — single-shot
  trajectory unchanged.
- `app/lark_chat/main.py` end-to-end inside Docker — multi-turn chat with
  history persistence; trivial turns (e.g. greeting) converge in 2 steps
  (`lark-cli reply → finish`).
- Parser regression: AST + import smoke on all changed files; unit smoke
  covering plain text, valid call, marker-but-no-body, Hermes unclosed,
  unknown name, bad JSON.

### API and Usage Example

**`StepOutput` schema (BREAKING)** — per-tool state moved into a new
`ToolResult` list; step-level fields removed:

​```python
# before
step.action          # single tool's bash cmd
step.observation     # single tool's stdout
step.execution_time

# after
step.tool_results    # list[ToolResult]; each has tool_call_id, name,
                     # action, observation, status, execution_time
​```

**`AgentInteraction(..., chat_mode=False)`** (NEW) — `False` (default)
preserves single-shot / training behavior (no tool call → format_error).
`True` flips to `turn_done` for long-running chat.

**`model.query()` return signature (BREAKING)** — 4-tuple; no more
`rollout_cache.extra_fields.last_tool_calls`:

​```python
# before
text, rollout_cache, generation_info = await model.query(...)
tool_calls = rollout_cache["extra_fields"].get("last_tool_calls", [])

# after
text, tool_calls, rollout_cache, generation_info = await model.query(...)
​```

**Parser semantics (BREAKING)** — `XMLToolParser` /
`HermesToolParser`.`extract_tool_calls` now return `(text, [])` for
plain text instead of raising. Outputs where a function name IS
recovered but invalid (unknown name, bad args, unclosed tag) still
raise.

**`exit_reason` enum (BREAKING)**:

| before | after |
|---|---|
| `timeout_error` (step) | `timeout` (per-tool `status`) |
| `syntax_error` (step) | `syntax_error` (per-tool `status`) |
| `terminal_not_alive` | `terminal_dead` |
| — | `turn_done`, `completed_with_tool_errors`, `timeout_budget_exhausted` (new) |

### Design & Code Changes

**Multi-tool with strict N:N invariant.** `step()` runs each tool call
sequentially in the shared bash session and appends one `role=tool`
message per call. The OpenAI API rejects unmatched assistant↔tool
linkages, so hard failures (terminal dead, timeout budget exhausted,
format error) synthesize `skipped` responses for the remaining tools
before bailing.

**`chat_mode` is opt-in.** Default `False` keeps the training / code-eval
loop's contract unchanged (no tool call → `format_error`). Only
`chat_mode=True` (set explicitly by `app/lark_chat`) turns that into
`turn_done`.

**Parser plain-text fix.** The previous parsers raised "No function call
found" for any output without `<tool_call>` markers, which conflated
"model chose not to call a tool" with "model called a tool wrong". That
made `chat_mode`'s `turn_done` path dead code at first. Now any output
we can't recover a function name from returns empty; only outputs where
we DO recover a name but it's invalid raise. Callers decide what empty
means (single-shot raises, chat ends turn).

**`OpenAICompatibleChatModel` de-stateification.** Dropped
`extra_fields.{api_messages, last_tool_calls}`. The caller
(`AgentInteraction`) now owns the message list and re-passes it on every
`query`; `tool_calls` are an explicit return value. Simpler model with
no hidden state.

**`app/lark_chat/` (`local_attach` only).**
- `listener.py` — async wrapper around `lark-cli event consume`; takes
  a `command_prefix` so it can route through `docker exec -i <container>`
- `conversation.py` — atomic per-chat JSON persistence preserving
  `tool_calls` ↔ `tool_call_id` linkage
- `prompts.py` — `finish`-first end-of-turn discipline, one-reply-per-turn,
  no exploration loops
- `main.py` — serial dispatch through one shared `AgentEnv` (swerex.server
  in the container) + one `OpenAICompatibleChatModel`

Single deployment mode (`local_attach`) means listener AND agent replies
both route through the container's `lark-cli`, so you auth once inside
the container with no host/container identity drift.

### Checklist Before Submitting

- [x] Read CONTRIBUTING.md
- [x] Pre-commit run
- [x] Docs / examples updated (`examples/*/demo.py`, `app/lark_chat/README.md`)
- [ ] Tests: manual validation only. No automated tests added — fully
      exercising the chat app needs a live vLLM + container + Lark bot,
      which isn't practical in CI. Existing parser logic smoke-tested.
- [x] PR title format checked
- [x] Placeholders replaced