### PR TITLE
[interaction] fix: use safe "{}" template for logger calls that embed exception or LLM content

### DIFF
--- a/tests/interaction/test_brace_safe_logging.py
+++ b/tests/interaction/test_brace_safe_logging.py
@@ -1,0 +1,68 @@
+"""Regression test for brace-bearing error messages in loguru-style logging.
+
+`AgentInteraction` previously passed exception reprs and LLM-generated text
+directly into the *template* arg of `self.logger.error(...)` via f-strings.
+Loguru runs `.format()` on the final rendered string, so any unbalanced
+'{' / '}' in the substituted content (typical of regex reprs, JSON, dict
+literals, code snippets) makes the log call itself raise
+`ValueError("Single '}' encountered in format string")` — which then
+cascades into the rollout-worker outer except handlers (also f-string-based)
+and kills the worker.
+
+The fix is to use the positional-arg pattern: `logger.error("{}", msg)`.
+The template field is the literal `"{}"`, which is always safe, and the
+brace-prone content rides in the positional argument and is NOT re-parsed
+by `.format()`.
+
+This file covers the contract that pattern relies on.
+"""
+
+from __future__ import annotations
+
+import pytest
+from loguru import logger
+
+# Real-world brace-bearing strings we have actually seen in production
+# rollout failures on Qwen3-235B SWE-bench training (2026-05).
+_BRACE_MESSAGES = [
+    # regex repr from a config validation failure
+    "ValueError: searcher_re must be a compiled re: re.compile('\\{action\\}')",
+    # LLM output snippet with JSON
+    'Fail to parse: {"thought": "I will edit',  # unbalanced — worst case
+    # exception repr containing a dict literal
+    "ConfigError: got {'tool': 'bash', 'args': {'cmd': 'ls'",
+    # bash heredoc preview
+    "Model Output: ```bash\ncat <<EOF\n{anything}",
+    # Python f-string in code output
+    "RuntimeError: f'hello {name}' is invalid here",
+]
+
+
+@pytest.mark.parametrize("brace_msg", _BRACE_MESSAGES)
+def test_safe_template_does_not_raise_on_brace_bearing_message(brace_msg: str) -> None:
+    """`logger.error("{}", msg)` must NOT raise when `msg` contains
+    unbalanced or stray '{' / '}'. This is the pattern the patched
+    handlers in `uni_agent/interaction/interaction.py` use."""
+    # Must not raise:
+    logger.error("{}", brace_msg)
+    logger.critical("{}", brace_msg)
+
+
+def test_safe_template_with_opt_exception_does_not_raise() -> None:
+    """The `run()` outer except handler uses
+    `logger.opt(exception=True).critical("{}", msg)` to also dump the
+    stack trace. Verify that chained `.opt(exception=True)` does not
+    break the brace-safety contract."""
+    brace_msg = "[step1] unknown_error: KeyError: '{routed_experts}' missing"
+    try:
+        raise KeyError("'{routed_experts}'")
+    except KeyError:
+        logger.opt(exception=True).critical("{}", brace_msg)
+
+
+def test_safe_template_with_bound_logger_does_not_raise() -> None:
+    """`AgentInteraction.logger` is a `logger.bind(name=..., run_id=...)`
+    so the safe-template contract must hold across bound loggers too."""
+    bound = logger.bind(name="test-interaction", run_id="brace-safety-check")
+    bound.error("{}", "ValueError: bad regex re.compile('{action}')")
+    bound.critical("{}", '{"json": "{nested"')

--- a/tests/interaction/test_brace_safe_logging.py
+++ b/tests/interaction/test_brace_safe_logging.py
@@ -1,58 +1,26 @@
-"""Regression test for brace-bearing error messages in loguru-style logging.
-
-`AgentInteraction` previously passed exception reprs and LLM-generated text
-directly into the *template* arg of `self.logger.error(...)` via f-strings.
-Loguru runs `.format()` on the final rendered string, so any unbalanced
-'{' / '}' in the substituted content (typical of regex reprs, JSON, dict
-literals, code snippets) makes the log call itself raise
-`ValueError("Single '}' encountered in format string")` — which then
-cascades into the rollout-worker outer except handlers (also f-string-based)
-and kills the worker.
-
-The fix is to use the positional-arg pattern: `logger.error("{}", msg)`.
-The template field is the literal `"{}"`, which is always safe, and the
-brace-prone content rides in the positional argument and is NOT re-parsed
-by `.format()`.
-
-This file covers the contract that pattern relies on.
-"""
+"""Regression tests for brace-safe loguru logging."""
 
 from __future__ import annotations
 
 import pytest
 from loguru import logger
 
-# Real-world brace-bearing strings we have actually seen in production
-# rollout failures on Qwen3-235B SWE-bench training (2026-05).
 _BRACE_MESSAGES = [
-    # regex repr from a config validation failure
     "ValueError: searcher_re must be a compiled re: re.compile('\\{action\\}')",
-    # LLM output snippet with JSON
-    'Fail to parse: {"thought": "I will edit',  # unbalanced — worst case
-    # exception repr containing a dict literal
+    'Fail to parse: {"thought": "I will edit',
     "ConfigError: got {'tool': 'bash', 'args': {'cmd': 'ls'",
-    # bash heredoc preview
     "Model Output: ```bash\ncat <<EOF\n{anything}",
-    # Python f-string in code output
     "RuntimeError: f'hello {name}' is invalid here",
 ]
 
 
 @pytest.mark.parametrize("brace_msg", _BRACE_MESSAGES)
 def test_safe_template_does_not_raise_on_brace_bearing_message(brace_msg: str) -> None:
-    """`logger.error("{}", msg)` must NOT raise when `msg` contains
-    unbalanced or stray '{' / '}'. This is the pattern the patched
-    handlers in `uni_agent/interaction/interaction.py` use."""
-    # Must not raise:
     logger.error("{}", brace_msg)
     logger.critical("{}", brace_msg)
 
 
 def test_safe_template_with_opt_exception_does_not_raise() -> None:
-    """The `run()` outer except handler uses
-    `logger.opt(exception=True).critical("{}", msg)` to also dump the
-    stack trace. Verify that chained `.opt(exception=True)` does not
-    break the brace-safety contract."""
     brace_msg = "[step1] unknown_error: KeyError: '{routed_experts}' missing"
     try:
         raise KeyError("'{routed_experts}'")
@@ -61,8 +29,6 @@ def test_safe_template_with_opt_exception_does_not_raise() -> None:
 
 
 def test_safe_template_with_bound_logger_does_not_raise() -> None:
-    """`AgentInteraction.logger` is a `logger.bind(name=..., run_id=...)`
-    so the safe-template contract must hold across bound loggers too."""
     bound = logger.bind(name="test-interaction", run_id="brace-safety-check")
     bound.error("{}", "ValueError: bad regex re.compile('{action}')")
     bound.critical("{}", '{"json": "{nested"')

--- a/uni_agent/interaction/interaction.py
+++ b/uni_agent/interaction/interaction.py
@@ -141,20 +141,6 @@ class AgentInteraction:
             )
             self.logger.debug(f"Model Output:\n{model_output}")
         except MaxTokenExceededError as e:
-            # Loguru re-runs .format() on the final rendered string. If we
-            # f-string an exception repr that contains '{' or '}' (a regex
-            # like re.compile('{...}'), a config dict, JSON, code) into the
-            # template field, the log call itself raises
-            # ValueError("Single '}' encountered in format string"). The
-            # outer error handlers in run() and in the agent_loop owner
-            # also do f-string logging, so a single brace cascades into
-            # killing the rollout worker. Use logger.error("{}", msg) so
-            # the template is the literal "{}" (always safe) and the
-            # brace-prone content is a positional arg that is NOT
-            # re-parsed by .format(). Include step_idx + cache lengths so
-            # token-limit failures can be located (step 1 = initial
-            # prompt+tools+system already exceeded max_model_len before
-            # generate even ran).
             _msg = (
                 f"[step{step_idx}] MaxTokenExceededError: "
                 f"response_mask_len_before={len(self.rollout_cache.get('response_mask', []))} "
@@ -203,10 +189,6 @@ class AgentInteraction:
             self.rollout_cache = await self.model.append_messages_to_rollout_cache(error_msgs, self.rollout_cache)
             step_output.exit_reason = "format_error"
             model_output_preview = "\n".join(model_output.splitlines()[:20])
-            # model_output is LLM-generated and routinely contains literal
-            # '{' / '}' (JSON, dict literals, code snippets). Use the safe
-            # "{}" template pattern; see the MaxTokenExceededError handler
-            # above for the full loguru gotcha explanation.
             _msg = (
                 f"Fail to parse thought and action from model output.\n"
                 f"Error Message: {str(e)}\n"
@@ -366,13 +348,6 @@ class AgentInteraction:
                     break
             except Exception as e:
                 # this should not happen, if it happens, we should fix the code
-                # Same loguru brace-bearing-message gotcha as the per-step
-                # handlers above: the exception repr can contain '{' / '}'
-                # (stringified config, JSON, regex) and re-formatting via an
-                # f-string in the template field crashes the log call itself.
-                # Use the "{}" positional template; also log type + state to
-                # disambiguate root causes (Modal swerex timeout, tokenizer
-                # corruption, transient HTTP, ...).
                 _msg = (
                     f"[step{step_idx}] unknown_error: {type(e).__name__}: {e} "
                     f"response_mask_len_before={len(self.rollout_cache.get('response_mask', []))} "

--- a/uni_agent/interaction/interaction.py
+++ b/uni_agent/interaction/interaction.py
@@ -141,7 +141,27 @@ class AgentInteraction:
             )
             self.logger.debug(f"Model Output:\n{model_output}")
         except MaxTokenExceededError as e:
-            self.logger.error(str(e))
+            # Loguru re-runs .format() on the final rendered string. If we
+            # f-string an exception repr that contains '{' or '}' (a regex
+            # like re.compile('{...}'), a config dict, JSON, code) into the
+            # template field, the log call itself raises
+            # ValueError("Single '}' encountered in format string"). The
+            # outer error handlers in run() and in the agent_loop owner
+            # also do f-string logging, so a single brace cascades into
+            # killing the rollout worker. Use logger.error("{}", msg) so
+            # the template is the literal "{}" (always safe) and the
+            # brace-prone content is a positional arg that is NOT
+            # re-parsed by .format(). Include step_idx + cache lengths so
+            # token-limit failures can be located (step 1 = initial
+            # prompt+tools+system already exceeded max_model_len before
+            # generate even ran).
+            _msg = (
+                f"[step{step_idx}] MaxTokenExceededError: "
+                f"response_mask_len_before={len(self.rollout_cache.get('response_mask', []))} "
+                f"prompt_ids_len={len(self.rollout_cache.get('prompt_ids', []))} "
+                f"detail: {str(e)}"
+            )
+            self.logger.error("{}", _msg)
             step_output.exit_reason = "token_limit"
             step_output.done = True
             return step_output
@@ -183,11 +203,16 @@ class AgentInteraction:
             self.rollout_cache = await self.model.append_messages_to_rollout_cache(error_msgs, self.rollout_cache)
             step_output.exit_reason = "format_error"
             model_output_preview = "\n".join(model_output.splitlines()[:20])
-            self.logger.error(
+            # model_output is LLM-generated and routinely contains literal
+            # '{' / '}' (JSON, dict literals, code snippets). Use the safe
+            # "{}" template pattern; see the MaxTokenExceededError handler
+            # above for the full loguru gotcha explanation.
+            _msg = (
                 f"Fail to parse thought and action from model output.\n"
                 f"Error Message: {str(e)}\n"
                 f"Model Output (first 20 lines): {model_output_preview}"
             )
+            self.logger.error("{}", _msg)
             return step_output
 
         step_output.thought = content
@@ -341,7 +366,19 @@ class AgentInteraction:
                     break
             except Exception as e:
                 # this should not happen, if it happens, we should fix the code
-                self.logger.critical(f"Exit due to unknown error: {str(e)}")
+                # Same loguru brace-bearing-message gotcha as the per-step
+                # handlers above: the exception repr can contain '{' / '}'
+                # (stringified config, JSON, regex) and re-formatting via an
+                # f-string in the template field crashes the log call itself.
+                # Use the "{}" positional template; also log type + state to
+                # disambiguate root causes (Modal swerex timeout, tokenizer
+                # corruption, transient HTTP, ...).
+                _msg = (
+                    f"[step{step_idx}] unknown_error: {type(e).__name__}: {e} "
+                    f"response_mask_len_before={len(self.rollout_cache.get('response_mask', []))} "
+                    f"prompt_ids_len={len(self.rollout_cache.get('prompt_ids', []))}"
+                )
+                self.logger.opt(exception=True).critical("{}", _msg)
                 step_output = StepOutput(step_idx=step_idx, exit_reason="unknown_error")
                 self.trajectory.append(step_output)
                 break


### PR DESCRIPTION
### What does this PR do?

`AgentInteraction` previously passed exception reprs and LLM-generated
text directly into the *template* field of `self.logger.error(...)`
via f-string interpolation. When the substituted content contains
stray `{` or `}` — common in regex reprs (`re.compile('{...}')`),
JSON, dict literals, bash heredocs, code snippets — the log call
itself can raise `ValueError("Single '}' encountered in format
string")`. The outer exception handler in `run()` also used
f-string-templated logging, so the resulting cascade killed the
rollout worker for what should have been a routine recoverable
trajectory failure.

Apply the safe positional-arg pattern at three sites in
`uni_agent/interaction/interaction.py`:

- `MaxTokenExceededError` handler in `step()`
- `FunctionCallFormatError` handler in `step()` (LLM `model_output` is
  routinely brace-bearing)
- generic `Exception` handler in `run()`

Pattern: precompute the message string, then call
`logger.error("{}", precomputed)` — the template is the literal `"{}"`
(always safe), and the brace-prone content rides in the positional
arg, which is not re-parsed by `.format()`.

While there, also widen the diagnostic info in each handler — the
exception type, the `response_mask` length at failure, and the
`prompt_ids` length. This makes it possible to distinguish a step-1
lethal failure (initial prompt + tools + system already exceeded
`max_model_len` before `generate` even ran) from a later-step
recoverable failure, which was previously indistinguishable from the
bare exception string.

### Checklist Before Starting

- [x] Search for similar PRs/issues:
  - `gh pr list --repo verl-project/uni-agent --state open --search "loguru"` → none
  - `gh issue list --repo verl-project/uni-agent --search "ValueError format string"` → none
  - `gh pr list --repo verl-project/uni-agent --state all --search "interaction logger"` → none touching the same handlers
- [x] Format the PR title as `[interaction] fix: ...`

### Test

Added `tests/interaction/test_brace_safe_logging.py` with 7 cases:

- 5 parametrized cases over real brace-bearing message patterns seen in production: regex repr, unbalanced JSON, dict literal, bash heredoc preview, Python f-string in code
- `.opt(exception=True).critical("{}", msg)` chained variant (matches the pattern used in the `run()` outer handler)
- `logger.bind(name=..., run_id=...)`-backed variant (matches `AgentInteraction.logger`)

```bash
pytest tests/interaction/test_brace_safe_logging.py -v
# 7 passed in 0.07s
```

### API and Usage Example

No public API change. No new env var, no new config knob. Existing callers and log output structure are unchanged; only the *template* field of the three patched `self.logger.error(...)` / `self.logger.critical(...)` sites differs.

### Design & Code Changes

- **`uni_agent/interaction/interaction.py`** — 3 handler sites switched to `logger.<level>("{}", precomputed_msg)` pattern. Each precomputed message now also carries `step_idx`, exception type, `response_mask_len_before`, and `prompt_ids_len`.
- **`tests/interaction/test_brace_safe_logging.py`** — new file, 7 test cases (~3 KB).

### Checklist Before Submitting

- [x] Read the Contribute Guide
- [x] `pre-commit run --files uni_agent/interaction/interaction.py tests/interaction/test_brace_safe_logging.py` — all hooks passed (ruff, ruff format, mypy, compile-all)
- [x] Unit tests added (`tests/interaction/test_brace_safe_logging.py`)
- [x] AI assistance was used (Claude Code); the submitting human (@aoshen02) reviewed every changed line and ran the test suite.
- [x] Not duplicating any open PR; not depending on any other PR.