### PR TITLE
[misc] chore: sync latest code base

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ If you find the project helpful, please cite:
   title        = {Uni-Agent: Build, Run, and Train Agents at Scale},
   year         = {2026},
   howpublished = {\url{https://github.com/verl-project/uni-agent}},
-  note         = {GitHub repository.},
+  note         = {GitHub repository. Supervisor: Xibin Wu and Juntao Li},
   urldate      = {2026-03-27}
 }
 ```

--- a/examples/agent_interaction/run_infer.sh
+++ b/examples/agent_interaction/run_infer.sh
@@ -3,10 +3,10 @@ ray job submit --no-wait \
     --runtime-env $RAY_DATA_HOME/data/swe_agent/runtime_env.yaml \
     --working-dir . \
     -- python3 examples/agent_interaction/parallel_infer.py \
-    --data-path $RAY_DATA_HOME/data/swe_agent/swe_bench_verified.parquet \
+    --data-path $RAY_DATA_HOME/data/swe_agent/swe_bench_verified_modal.parquet \
     --model-path $RAY_DATA_HOME/models/Qwen3-Coder-30B-A3B-Instruct \
-    --agent-config-path examples/agent_interaction/agent_config.yaml \
-    --nnodes 1 \
+    --agent-config-path examples/agent_interaction/agent_config_modal.yaml \
+    --nnodes 8 --response-length 131072 --temperature 1.0 --top-p 0.95 --n 16 \
 
 
 # terminal bench v2

--- a/examples/data_preprocess/swe_rebench.py
+++ b/examples/data_preprocess/swe_rebench.py
@@ -153,9 +153,9 @@ def build_swe_rebench():
         }
         return sample
 
-    data_source = "nebius/SWE-rebench"
+    data_source = "dyyyyyyyy/swe-rebench-filtered"
     print(f"Loading the {data_source} dataset from huggingface...", flush=True)
-    dataset = load_dataset(data_source, split="filtered")
+    dataset = load_dataset(data_source, split="train")
     dataset = dataset.map(process_swe_rebench, remove_columns=dataset.column_names)
     dataset = dataset.filter(lambda ex: ex["extra_info"]["tools_kwargs"]["env"]["deployment"]["image"] is not None)
     return dataset

--- a/examples/data_preprocess/swe_rebench.py
+++ b/examples/data_preprocess/swe_rebench.py
@@ -102,6 +102,8 @@ A successful resolution means:
 - Edge cases are properly handled
 """.strip()
 
+SKIP_INSTANCES = []
+
 
 def build_swe_rebench():
     def process_swe_rebench(example):
@@ -123,13 +125,11 @@ def build_swe_rebench():
             "test_cmd": example["install_config"]["test_cmd"],
         }
         instance_id = metadata["instance_id"]
-        image_name = get_image_name(dataset_id, instance_id)
+        image_name = get_image_name(dataset_id, instance_id) if instance_id not in SKIP_INSTANCES else None
         reset_cmds = [
             "git tag -d $(git tag -l) || true",
             "git reflog expire --expire=now --all || true",
             "git gc --prune=now || true",
-            f"git checkout {metadata['base_commit']} || true",
-            "git clean -fdq || true",
         ]
         reset_script = " && ".join(reset_cmds)
         sample = {
@@ -153,10 +153,11 @@ def build_swe_rebench():
         }
         return sample
 
-    data_source = "dyyyyyyyy/swe-rebench-filtered"
+    data_source = "nebius/SWE-rebench"
     print(f"Loading the {data_source} dataset from huggingface...", flush=True)
-    dataset = load_dataset(data_source, split="train")
+    dataset = load_dataset(data_source, split="filtered")
     dataset = dataset.map(process_swe_rebench, remove_columns=dataset.column_names)
+    dataset = dataset.filter(lambda ex: ex["extra_info"]["tools_kwargs"]["env"]["deployment"]["image"] is not None)
     return dataset
 
 
@@ -167,4 +168,5 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     sbv_dataset = build_swe_rebench()
+    print(f"Capped to {len(sbv_dataset)} instances", flush=True)
     sbv_dataset.to_parquet(f"{args.local_save_dir}/swe_rebench_filtered_{impl}.parquet")

--- a/examples/data_preprocess/swe_rebench_v2.py
+++ b/examples/data_preprocess/swe_rebench_v2.py
@@ -198,6 +198,7 @@ def build_swe_rebench_v2(languages: set[str] | None, max_instances: int | None):
         print(f"Capped to {len(dataset)} instances", flush=True)
 
     dataset = dataset.map(process, remove_columns=dataset.column_names)
+    dataset = dataset.filter(lambda ex: ex["extra_info"]["tools_kwargs"]["env"]["deployment"]["image"] is not None)
     return dataset
 
 

--- a/uni_agent/agent_loop.py
+++ b/uni_agent/agent_loop.py
@@ -90,17 +90,16 @@ class UniAgentLoop(AgentLoopBase):
         else:
             self.reward_spec = None
 
-        add_file_handler(self.output_dir / "run.log", self.run_id)
-
-        self.logger.info(f"model name: {self.config.actor_rollout_ref.model.path}")
-        self.logger.info(f"sampling_params: {sampling_params}")
-        self.logger.info(f"environment config: {config_dict['env']}")
-        self.logger.info(f"tools config: {config_dict['tools']}")
-        self.logger.info(f"interaction config: {config_dict['interaction']}")
-        self.logger.info(f"mask_abnormal_exit_traj: {self.mask_abnormal_exit_traj}")
-        self.logger.info(f"output_dir: {self.output_dir}")
-
         async with self._semaphore:
+            add_file_handler(self.output_dir / "run.log", self.run_id)
+
+            self.logger.info(f"model name: {self.config.actor_rollout_ref.model.path}")
+            self.logger.info(f"sampling_params: {sampling_params}")
+            self.logger.info(f"environment config: {config_dict['env']}")
+            self.logger.info(f"tools config: {config_dict['tools']}")
+            self.logger.info(f"interaction config: {config_dict['interaction']}")
+            self.logger.info(f"mask_abnormal_exit_traj: {self.mask_abnormal_exit_traj}")
+            self.logger.info(f"output_dir: {self.output_dir}")
             try:
                 await self.env.start()
 

--- a/uni_agent/reward/swe_rebench.py
+++ b/uni_agent/reward/swe_rebench.py
@@ -29,7 +29,10 @@ def _make_eval_script_list(instance, specs, env_name, repo_directory, base_commi
     HEREDOC_DELIMITER = "EOF_114329324912"
     test_files = get_modified_files(test_patch)
     # Reset test files to the state they should be in before the patch.
-    reset_tests_command = f"git checkout {base_commit} {' '.join(test_files)}"
+    if test_files:
+        reset_tests_command = f"git checkout {base_commit} {' '.join(test_files)}"
+    else:
+        reset_tests_command = "echo 'skip reset'"
     apply_test_patch_command = f"git apply -v - <<'{HEREDOC_DELIMITER}'\n{test_patch}\n{HEREDOC_DELIMITER}"
 
     test_cmd = specs["test_cmd"]


### PR DESCRIPTION
## Summary

Minor data-pipeline / eval fixes and housekeeping for the SWE-agent examples.

### Data preprocessing
- `swe_rebench.py`: add a `SKIP_INSTANCES` hook and drop instances without an image; remove the `git checkout <base_commit>` / `git clean` steps from the per-instance reset; print the final instance count.
- `swe_rebench_v2.py`: filter out instances whose deployment image is `None`.

### Eval / reward
- `reward/swe_rebench.py`: skip the test-file reset when a task has no modified test files (avoids running `git checkout <commit>` with no paths).

### Agent loop
- `agent_loop.py`: move the per-run log handler and config logging inside the concurrency semaphore.

### Misc
- `run_infer.sh`: point the example at the modal parquet/config and bump `--nnodes` + sampling params.
- `README.md`: add supervisor note to the citation.
- Bump the `verl` submodule.