### PR TITLE
[deployment,docs] feat: optimize lark_chat app and update docs

### DIFF
--- a/app/lark_chat/README.md
+++ b/app/lark_chat/README.md
@@ -8,9 +8,24 @@ persisted per `chat_id` and trimmed on a sliding window so you can
 talk to the same bot across many turns and across process restarts.
 
 The agent also keeps a **persistent user profile / preferences memory**
-under the container's `/workspace/memory/`, written by the model
-itself, so it accumulates a real picture of the user across
+under a `memory_dir` (default `/workspace/memory/` for `local_attach`,
+`~/.uni-agent/app/lark_chat/memory/` for `local_native`), written by
+the model itself, so it accumulates a real picture of the user across
 conversations (not just within a single chat thread).
+
+Two deployments are supported, each with its own config file:
+
+- **`local_native`** — agent runs shell commands directly against the
+  host. **Unsafe on a personal machine** — only use this when the
+  environment you're running in is already a sandbox / VM / container.
+  Config: [`config.local_native.yaml`](./config.local_native.yaml) —
+  picked up when `--config` is omitted because it requires zero
+  bootstrap.
+- **`local_attach`** — agent runs inside a user-managed Docker container;
+  only the directories you bind-mount are reachable. Safer choice on a
+  personal machine, **recommended**. Config:
+  [`config.local_attach.yaml`](./config.local_attach.yaml) (pass via
+  `--config`).
 
 Sits on top of the same `AgentInteraction` loop as `examples/lark/demo.py`,
 but evolves it from "one user request → one run → exit" to
@@ -27,19 +42,20 @@ response (fallback)** as end-of-turn — see
                 │  host process: app.lark_chat.main                       │
                 │                                                         │
    Lark IM ───► │  LarkEventListener                                      │
-                │      └─ docker exec -i <container> lark-cli event       │
+                │      └─ [docker exec -i <container>]? lark-cli event    │
                 │            consume im.message.receive_v1                │
                 │      │   NDJSON over stdout                             │
                 │      ▼                                                  │
                 │  async for event:                                       │
                 │     handle_one_message(event)                           │
                 │       1. TranscriptStore.load(chat_id)                  │
-                │       2. trim_history(...) + append user msg            │
+                │       2. compact_history(...) + append user msg         │
                 │       3. AgentInteraction.run()  ──────────────┐        │
                 │       4. TranscriptStore.save(messages)        │        │
                 │                                                ▼        │
-                │  shared AgentEnv (local_attach)                         │
-                │      └─ swerex.server in <container>                    │
+                │  shared AgentEnv                                        │
+                │      ├─ local_attach:  swerex.server in <container>     │
+                │      └─ local_native:  pexpect bash on the host         │
                 │            execute_bash / lark-cli / str_replace_editor │
                 │            / finish                                     │
                 └─────────────────────────────────────────────────────────┘
@@ -49,12 +65,15 @@ response (fallback)** as end-of-turn — see
                                    Lark Open API
 ```
 
-- **One container, one bash session, one model client** for the lifetime of the process.
+- **One runtime, one bash session, one model client** for the lifetime of the process.
 - Inbound messages are handled **serially** (the bash session is single-threaded — running two agent turns in parallel through it is pointless). If the user sends two messages back-to-back, the second is queued.
-- **Single lark identity, single auth.** Both the listener AND the agent's replies route through the container's `lark-cli` (via `docker exec -i <container>`). You auth `lark-cli` **once**, inside the container — no host/container identity drift.
+- **Single lark identity, single auth.** Both the listener AND the agent's replies route through the *same* `lark-cli`:
+  - `local_attach` → the container's `lark-cli` (host side uses `docker exec -i <container>`).
+  - `local_native` → the host's `lark-cli` directly.
+  Either way, you auth `lark-cli` **once** on the side that owns it — no host/container identity drift.
 - Two distinct persistence stores, with different lifecycles and owners:
   - **Per-chat transcripts** — one JSON file per `chat_id` under `~/.uni-agent/app/lark_chat/transcripts/`, written by Python. Holds the **OpenAI-shaped** message log (`tool_calls` on assistants, `tool_call_id` on `role=tool` entries) so re-feeding preserves the assistant↔tool linkage and the model "remembers" the last N turns of THIS chat.
-  - **Long-term memory** — files under `/workspace/memory/` inside the container (bind-mounted to a host dir), written by **the model itself** via `str_replace_editor`. Holds the user's profile, preferences, and digested per-topic notes — survives chat-history trimming AND process restarts, and is shared across all chats with the same bot.
+  - **Long-term memory** — files under the configured `memory_dir` (`/workspace/memory/` in the container for `local_attach`, `~/.uni-agent/app/lark_chat/memory/` on the host for `local_native`), written by **the model itself** via `str_replace_editor`. Holds the user's profile, preferences, and digested per-topic notes — survives runtime / process restarts, and is shared across all chats with the same bot.
 
 ## Setup
 
@@ -75,7 +94,21 @@ vllm serve /path/to/Qwen3.6-35B-A3B \
 
 The bot must be subscribed to `im.message.receive_v1` (application-identity event) in the [Lark / Feishu Developer Console](https://open.feishu.cn), with event delivery mode set to **WebSocket / long-link** (so `lark-cli event consume` can attach as a client).
 
-### 3. Sandbox container (one-time bootstrap)
+### 3. Install `lark-cli` and authorize a bot
+
+```bash
+npm install -g @larksuite/cli
+lark-cli --version           # sanity check
+lark-cli config init --new   # creates a new app on the Lark Open Platform
+lark-cli auth login          # OAuth device flow, binds the app to your Feishu account
+lark-cli auth status
+```
+
+The same authenticated `lark-cli` is reused by the event listener AND by the agent's replies — no host/container identity drift. Edit [`config.local_native.yaml`](./config.local_native.yaml) to point `model.base_url` / `model.name` at your endpoint.
+
+### 4. (Optional, recommended on a personal machine) Deploy in a sandbox
+
+The agent runs LLM-generated shell every turn. Running that directly against your host is unsafe on a personal machine. For isolation, spin up a Docker container first and run the same setup as Step 3 inside it (plus `swerex.server` so the host process can attach over HTTP):
 
 ```bash
 docker rm -f lark-chat-sandbox 2>/dev/null
@@ -88,96 +121,118 @@ docker exec -it lark-chat-sandbox bash -lc '
   npm install -g @larksuite/cli
   pip install swe-rex
   lark-cli config init --new
-  lark-cli auth login        # complete OAuth inside the container
+  lark-cli auth login
   lark-cli auth status'
 
 docker exec -d lark-chat-sandbox bash -lc '
   python3 -m swerex.server --host 0.0.0.0 --port 18000 --auth-token CHANGEME'
 ```
 
-On the host you only need Python + `docker`. `lark-cli` lives in the container.
+The container only sees what you bind-mount (`-v ...:/workspace` above). On the host you only need Python + `docker`; `lark-cli` lives in the container.
 
-### 4. (Optional) Skills
+Then edit [`config.local_attach.yaml`](./config.local_attach.yaml): `deployment.container` must match the container name above, and `deployment.swerex.auth_token` must match the `--auth-token` passed to `swerex.server`.
 
-Drop SKILL.md packs under `~/.uni-agent/skills/` (override with `LARK_SKILLS_DIR=...`). The skill manifest is injected into the system prompt on the first turn of each chat, so the model knows it can `cat <path>/SKILL.md` for things like `lark-im`, `lark-calendar`, `lark-doc`, etc.
+### 5. (Optional) Skills
 
-### 5. Run
+Drop SKILL.md packs under `~/.agents/skills/`, or point `skills_dir` in the YAML at a different directory. The skill manifest is injected into the system prompt on the first turn of each chat, so the model knows it can `cat <path>/SKILL.md` for packs like `lark-im`, `lark-calendar`, `lark-doc`, etc.
+
+### 6. Run
 
 ```bash
-LOCAL_ATTACH_AUTH_TOKEN=CHANGEME python -m app.lark_chat.main
+python -m app.lark_chat.main
 ```
+
+Picks up `config.local_native.yaml` automatically. For `local_attach`:
+
+```bash
+LOCAL_ATTACH_AUTH_TOKEN=CHANGEME \
+  python -m app.lark_chat.main --config app/lark_chat/config.local_attach.yaml
+```
+
+(`LOCAL_ATTACH_AUTH_TOKEN` is only needed when `deployment.swerex.auth_token` is left `null` in YAML.)
 
 Send a message to the bot in Lark; the trace prints per-turn step / tool / status info. Ctrl+C to shut down (the listener stops cleanly via stdin EOF, the env is closed).
 
-To use a custom config:
-
-```bash
-LOCAL_ATTACH_AUTH_TOKEN=CHANGEME python -m app.lark_chat.main --config /path/to/my.yaml
-```
-
 ## Configuration
 
-All non-secret settings live in [`config.yaml`](./config.yaml). Override the path with `--config <file>`. Top-level keys:
+Two reference configs ship with the app — pick one and pass it via `--config <file>`:
+
+- [`config.local_attach.yaml`](./config.local_attach.yaml) — attach to a user-managed Docker container (recommended on a personal machine).
+- [`config.local_native.yaml`](./config.local_native.yaml) — host pexpect, no container (picked up when `--config` is omitted).
+
+Top-level keys:
 
 | Key | Default | Purpose |
 |---|---|---|
-| `container` | `lark-chat-sandbox` | Container name the listener `docker exec`s into and `swerex.server` runs in. Owns the lark-cli auth. |
-| `swerex.host` / `.port` | `http://127.0.0.1` / `18000` | swerex.server endpoint |
-| `swerex.auth_token` | `null` → `$LOCAL_ATTACH_AUTH_TOKEN` | swerex.server `--auth-token`. Secret; leave `null` in YAML and set the env var, or inline for local dev. |
+| `deployment.type` | `local_native` (in the default config) | Selects deployment. Either `local_attach` (container — recommended on a personal machine) or `local_native` (host pexpect — only safe inside a sandbox / VM / container). |
+| `deployment.container` | — (required for `local_attach`) | Container name the listener `docker exec`s into and `swerex.server` runs in. Owns the lark-cli auth. |
+| `deployment.swerex.host` / `.port` | `http://127.0.0.1` / `18000` (`local_attach` only) | swerex.server endpoint |
+| `deployment.swerex.auth_token` | `null` → `$LOCAL_ATTACH_AUTH_TOKEN` (`local_attach` only) | swerex.server `--auth-token`. Secret; leave `null` in YAML and set the env var, or inline for local dev. |
+| `deployment.post_setup_cmd` | `cd /workspace` (`local_attach`) | Command run once after the bash session starts. |
+| `deployment.startup_timeout` | `30.0` / `60.0` | Initial handshake timeout. |
+| `deployment.tool_install_dir` | `~/.uni-agent/bin` (`local_native` only) | Where local-only tool scripts are written. Must be writable by the agent process. |
+| `memory_dir` | `/workspace/memory` (`local_attach`) / `~/.uni-agent/app/lark_chat/memory` (`local_native`) | Path INSIDE the runtime bash session where the model writes its persistent profile / preferences / notes. Mirrored into the system prompt. |
 | `model.base_url` / `.name` | `http://localhost:8000/v1` / `Qwen/Qwen3.6-35B-A3B` | OpenAI-compatible endpoint + model name |
-| `model.api_key` | `null` → `$API_KEY` → `EMPTY` | Secret; same rule as `swerex.auth_token`. |
+| `model.api_key` | `null` → `$API_KEY` → `EMPTY` | Secret; same rule as `deployment.swerex.auth_token`. |
 | `model.sampling_params` | sensible defaults | Forwarded to the chat-completion call (`temperature`, `top_p`, `top_k`, `presence_penalty`, `repetition_penalty`, ...) |
 | `tools` | `[execute_bash, lark-cli, str_replace_editor, finish]` | Tools registered on `ToolsManager`. Each entry becomes `ToolConfig(name=...)`. |
-| `skills_dir` | `~/.uni-agent/skills` | Skill packs directory (`~` is expanded) |
-| `transcripts_dir` | `~/.uni-agent/app/lark_chat/transcripts` | Where per-chat message-log JSON files live on the host (one file per `chat_id`). Distinct from the container's `/workspace/memory/` (model-curated user profile / preferences / notes). |
+| `skills_dir` | `~/.agents/skills` | Skill packs directory (`~` is expanded) |
+| `transcripts_dir` | `~/.uni-agent/app/lark_chat/transcripts` | Where per-chat message-log JSON files live on the host (one file per `chat_id`). Distinct from `memory_dir` (model-curated user profile / preferences / notes). |
 | `agent.action_timeout` | `60` | Seconds per single tool call |
 | `agent.max_steps_per_turn` | `20` | Agent steps before forcing turn end (hard cap; `finish` should land it well under this) |
-| `agent.max_history_turns` | `30` | Trim history to last N user-anchored turns |
+| `agent.history_max_tokens` | `128000` | Compaction trigger. While the persisted history fits under this, it is forwarded to the model **unchanged** so the server's prefix KV cache stays warm across turns. Crossing this triggers exactly one compaction down to `history_target_tokens`. |
+| `agent.history_target_tokens` | `32000` | Post-compaction history size. Must be `<= history_max_tokens`; the gap is the cache-hit headroom that amortizes the compaction-turn cache miss across many subsequent appending turns. Trimming respects user-anchored chunks (`role=tool` is never separated from its parent `role=assistant`) and always keeps the most-recent chunk. Token counts use `tiktoken.cl100k_base` when available, else `len(text) // 4`. |
 
 **Env var overrides** are intentionally limited to secrets:
 
 | Env var | Falls back to | When YAML field is `null` |
 |---|---|---|
-| `LOCAL_ATTACH_AUTH_TOKEN` | `swerex.auth_token` | required (raise if both missing) |
+| `LOCAL_ATTACH_AUTH_TOKEN` | `deployment.swerex.auth_token` | required for `local_attach` (raise if both missing); ignored for `local_native` |
 | `API_KEY` | `model.api_key` | defaults to `"EMPTY"` |
 
 ## What happens per user message
 
 1. **Filter at the source.** `lark-cli event consume` is launched with a `--jq` filter that drops events from the bot itself (`sender_id == <bot_open_id>`) and any non-text/post message types, so they never reach the Python loop.
-2. **Load + trim transcript.** `TranscriptStore.load(chat_id)` returns the persisted message list; `trim_history` keeps the system message + the last `agent.max_history_turns` user-anchored chunks intact (never strips a `role=tool` away from its parent `role=assistant`).
+2. **Load + (lazy) compact transcript.** `TranscriptStore.load(chat_id)` returns the persisted message list; `compact_history` forwards it unchanged while the total fits under `agent.history_max_tokens` (so the model server's prefix KV cache hits across turns), and only compacts down to `agent.history_target_tokens` when the threshold is crossed. Compaction respects user-anchored chunks (`role=tool` is never separated from its parent `role=assistant`) and always keeps at least the last chunk so the message being replied to is never dropped.
 3. **Append the new user message.** Includes a structured Lark metadata block (`chat_id`, `message_id`, `sender_open_id`, `chat_type`, `message_type`, `create_time`) above the content so the agent can call `lark-cli im +messages-reply --message-id <om_...>` directly without parsing IDs out of prose.
-4. **Run one turn.** `AgentInteraction.run()` loops: model call → parse 0..N tool calls → execute each sequentially → repeat. The system prompt requires the agent to `ls /workspace/memory/` + `cat profile.md preferences.md` at the start of every turn, then do the work, then write any newly-learned durable facts back into memory BEFORE replying. The turn ends when the model calls `finish` (preferred end-of-turn signal) or returns plain text with no tool call (fallback). `agent.max_steps_per_turn` is a hard safety cap.
+4. **Run one turn.** `AgentInteraction.run()` loops: model call → parse 0..N tool calls → execute each sequentially → repeat. The system prompt requires the agent to `ls <memory_dir>/` + `cat <memory_dir>/profile.md <memory_dir>/preferences.md` at the start of every turn, then do the work, then write any newly-learned durable facts back into memory BEFORE replying. The turn ends when the model calls `finish` (preferred end-of-turn signal) or returns plain text with no tool call (fallback). `agent.max_steps_per_turn` is a hard safety cap.
 5. **Persist transcript.** `result["messages"]` (the OpenAI-shape message log) is saved atomically back to the chat's JSON file. Memory files are *not* touched by Python — the model wrote them in step 4.
 
-## Long-term memory contract (`/workspace/memory/`)
+## Long-term memory contract (`memory_dir`)
 
-The container's `/workspace` is bind-mounted to `~/.uni-agent/app/lark_chat/workspace` on the host (per the bootstrap above). `/workspace/memory/` therefore survives container / process restarts, and is shared across every chat the bot handles.
+`memory_dir` is the directory the agent reads/writes long-term memory from, *inside the runtime bash session*:
 
-The system prompt establishes a fixed file layout the model is required to follow:
+- For **`local_attach`**: default is `/workspace/memory/` (a container path). Bind-mount the container's `/workspace` to a host directory (per the bootstrap above) so memory survives container restarts.
+- For **`local_native`**: default is `~/.uni-agent/app/lark_chat/memory/` — already on the host, so survival across process restarts is automatic.
 
-| Path | Purpose |
+Either way, `memory_dir` is shared across every chat the bot handles, since there is only one runtime.
+
+The system prompt is rendered against `memory_dir` and establishes a fixed file layout the model is required to follow:
+
+| Path (relative to `memory_dir`) | Purpose |
 |---|---|
-| `/workspace/memory/profile.md` | WHO the user is — name, role/team, timezone, language, contact, projects |
-| `/workspace/memory/preferences.md` | HOW the user wants you to behave — reply language, formatting style, default identity, recurring constraints |
-| `/workspace/memory/notes/<slug>.md` | Durable per-topic state — pending tasks, decisions, ongoing efforts |
+| `profile.md` | WHO the user is — name, role/team, timezone, language, contact, projects |
+| `preferences.md` | HOW the user wants you to behave — reply language, formatting style, default identity, recurring constraints |
+| `notes/<slug>.md` | Durable per-topic state — pending tasks, decisions, ongoing efforts |
 
 Read/write protocol enforced by the prompt:
 
-- **Read every turn**: `ls /workspace/memory/` + `cat profile.md preferences.md` in a single batched assistant response, unless the in-context history of THIS conversation already shows the load happened.
+- **Read every turn**: `ls <memory_dir>/` + `cat <memory_dir>/profile.md <memory_dir>/preferences.md` in a single batched assistant response, unless the in-context history of THIS conversation already shows the load happened.
 - **Write same turn** *before* replying: whenever the user reveals a fact (name, role, timezone, language, project) or a preference, update the relevant file via `str_replace_editor`.
 - **Never mirror the transcript** — memory is digested bullets, not raw chat dumps.
 
-`mkdir -p /workspace/memory/notes` is run at startup by `main.py` so the directory always exists; the model is responsible for actually populating it.
+`mkdir -p <memory_dir>/notes` is run at startup by `main.py` so the directory always exists; the model is responsible for actually populating it.
 
 ## Files
 
 ```
 app/lark_chat/
 ├── __init__.py
-├── README.md              ← this file
-├── config.yaml            ← default config (override with --config <path>)
-├── main.py                ← entrypoint: bootstrap + listener loop + LarkChatConfig
-├── prompts.py             ← SYSTEM_PROMPT + format_user_message
-├── transcript.py          ← TranscriptStore (JSON message log per chat_id)
-└── listener.py            ← LarkEventListener + fetch_bot_open_id
+├── README.md                       ← this file
+├── config.local_attach.yaml        ← reference config for local_attach (recommended)
+├── config.local_native.yaml        ← reference config for local_native (default --config)
+├── main.py                         ← entrypoint: bootstrap + listener loop + LarkChatConfig
+├── prompts.py                      ← build_system_prompt(memory_dir) + format_user_message
+├── transcript.py                   ← TranscriptStore (JSON message log per chat_id)
+└── listener.py                     ← LarkEventListener + fetch_bot_open_id
 ```

--- a/app/lark_chat/__init__.py
+++ b/app/lark_chat/__init__.py
@@ -5,8 +5,10 @@ multi-step ``AgentInteraction`` loop running on a shared sandbox env,
 and replies back to the user via ``lark-cli``. Per-chat message
 transcripts are persisted so the agent can hold a real, ongoing
 conversation across many turns and process restarts. Long-term user
-profile / preferences live separately under the container's
-``/workspace/memory/`` (written by the model itself, not by Python).
+profile / preferences live separately under a ``memory_dir`` written by
+the model itself (not by Python) — a container path under
+``/workspace/memory/`` for the ``local_attach`` deployment, or a host
+path such as ``~/.uni-agent/app/lark_chat/memory/`` for ``local_native``.
 
 See ``app/lark_chat/README.md`` for setup and run instructions.
 """

--- a/app/lark_chat/config.local_attach.yaml
+++ b/app/lark_chat/config.local_attach.yaml
@@ -1,0 +1,41 @@
+# local_attach deployment: bash + lark-cli inside a user-managed
+# Docker container; host attaches to its swerex.server over HTTP.
+# Bootstrap + run instructions: see app/lark_chat/README.md.
+
+deployment:
+  type: local_attach
+  container: lark-chat-sandbox
+  swerex:
+    host: http://127.0.0.1
+    port: 18000
+    auth_token: CHANGEME   # or leave null and pass LOCAL_ATTACH_AUTH_TOKEN env var
+  post_setup_cmd: cd /workspace
+
+# Container path. Bind-mount /workspace to a host dir so memory survives container restarts.
+memory_dir: /workspace/memory
+
+model:
+  base_url: http://localhost:8000/v1
+  name: Qwen/Qwen3.6-35B-A3B
+  api_key: EMPTY
+  sampling_params:
+    temperature: 1.0
+    top_p: 0.95
+    presence_penalty: 1.5
+    top_k: 20
+    repetition_penalty: 1.0
+
+tools:
+  - execute_bash
+  - lark-cli
+  - str_replace_editor
+  - finish
+
+skills_dir: ~/.agents/skills
+transcripts_dir: ~/.uni-agent/app/lark_chat/transcripts
+
+agent:
+  action_timeout: 60
+  max_steps_per_turn: 20
+  history_max_tokens: 128000      # compaction trigger
+  history_target_tokens: 32000    # post-compaction size

--- a/app/lark_chat/config.local_native.yaml
+++ b/app/lark_chat/config.local_native.yaml
@@ -1,0 +1,35 @@
+# local_native deployment: pexpect bash on the host, no container.
+# Bootstrap + run instructions: see app/lark_chat/README.md.
+
+deployment:
+  type: local_native
+  startup_timeout: 60.0
+  # tool_install_dir: ~/.uni-agent/bin   # optional; default shown
+
+memory_dir: ~/.uni-agent/app/lark_chat/memory
+
+model:
+  base_url: http://localhost:8000/v1
+  name: Qwen/Qwen3.6-35B-A3B
+  api_key: EMPTY
+  sampling_params:
+    temperature: 1.0
+    top_p: 0.95
+    presence_penalty: 1.5
+    top_k: 20
+    repetition_penalty: 1.0
+
+tools:
+  - execute_bash
+  - lark-cli
+  - str_replace_editor
+  - finish
+
+skills_dir: ~/.agents/skills
+transcripts_dir: ~/.uni-agent/app/lark_chat/transcripts
+
+agent:
+  action_timeout: 60
+  max_steps_per_turn: 20
+  history_max_tokens: 128000      # compaction trigger
+  history_target_tokens: 32000    # post-compaction size

--- a/app/lark_chat/main.py
+++ b/app/lark_chat/main.py
@@ -106,31 +106,15 @@ class AgentLoopConfig:
 
 @dataclass
 class LarkChatConfig:
-    """Runtime config loaded from YAML via :meth:`load`."""
+    """Runtime config for the Lark chat agent.
+
+    Loaded from YAML via :meth:`load`. Secrets (``deployment.swerex.auth_token``
+    for ``local_attach``, ``model.api_key``) may be left ``null`` in YAML and
+    supplied through ``LOCAL_ATTACH_AUTH_TOKEN`` / ``API_KEY`` env vars instead.
+    """
 
     deployment: DeploymentConfig
     memory_dir: Path
-    model: ModelConfig
-    tools: list[str]
-    skills_dir: Path
-    transcripts_dir: Path
-    agent: AgentLoopConfig
-
-
-@dataclass
-class LarkChatConfig:
-    """Runtime config for the long-running Lark chat agent.
-
-    Deployment is always ``local_attach`` -- the agent's bash session +
-    its ``lark-cli`` both live inside a user-managed Docker container,
-    so identity stays consistent between event subscription and reply.
-    Load from YAML via :meth:`load`. Secrets (``swerex.auth_token``,
-    ``model.api_key``) may be left ``null`` in YAML and supplied through
-    ``LOCAL_ATTACH_AUTH_TOKEN`` / ``API_KEY`` env vars instead.
-    """
-
-    container: str
-    swerex: SwerexConfig
     model: ModelConfig
     tools: list[str]
     skills_dir: Path

--- a/app/lark_chat/main.py
+++ b/app/lark_chat/main.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import os
+import shlex
 import sys
 import traceback
 import uuid
@@ -41,7 +42,11 @@ from uni_agent.interaction import (  # noqa: E402
 from uni_agent.skills import SkillsManager, SkillsManagerConfig  # noqa: E402
 from uni_agent.tools import ToolConfig  # noqa: E402
 
-DEFAULT_CONFIG_PATH = Path(__file__).parent / "config.yaml"
+DEFAULT_CONFIG_PATH = Path(__file__).parent / "config.local_native.yaml"
+
+_DEFAULT_LOCAL_ATTACH_MEMORY_DIR = Path("/workspace/memory")
+_DEFAULT_LOCAL_NATIVE_MEMORY_DIR = Path("~/.uni-agent/app/lark_chat/memory").expanduser()
+_DEFAULT_LOCAL_NATIVE_TOOL_INSTALL_DIR = Path("~/.uni-agent/bin").expanduser()
 
 
 @dataclass
@@ -49,6 +54,29 @@ class SwerexConfig:
     host: str
     port: int
     auth_token: str
+
+
+@dataclass
+class LocalAttachDeployment:
+    """Bash session + ``lark-cli`` live in a user-managed Docker container;
+    the host listener routes through ``docker exec -i <container>``."""
+
+    container: str
+    swerex: SwerexConfig
+    post_setup_cmd: str | None = "cd /workspace"
+    timeout: float = 300.0
+    startup_timeout: float = 30.0
+
+
+@dataclass
+class LocalNativeDeployment:
+    """Pexpect bash directly on the host; reuses host-side ``lark-cli``."""
+
+    startup_timeout: float = 60.0
+    tool_install_dir: Path = field(default_factory=lambda: _DEFAULT_LOCAL_NATIVE_TOOL_INSTALL_DIR)
+
+
+DeploymentConfig = LocalAttachDeployment | LocalNativeDeployment
 
 
 @dataclass
@@ -63,7 +91,30 @@ class ModelConfig:
 class AgentLoopConfig:
     action_timeout: int = 60
     max_steps_per_turn: int = 20
-    max_history_turns: int = 30
+    history_max_tokens: int = 128000
+    """Compaction trigger; history is forwarded unchanged while it fits under this."""
+    history_target_tokens: int = 32000
+    """Post-compaction size. Must be ``<= history_max_tokens``."""
+
+    def __post_init__(self) -> None:
+        if self.history_target_tokens > self.history_max_tokens:
+            raise ValueError(
+                f"agent.history_target_tokens ({self.history_target_tokens}) must be "
+                f"<= agent.history_max_tokens ({self.history_max_tokens})."
+            )
+
+
+@dataclass
+class LarkChatConfig:
+    """Runtime config loaded from YAML via :meth:`load`."""
+
+    deployment: DeploymentConfig
+    memory_dir: Path
+    model: ModelConfig
+    tools: list[str]
+    skills_dir: Path
+    transcripts_dir: Path
+    agent: AgentLoopConfig
 
 
 @dataclass
@@ -92,25 +143,59 @@ class LarkChatConfig:
             raise FileNotFoundError(f"Config file not found: {path}")
         raw = yaml.safe_load(path.read_text()) or {}
 
-        swerex_raw = raw.get("swerex") or {}
-        auth_token = swerex_raw.get("auth_token") or os.environ.get("LOCAL_ATTACH_AUTH_TOKEN")
-        if not auth_token:
-            raise RuntimeError(
-                "swerex.auth_token is required: set it in the config file or via the "
-                "LOCAL_ATTACH_AUTH_TOKEN env var (must match the --auth-token passed "
-                "to swerex.server inside the container)."
+        deployment_raw = raw.get("deployment") or {}
+        dep_type = deployment_raw.get("type") or "local_attach"
+        if dep_type == "local_attach":
+            swerex_raw = deployment_raw.get("swerex") or {}
+            auth_token = swerex_raw.get("auth_token") or os.environ.get("LOCAL_ATTACH_AUTH_TOKEN")
+            if not auth_token:
+                raise RuntimeError(
+                    "deployment.swerex.auth_token is required for local_attach: set it in the "
+                    "config file or via the LOCAL_ATTACH_AUTH_TOKEN env var (must match the "
+                    "--auth-token passed to swerex.server inside the container)."
+                )
+            if "container" not in deployment_raw:
+                raise RuntimeError("deployment.container is required for local_attach")
+            deployment: DeploymentConfig = LocalAttachDeployment(
+                container=deployment_raw["container"],
+                swerex=SwerexConfig(
+                    host=swerex_raw["host"],
+                    port=int(swerex_raw["port"]),
+                    auth_token=auth_token,
+                ),
+                post_setup_cmd=deployment_raw.get("post_setup_cmd", "cd /workspace"),
+                timeout=float(deployment_raw.get("timeout", 300.0)),
+                startup_timeout=float(deployment_raw.get("startup_timeout", 30.0)),
             )
+            default_memory_dir = _DEFAULT_LOCAL_ATTACH_MEMORY_DIR
+        elif dep_type == "local_native":
+            tool_install_dir = Path(
+                deployment_raw.get("tool_install_dir") or _DEFAULT_LOCAL_NATIVE_TOOL_INSTALL_DIR
+            ).expanduser()
+            deployment = LocalNativeDeployment(
+                startup_timeout=float(deployment_raw.get("startup_timeout", 60.0)),
+                tool_install_dir=tool_install_dir,
+            )
+            default_memory_dir = _DEFAULT_LOCAL_NATIVE_MEMORY_DIR
+        else:
+            raise ValueError(
+                f"deployment.type={dep_type!r} is not supported; expected 'local_attach' or 'local_native'."
+            )
+
+        memory_raw = raw.get("memory_dir")
+        if memory_raw is None:
+            memory_dir = default_memory_dir
+        else:
+            memory_path = Path(memory_raw)
+            # local_attach memory_dir is a container path; don't expand ~ to a host path.
+            memory_dir = memory_path.expanduser() if isinstance(deployment, LocalNativeDeployment) else memory_path
 
         model_raw = raw.get("model") or {}
         api_key = model_raw.get("api_key") or os.environ.get("API_KEY") or "EMPTY"
 
         return cls(
-            container=raw["container"],
-            swerex=SwerexConfig(
-                host=swerex_raw["host"],
-                port=int(swerex_raw["port"]),
-                auth_token=auth_token,
-            ),
+            deployment=deployment,
+            memory_dir=memory_dir,
             model=ModelConfig(
                 base_url=model_raw["base_url"],
                 name=model_raw["name"],
@@ -124,39 +209,134 @@ class LarkChatConfig:
         )
 
     def lark_cli_prefix(self) -> list[str]:
-        """argv prefix routing host-side ``lark-cli`` calls (listener +
-        bot open_id lookup) into the same container the agent uses, so
-        every lark-cli call shares one identity / one auth.
-        """
-        return ["docker", "exec", "-i", self.container]
+        """argv prefix wrapping ``lark-cli`` calls (``docker exec -i <container>``
+        for ``local_attach``, empty for ``local_native``)."""
+        if isinstance(self.deployment, LocalAttachDeployment):
+            return ["docker", "exec", "-i", self.deployment.container]
+        return []
 
     def build_env_config(self) -> AgentEnvConfig:
+        if isinstance(self.deployment, LocalAttachDeployment):
+            d = self.deployment
+            return AgentEnvConfig(
+                deployment={
+                    "type": "local_attach",
+                    "host": d.swerex.host,
+                    "port": d.swerex.port,
+                    "auth_token": d.swerex.auth_token,
+                    "timeout": d.timeout,
+                    "startup_timeout": d.startup_timeout,
+                },
+                env_variables={"NO_COLOR": "1", "TERM": "dumb"},
+                post_setup_cmd=d.post_setup_cmd,
+            )
+
+        native = self.deployment
         return AgentEnvConfig(
             deployment={
-                "type": "local_attach",
-                "host": self.swerex.host,
-                "port": self.swerex.port,
-                "auth_token": self.swerex.auth_token,
-                "timeout": 300.0,
-                "startup_timeout": 30.0,
+                "type": "local_native",
+                "startup_timeout": native.startup_timeout,
             },
             env_variables={"NO_COLOR": "1", "TERM": "dumb"},
-            post_setup_cmd="cd /workspace",
+            tool_install_dir=native.tool_install_dir,
         )
 
 
-def trim_history(messages: list[dict], max_user_turns: int) -> list[dict]:
-    """Keep the system message + the most-recent ``max_user_turns``
-    user-anchored chunks. Trimming respects chunk boundaries so a
-    ``role=tool`` is never separated from its parent ``role=assistant``
-    (the OpenAI API rejects that with a 400 on ``tool_call_id`` linkage).
+def _get_token_counter() -> Any:
+    """``(text) -> int`` token counter; tiktoken ``cl100k_base`` when available,
+    else ``len(text) // 4``. Cached on the function attribute."""
+    cached = getattr(_get_token_counter, "_cached", None)
+    if cached is not None:
+        return cached
+    try:
+        import tiktoken
+
+        enc = tiktoken.get_encoding("cl100k_base")
+
+        def count(text: str) -> int:
+            return len(enc.encode(text or "", disallowed_special=()))
+    except Exception:
+
+        def count(text: str) -> int:
+            return max(1, len(text or "") // 4)
+
+    _get_token_counter._cached = count  # type: ignore[attr-defined]
+    return count
+
+
+def _message_tokens(msg: dict, count: Any) -> int:
+    n = 0
+    content = msg.get("content")
+    if isinstance(content, str):
+        n += count(content)
+    elif isinstance(content, list):
+        for part in content:
+            if isinstance(part, dict):
+                n += count(part.get("text") or "")
+    for tc in msg.get("tool_calls") or []:
+        fn = tc.get("function") or {}
+        n += count(fn.get("name") or "")
+        n += count(fn.get("arguments") or "")
+    if isinstance(msg.get("name"), str):
+        n += count(msg["name"])
+    return n + 4
+
+
+def compact_history(
+    messages: list[dict],
+    *,
+    max_tokens: int,
+    target_tokens: int,
+) -> list[dict]:
+    """Hysteresis history compaction.
+
+    Returns ``messages`` unchanged while total tokens fit under ``max_tokens``;
+    otherwise trims non-system messages in user-anchored chunks down to
+    ``target_tokens``. Chunks are atomic (so a ``role=tool`` is never separated
+    from its parent ``role=assistant`` -- OpenAI rejects that with a 400 on
+    ``tool_call_id`` linkage). The most-recent chunk is always kept.
     """
-    user_idxs = [i for i, m in enumerate(messages) if m.get("role") == "user"]
-    if len(user_idxs) <= max_user_turns:
+    if max_tokens <= 0 or target_tokens <= 0:
         return messages
-    cutoff = user_idxs[-max_user_turns]
-    head = [m for m in messages[:cutoff] if m.get("role") == "system"]
-    return head + messages[cutoff:]
+
+    count = _get_token_counter()
+
+    sys_msgs: list[dict] = []
+    rest: list[dict] = []
+    rest_costs: list[int] = []
+    sys_cost = 0
+    for m in messages:
+        cost = _message_tokens(m, count)
+        if m.get("role") == "system":
+            sys_msgs.append(m)
+            sys_cost += cost
+        else:
+            rest.append(m)
+            rest_costs.append(cost)
+
+    if sys_cost + sum(rest_costs) <= max_tokens:
+        return messages
+
+    user_idxs = [i for i, m in enumerate(rest) if m.get("role") == "user"]
+    if not user_idxs:
+        return messages
+
+    chunks: list[tuple[list[dict], int]] = []
+    for i, start in enumerate(user_idxs):
+        end = user_idxs[i + 1] if i + 1 < len(user_idxs) else len(rest)
+        chunks.append((rest[start:end], sum(rest_costs[start:end])))
+
+    budget = max(0, target_tokens - sys_cost)
+    kept_rev: list[list[dict]] = []
+    used = 0
+    for chunk, cost in reversed(chunks):
+        if not kept_rev or used + cost <= budget:
+            kept_rev.append(chunk)
+            used += cost
+        else:
+            break
+
+    return sys_msgs + [m for chunk in reversed(kept_rev) for m in chunk]
 
 
 async def handle_one_message(
@@ -190,9 +370,15 @@ async def handle_one_message(
     first_turn = not persisted
 
     if first_turn:
-        messages: list[dict] = [{"role": "system", "content": prompts.SYSTEM_PROMPT}]
+        messages: list[dict] = [
+            {"role": "system", "content": prompts.build_system_prompt(memory_dir=config.memory_dir)}
+        ]
     else:
-        messages = trim_history(persisted, max_user_turns=config.agent.max_history_turns)
+        messages = compact_history(
+            persisted,
+            max_tokens=config.agent.history_max_tokens,
+            target_tokens=config.agent.history_target_tokens,
+        )
 
     messages.append(
         {
@@ -287,15 +473,22 @@ async def main() -> None:
     print("Lark chat agent (multi-turn, multi-tool)")
     print("=" * 80)
     print(f"config:        {args.config}")
-    print(f"container:     {config.container}")
-    print(f"swerex:        {config.swerex.host}:{config.swerex.port}")
+    if isinstance(config.deployment, LocalAttachDeployment):
+        print("deployment:    local_attach")
+        print(f"container:     {config.deployment.container}")
+        print(f"swerex:        {config.deployment.swerex.host}:{config.deployment.swerex.port}")
+    else:
+        print("deployment:    local_native (pexpect on host, no container)")
+        print(f"tool install:  {config.deployment.tool_install_dir}")
+    print(f"memory dir:    {config.memory_dir}  (inside runtime bash)")
     print(f"model:         {config.model.name} @ {config.model.base_url}")
     print(f"tools:         {config.tools}")
     print(f"skills dir:    {config.skills_dir} (exists={config.skills_dir.is_dir()})")
     print(f"transcripts:   {config.transcripts_dir}")
 
     lark_cli_prefix = config.lark_cli_prefix()
-    print(f"lark-cli via:  {' '.join(lark_cli_prefix)} lark-cli ...")
+    prefix_str = " ".join(lark_cli_prefix) + " " if lark_cli_prefix else ""
+    print(f"lark-cli via:  {prefix_str}lark-cli ...")
 
     print("\n[1/6] Resolving bot open_id via Lark Open API...")
     bot_open_id = await fetch_bot_open_id(command_prefix=lark_cli_prefix)
@@ -317,7 +510,8 @@ async def main() -> None:
     await env.install_skills(skills_manager)
     print(f"  {len(skills_manager.skills)} skill(s): {[s.name for s in skills_manager.skills]}")
 
-    await env.communicate("mkdir -p /workspace/memory/notes", check="raise")
+    notes_dir = config.memory_dir / "notes"
+    await env.communicate(f"mkdir -p {shlex.quote(str(notes_dir))}", check="raise")
 
     print("\n[4/6] Wiring model client...")
     model = OpenAICompatibleChatModel(

--- a/app/lark_chat/prompts.py
+++ b/app/lark_chat/prompts.py
@@ -1,7 +1,11 @@
 # ruff: noqa: E501
 """System prompt + user-message formatter for the Lark chat agent."""
 
-SYSTEM_PROMPT = """You are an agent embedded in a long-running Lark / Feishu chat. You help the user by calling tools, including `lark-cli` to actually reply to them. You also maintain a persistent picture of the user across conversations via `/workspace/memory/`.
+from __future__ import annotations
+
+from pathlib import Path
+
+_SYSTEM_PROMPT_TEMPLATE = """You are an agent embedded in a long-running Lark / Feishu chat. You help the user by calling tools, including `lark-cli` to actually reply to them. You also maintain a persistent picture of the user across conversations via `{memory_dir}/`.
 
 # Tools and skills
 
@@ -14,32 +18,27 @@ You have a fixed set of tools (see the function-calling schema) and a library of
 # Tool-calling discipline
 
 - An assistant response may emit ONE or more tool calls. Use multiple calls in one response for **independent** read-only steps (e.g. `ls` + `cat` together); for dependent steps, separate responses so you can read each result before deciding the next.
-- One reply per inbound user message. Do the work silently, then send exactly one user-facing reply. No "let me check…" + "done!" pattern.
-- When the user-facing reply has been sent and the request is fully satisfied, call `finish` with a one-sentence summary covering the reply + any memory writes. This yields control back to the user.
-- A plain-text assistant response with no tool call also ends the turn, but `finish` is the preferred explicit signal.
+- One reply per inbound user message. Do the work silently, then send exactly one user-facing reply via `lark-cli`, then call `finish` with a one-sentence summary covering the reply + any memory writes. No "let me check…" + "done!" pattern.
 
-# Long-term memory (`/workspace/memory/`)
+# Long-term memory (`{memory_dir}/`)
 
 Your persistent picture of who the user is and how they like to be helped. Survives container / process restarts and chat-history trimming. Loading and maintaining it is NOT optional — it's how you give the user a continuous, personalized experience instead of starting from scratch every conversation.
 
 File layout:
 
-- `profile.md` — WHO the user is: name, Lark open_id, email, role / team, timezone, primary language, projects, anyone they frequently mention.
-- `preferences.md` — HOW the user wants you to behave: reply language, formatting style, default identity for tools, recurring constraints.
-- `notes/<short-slug>.md` — durable per-topic state: pending tasks, decisions, ongoing efforts. One topic per file, short and digested.
+- `{memory_dir}/profile.md` — WHO the user is: name, Lark open_id, email, role / team, timezone, primary language, projects, anyone they frequently mention.
+- `{memory_dir}/preferences.md` — HOW the user wants you to behave: reply language, formatting style, default identity for tools, recurring constraints.
+- `{memory_dir}/notes/<short-slug>.md` — durable per-topic state: pending tasks, decisions, ongoing efforts. One topic per file, short and digested.
 
-Read every turn before doing any work: `ls /workspace/memory/` + `cat profile.md preferences.md` (and any relevant `notes/<slug>.md`) in ONE batched response — unless the in-context history of THIS conversation already shows the load happened.
+Read every turn before doing any work: `ls {memory_dir}/` + `cat {memory_dir}/profile.md {memory_dir}/preferences.md` (and any relevant `{memory_dir}/notes/<slug>.md`) in ONE batched response — unless the in-context history of THIS conversation already shows the load happened.
 
 Write whenever you learn something durable, BEFORE sending the user-facing reply. Use `str_replace_editor`. Prefer updating existing entries over creating new files; keep `profile.md` and `preferences.md` short and authoritative (overwrite stale facts, don't accumulate). Do NOT mirror the chat transcript — save digested, structured memory only.
 
-# Lark reply formatting (uniform rule — no exceptions)
+# Lark reply formatting
 
-Inline strings to `--text` / `--markdown` are unreliable: models often double-escape newlines (`\\n` ends up as literal characters) and `--text` does not render markdown at all. Use ONE shape for every reply:
+Always use `--markdown`, never `--text` (`--text` does not render markdown). To reply: `lark-cli im +messages-reply --message-id <om_...> --markdown <body> --as bot` (or `+messages-send --chat-id <oc_...>` when there is no inbound message to reply to).
 
-1. Write the full reply body to a fresh file with `str_replace_editor` (real newlines, no `\\n` escapes).
-2. Send via shell command substitution: `lark-cli im +messages-reply --message-id <om_...> --markdown "$(cat <file>)" --as bot` (or `+messages-send --chat-id <oc_...>` when there is no inbound message to reply to).
-
-Mandatory even for a single short line. Never use `--text`. Never inline body content into the `lark-cli` command.
+`<body>` may be inlined for short single-line replies. For multi-line or markdown-heavy replies, first write the body to a fresh file with `str_replace_editor` and pass it via `--markdown "$(cat <file>)"` — inlining multi-line strings into the tool-call args tends to corrupt newlines.
 
 # Identity (`--as bot` vs `--as user`)
 
@@ -65,6 +64,11 @@ You are the **bot**; the human is the **user**.
 """
 
 
+def build_system_prompt(memory_dir: str | Path) -> str:
+    """Render the system prompt template with ``memory_dir`` substituted."""
+    return _SYSTEM_PROMPT_TEMPLATE.format(memory_dir=str(memory_dir).rstrip("/"))
+
+
 def format_user_message(
     *,
     chat_id: str,
@@ -75,12 +79,9 @@ def format_user_message(
     content: str,
     create_time: str | None = None,
 ) -> str:
-    """Format an inbound Lark IM event into the user message text seen by the agent.
-
-    The structured metadata block at the top is what lets the agent
-    call ``lark-cli im +messages-reply --message-id <om_...>`` without
-    needing to extract IDs from prose.
-    """
+    """Format an inbound Lark IM event as the user message the agent sees.
+    The metadata block at the top lets the agent reply without parsing IDs out
+    of prose."""
     meta_lines = [
         "[New Lark message]",
         f"  chat_id:        {chat_id}",
@@ -91,10 +92,4 @@ def format_user_message(
     ]
     if create_time:
         meta_lines.append(f"  create_time_ms: {create_time}")
-    return (
-        "\n".join(meta_lines)
-        + "\n\nContent:\n"
-        + content.rstrip()
-        + "\n\nReply (system prompt's file pattern): write body to a file with `str_replace_editor`, then:\n"
-        f'  lark-cli im +messages-reply --message-id {message_id} --markdown "$(cat <file>)" --as bot\n'
-    )
+    return "\n".join(meta_lines) + "\n\nContent:\n" + content.rstrip() + "\n"

--- a/docs/source/blog/lark_agent.md
+++ b/docs/source/blog/lark_agent.md
@@ -30,11 +30,11 @@ Through `lark-cli`, the agent can operate the Lark surface area your account can
 Two layers of persistence:
 
 - **Per-chat transcript**: a JSON message log per `chat_id`, preserving OpenAI-shaped assistant/tool linkage so multi-turn conversations continue cleanly.
-- **Long-term memory**: model-written files under `/workspace/memory/`, such as `profile.md`, `preferences.md`, and topic notes.
+- **Long-term memory**: model-written files under the configured `memory_dir` (`/workspace/memory/` in the container for the `local_attach` deployment, or `~/.uni-agent/app/lark_chat/memory/` on the host for `local_native`) — `profile.md`, `preferences.md`, and topic notes.
 
 The transcript captures what happened recently in this chat. Memory captures what should remain true tomorrow: your name, timezone, team, projects, language preference, recurring constraints, and the people you often mention.
 
-If history is trimmed, the process restarts, or the container is recreated, memory still lives on the host bind mount. The next Lark message picks up from there.
+If history is trimmed, the process restarts, or the container is recreated, memory still lives where it was written. The next Lark message picks up from there.
 
 ### Bring your own model
 
@@ -51,11 +51,10 @@ Big GPU box? Run the bigger model. Laptop demo? Point it at a smaller endpoint. 
 
 ---
 
-## Quickstart
+## Step 0: Prerequisites and dependencies
 
-### Step 0: Prerequisites and dependencies
-
-- macOS or Linux with Docker (Recommended)
+- macOS or Linux
+- Docker (used by the recommended `local_attach` deployment; not strictly required if you choose `local_native`)
 - An OpenAI-compatible chat-completions endpoint
 - A Lark/Feishu app in the [Lark Open Platform](https://open.feishu.cn)
 
@@ -68,11 +67,20 @@ cd uni-agent
 python3 -m venv .venv
 source .venv/bin/activate
 
-pip install swe-rex pydantic loguru orjson aiohttp openai
+pip install swe-rex pydantic loguru orjson aiohttp openai pexpect pyyaml
 ```
 
+## Step 1: Create a Lark bot
 
-### Step 1: Start the sandbox and authenticate `lark-cli`
+**Create a Lark bot and authorize it.**
+
+- `npm install -g @larksuite/cli` to install the CLI; `lark-cli --version` to verify.
+- `lark-cli config init --new`, creates a new app in the [Lark Open Platform](https://open.feishu.cn) (browser flow, captures `app_id` / `app_secret`).
+- `lark-cli auth login`, OAuth device flow that binds the app to your Feishu account and grants its scopes.
+
+The agent acts as this bot; its reach is exactly the scopes you authorized.
+
+**Deploy in a sandbox (Optional).** Running LLM-generated shell directly against your host is risky on a personal machine. For isolation, spin up a Docker container first and run the same setup as above inside it (plus a `swerex.server` so the host process can attach over HTTP):
 
 ```bash
 docker rm -f lark-chat-sandbox 2>/dev/null
@@ -92,19 +100,18 @@ docker exec -d lark-chat-sandbox bash -lc '
   python3 -m swerex.server --host 0.0.0.0 --port 18000 --auth-token CHANGEME'
 ```
 
-The container owns the shell runtime, `lark-cli` authentication, skills, and `swerex.server`. The host process talks to it through the local attach endpoint. `CHANGEME` can be any token as long as it matches the config below.
+`CHANGEME` can be any string; just match it in Step 2.
 
-### Step 2: Configure the bot
+## Step 2: Configure
 
-Edit `app/lark_chat/config.yaml` (the default config the app reads on startup). A working example:
+Open `app/lark_chat/config.local_native.yaml`, the default config:
 
 ```yaml
-container: lark-chat-sandbox
+deployment:
+  type: local_native
+  startup_timeout: 60.0
 
-swerex:
-  host: http://127.0.0.1
-  port: 18000
-  auth_token: CHANGEME
+memory_dir: ~/.uni-agent/app/lark_chat/memory
 
 model:
   base_url: http://localhost:8000/v1
@@ -123,26 +130,60 @@ tools:
   - str_replace_editor
   - finish
 
-skills_dir: ~/.uni-agent/skills
+skills_dir: ~/.agents/skills
 transcripts_dir: ~/.uni-agent/app/lark_chat/transcripts
 
 agent:
   action_timeout: 60
   max_steps_per_turn: 20
-  max_history_turns: 30
+  history_max_tokens: 128000      # compaction trigger
+  history_target_tokens: 32000    # post-compaction size
 ```
 
-`container` and `swerex.auth_token` must match what Step 1 used. Everything else has sensible defaults; tweak `model.base_url` / `model.name` to point at your endpoint.
+What each section does:
 
-### Step 3: Run the bot
+- `deployment`: where the agent's bash session runs. `local_native` runs in-process via `pexpect`; `startup_timeout` caps boot.
+- `memory_dir`: long-term notes the agent writes (profile, preferences, topic memos). Survives restarts.
+- `model`: any OpenAI-compatible chat-completions endpoint. Two common setups:
+  - **Self-hosted**: serve a model with vLLM or SGLang and point `base_url` at it (`api_key` can be any non-empty string).
+  - **Hosted API**: e.g. Doubao Seed on Volc Ark, set `base_url: https://ark.cn-beijing.volces.com/api/v3`, `name: doubao-seed-1-6-250615` (or your model id), `api_key: <ARK_API_KEY>`.
+- `sampling_params`: forwarded to the chat-completions call.
+- `tools`: built-in tool wrappers exposed to the model.
+- `skills_dir`: where `SkillsManager` finds skill packs (`lark-im`, `lark-base`, …).
+- `transcripts_dir`: per-chat JSON trajectory logs (model messages + tool calls + results).
+- `agent`: per-action timeout, max model steps per Lark turn, and a hysteresis-style history budget — `history_max_tokens` is the compaction trigger, `history_target_tokens` the size we compact back down to. While we stay under the trigger, the history is forwarded unchanged so the model server's prefix KV cache hits across turns.
+
+**For `local_attach`**, edit `config.local_attach.yaml` and override just the `deployment` block + `memory_dir`; everything else stays the same:
+
+```yaml
+deployment:
+  type: local_attach
+  container: lark-chat-sandbox       # match docker run --name
+  swerex:
+    host: http://127.0.0.1
+    port: 18000
+    auth_token: CHANGEME             # match swerex.server --auth-token
+  post_setup_cmd: cd /workspace
+
+memory_dir: /workspace/memory        # container path; bind-mount /workspace to a host dir to persist memory across container restarts.
+```
+
+## Step 3: Run
 
 ```bash
 python -m app.lark_chat.main
 ```
 
-(Pass `--config <path>` if you keep your config somewhere other than `app/lark_chat/config.yaml`.)
+That picks up `config.local_native.yaml`. For `local_attach`, pass the config explicitly:
 
-Startup resolves the bot `open_id`, starts the sandbox env, installs tools and skills, wires the model client, starts the Lark event listener, and enters the chat loop. When you see this line, it is live:
+```bash
+LOCAL_ATTACH_AUTH_TOKEN=CHANGEME \
+  python -m app.lark_chat.main --config app/lark_chat/config.local_attach.yaml
+```
+
+(`LOCAL_ATTACH_AUTH_TOKEN` is only needed when `deployment.swerex.auth_token` is `null` in the YAML.)
+
+You're live when you see:
 
 ```text
 Entering chat loop. Send a Lark message to the bot.

--- a/examples/lark/demo.py
+++ b/examples/lark/demo.py
@@ -32,7 +32,7 @@ Prereqs (on the host, one-time, both modes)
 ------------------------------------------------------------------------
 
 1. (Optional, for skills) ``npx skills add larksuite/cli -y -g`` or
-   manually copy any ``<name>/SKILL.md`` packs under ``~/.uni-agent/skills/``.
+   manually copy any ``<name>/SKILL.md`` packs under ``~/.agents/skills/``.
    Override the directory with ``LARK_SKILLS_DIR=...``.
 2. An OpenAI-compatible chat completion endpoint serving a tool-calling
    model (e.g. vLLM hosting Qwen3-Coder). Defaults to ``localhost:8000``.
@@ -116,7 +116,7 @@ model_base_url = os.getenv("BASE_URL", "http://localhost:8000/v1")
 model_api_key = os.getenv("API_KEY", "EMPTY")
 model_name = os.getenv("MODEL_NAME", "Qwen/Qwen3.6-35B-A3B")
 
-skills_dir = Path(os.getenv("LARK_SKILLS_DIR", str(Path.home() / ".uni-agent" / "skills")))
+skills_dir = Path(os.getenv("LARK_SKILLS_DIR", str(Path.home() / ".agents" / "skills")))
 
 # --- deployment ------------------------------------------------------------
 # Pick where the bash session + tools live:

--- a/uni_agent/skills/manager.py
+++ b/uni_agent/skills/manager.py
@@ -11,7 +11,7 @@ Mirrors Claude Code / Qwen Code's progressive disclosure model:
   alongside ``SKILL.md`` and read lazily by the model.
 
 Skills are fully **user-managed**: drop the directories you want exposed
-into a single host-side dir (e.g. ``~/.uni-agent/skills/``) and point
+into a single host-side dir (e.g. ``~/.agents/skills/``) and point
 ``SkillsManagerConfig.skills_dir`` at it. Tools themselves bundle no
 skills. Path resolution and per-deployment transfer are owned by
 ``AgentEnv`` (see ``env.install_skills``): host deployments keep skills
@@ -35,7 +35,7 @@ class SkillsManagerConfig(BaseModel):
         description=(
             "Host-side directory holding ``<skill-name>/SKILL.md`` subdirs. "
             "All discovered skills come from here -- tools ship no skills "
-            "of their own. ``~`` is expanded. Example: ``~/.uni-agent/skills``."
+            "of their own. ``~`` is expanded. Example: ``~/.agents/skills``."
         ),
     )
     model_config = ConfigDict(extra="forbid")


### PR DESCRIPTION
### What does this PR do?

Follow-up to #41. Tightens the Lark chat agent along three axes: deployment model, history window management, and documentation.

**1. New `local_native` deployment alongside `local_attach`**

- `local_native`: bash session runs directly on the host via `pexpect`. No docker, no `swerex.server`, no host/container identity drift — the host's `lark-cli` is reused for both the event listener and the agent's replies. Lowest-friction option, and the new default (`config.local_native.yaml` is loaded when `--config` is omitted).
- `local_attach`: preserves the previous behavior (attach to a user-managed docker running `swerex.server`). Documented as the **recommended option for personal machines**, since `local_native` hands the agent a full host shell.
- The original `config.yaml` is split into `config.local_native.yaml` / `config.local_attach.yaml`, each with its own `memory_dir` default.
- `prompts.py` now uses a template; the memory path is injected at runtime via `build_system_prompt(memory_dir=...)`.

**2. History window becomes a hysteresis-style token budget**

Replaces the old `max_history_turns`:

- `agent.history_max_tokens` (default `128000`): compaction trigger. While the history fits under this, `compact_history` returns it unchanged so the model server's prefix KV cache stays warm across turns.
- `agent.history_target_tokens` (default `32000`): post-compaction size. The `max − target` gap is the headroom that amortizes a single compaction-turn cache miss across many subsequent cache-hit turns.
- Compaction respects user-anchored chunks (a `role=tool` message is never separated from its parent `role=assistant`) and always keeps the most-recent chunk.
- Token counting prefers `tiktoken.cl100k_base`, falling back to `len(text) // 4` when tiktoken is unavailable.

**3. Tighter prompt + reply discipline**

- Reworked the system prompt's "Tool-calling discipline" section: every turn must end with one `lark-cli` send/reply followed by `finish`. Removed the loophole that allowed a plain-text response to silently end the turn.
- Added a defensive warning log in `main.py`: if a turn finishes without observing any `lark-cli im +messages-send/+messages-reply` tool call, we print a warning so the "agent wrote text but the Lark user got nothing" failure mode is loud rather than silent.

**4. Misc.**

- Default `skills_dir` changed from `~/.uni-agent/skills` to `~/.agents/skills` (updated in `skills/manager.py`, `demo.py`, README, and the blog).
- `conversation.py` → `transcript.py`, to match the existing `TranscriptStore` naming.
- Quickstart in both `app/lark_chat/README.md` and `docs/source/blog/lark_agent.md` rewritten as a linear flow: create bot + auth → (optional) docker sandbox → configure → run. Both consistently introduce `local_native` first and present `local_attach` as a security overlay on top.

### Checklist Before Starting

- [x] PR title follows `[{modules}] {type}: {description}`
- [ ] Related issue / PR: follow-up to #41

### Test

- `pre-commit run --all-files` clean (ruff / ruff format / mypy / py-compile).
- Locally launched `local_native` via `python -m app.lark_chat.main`, sent a message to the bot, observed one full turn ending in `lark-cli im +messages-reply` followed by `finish`.
- Multi-turn conversation: prompt-token count stays under `history_target_tokens` in steady state; crossing `history_max_tokens` triggers one compaction, after which the budget settles back near the target.

### API and Usage Example

```bash
# default (local_native)
python -m app.lark_chat.main

# explicit local_attach (start your own docker running swerex.server first)
python -m app.lark_chat.main --config app/lark_chat/config.local_attach.yaml
```

History budget (present in both configs):

```yaml
agent:
  history_max_tokens: 128000      # compaction trigger
  history_target_tokens: 32000    # post-compaction size
```