### PR TITLE
[core] fix: replace per-run log sinks with single dispatch sink to fix leaks and HDFS stalls

### DIFF
--- a/uni_agent/agent_loop.py
+++ b/uni_agent/agent_loop.py
@@ -8,7 +8,7 @@ from typing import Any
 import numpy as np
 import yaml
 
-from uni_agent.async_logging import add_file_handler, get_logger
+from uni_agent.async_logging import add_file_handler, cleanup_handlers, get_logger
 from uni_agent.interaction import (
     AgentChatModel,
     AgentEnv,
@@ -132,6 +132,7 @@ class UniAgentLoop(AgentLoopBase):
                 output = await self._build_empty_agent_output(exit_reason="agent_loop_failed")
             finally:
                 await self.env.close()
+                cleanup_handlers(self.run_id)
             return output
 
     async def _build_empty_agent_output(self, exit_reason: str) -> AgentLoopOutput:

--- a/uni_agent/async_logging.py
+++ b/uni_agent/async_logging.py
@@ -11,10 +11,15 @@ logger.remove()
 _LOG_FORMAT = "{time:YYYY-MM-DD HH:mm:ss} | {extra[name]: <12} | {level: <8} | {message}"
 
 
+def _env_flag(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in ("1", "true", "yes", "on")
+
+
 def _debug_enabled() -> bool:
-    # os.getenv returns a string, so a naive truthiness check treats "0"/"false"/""
-    # as enabled. Parse the value explicitly instead.
-    return os.getenv("DEBUG_MODE", "").strip().lower() in ("1", "true", "yes", "on")
+    return _env_flag("DEBUG_MODE")
+
+
+_FLUSH_EACH_LINE = _env_flag("LOG_FLUSH_EACH_LINE")
 
 
 if _debug_enabled():
@@ -25,21 +30,14 @@ if _debug_enabled():
         filter=lambda record: "name" in record["extra"],
     )
 
-# run_id -> (open file object, min level no). Touched from loguru's background
-# (enqueue) writer thread and from the asyncio thread that adds/removes runs,
-# so guard access with a lock.
+
 _run_files: dict[str, tuple] = {}
 _lock = threading.Lock()
 
 
 def _dispatch(message) -> None:
-    """Single sink that routes each record to its run's file in O(1).
-
-    This replaces the previous "one loguru sink per run" design, where every
-    record fanned out across all live sinks (O(num_runs) filtering per message)
-    and each run leaked a sink + background thread + file descriptor when it
-    wasn't cleaned up -- the main reason logging fell over under large-scale
-    concurrent training.
+    """
+    Single sink that routes each record to its run's file in O(1).
     """
     record = message.record
     run_id = record["extra"].get("run_id")
@@ -52,12 +50,12 @@ def _dispatch(message) -> None:
         file_obj, min_no = entry
         if record["level"].no < min_no:
             return
-        try:
-            file_obj.write(message)
+    try:
+        file_obj.write(message)
+        if _FLUSH_EACH_LINE:
             file_obj.flush()
-        except (ValueError, OSError):
-            # File was closed/cleaned up between lookup and write; drop late records.
-            pass
+    except (ValueError, OSError):
+        pass
 
 
 # One global sink: O(1) dispatch by run_id, a single background writer thread.

--- a/uni_agent/async_logging.py
+++ b/uni_agent/async_logging.py
@@ -1,49 +1,93 @@
-import logging
 import os
 import sys
+import threading
 from pathlib import Path
 
 from loguru import logger
 
+# Replace loguru's default stderr sink; all routing is done by the dispatch sink below.
 logger.remove()
 
-debug_mode = os.getenv("DEBUG_MODE", False)
-if debug_mode:
-    logger.add(sys.stdout, level="INFO")
-    logger.add(sys.stderr, level="ERROR")
-
-_handler_registry = {}
+_LOG_FORMAT = "{time:YYYY-MM-DD HH:mm:ss} | {extra[name]: <12} | {level: <8} | {message}"
 
 
-def add_file_handler(file_path: Path, run_id: str, level: str = "info"):
-    def case_filter(record):
-        return record["extra"].get("run_id") == run_id and record["level"].no >= logger.level(level.upper()).no
+def _debug_enabled() -> bool:
+    # os.getenv returns a string, so a naive truthiness check treats "0"/"false"/""
+    # as enabled. Parse the value explicitly instead.
+    return os.getenv("DEBUG_MODE", "").strip().lower() in ("1", "true", "yes", "on")
 
-    handler_id = logger.add(
-        str(file_path),
-        level=level.upper(),
-        filter=case_filter,
-        format="{time:YYYY-MM-DD HH:mm:ss} | {extra[name]: <12} | {level: <8} | {message}",
-        enqueue=True,
+
+if _debug_enabled():
+    logger.add(
+        sys.stdout,
+        level="INFO",
+        format=_LOG_FORMAT,
+        filter=lambda record: "name" in record["extra"],
     )
-    if run_id not in _handler_registry:
-        _handler_registry[run_id] = []
-    _handler_registry[run_id].append(handler_id)
-    return handler_id
+
+# run_id -> (open file object, min level no). Touched from loguru's background
+# (enqueue) writer thread and from the asyncio thread that adds/removes runs,
+# so guard access with a lock.
+_run_files: dict[str, tuple] = {}
+_lock = threading.Lock()
 
 
-def get_logger(
-    name: str,
-    run_id: str,
-) -> logging.Logger:
+def _dispatch(message) -> None:
+    """Single sink that routes each record to its run's file in O(1).
+
+    This replaces the previous "one loguru sink per run" design, where every
+    record fanned out across all live sinks (O(num_runs) filtering per message)
+    and each run leaked a sink + background thread + file descriptor when it
+    wasn't cleaned up -- the main reason logging fell over under large-scale
+    concurrent training.
+    """
+    record = message.record
+    run_id = record["extra"].get("run_id")
+    if run_id is None:
+        return
+    with _lock:
+        entry = _run_files.get(run_id)
+        if entry is None:
+            return
+        file_obj, min_no = entry
+        if record["level"].no < min_no:
+            return
+        try:
+            file_obj.write(message)
+            file_obj.flush()
+        except (ValueError, OSError):
+            # File was closed/cleaned up between lookup and write; drop late records.
+            pass
+
+
+# One global sink: O(1) dispatch by run_id, a single background writer thread.
+logger.add(_dispatch, level="DEBUG", format=_LOG_FORMAT, enqueue=True)
+
+
+def add_file_handler(file_path: Path, run_id: str, level: str = "info") -> str:
+    min_no = logger.level(level.upper()).no
+    Path(file_path).parent.mkdir(parents=True, exist_ok=True)
+    file_obj = open(file_path, "a", encoding="utf-8")
+    with _lock:
+        previous = _run_files.get(run_id)
+        _run_files[run_id] = (file_obj, min_no)
+    if previous is not None:
+        try:
+            previous[0].close()
+        except OSError:
+            pass
+    return run_id
+
+
+def get_logger(name: str, run_id: str):
     return logger.bind(name=name, run_id=run_id)
 
 
-def cleanup_handlers(run_id: str):
-    if run_id in _handler_registry:
-        for handler_id in _handler_registry[run_id]:
-            try:
-                logger.remove(handler_id)
-            except ValueError:
-                pass
-        del _handler_registry[run_id]
+def cleanup_handlers(run_id: str) -> None:
+    with _lock:
+        entry = _run_files.pop(run_id, None)
+    if entry is not None:
+        try:
+            entry[0].close()
+        except OSError:
+            pass


### PR DESCRIPTION
## Summary
Rework the per-run logging backend so it survives large-scale concurrent
training. Replaces the "one loguru sink per run" design with a single global
dispatch sink, fixes a sink/thread/fd leak, and stops per-record flushes from
stalling the writer thread when `log_dir` lives on HDFS/FUSE.
## Problem
The previous implementation called `logger.add(<file>)` once per run:
- **O(num_runs) per message**: every record fanned out across *all* live sinks,
  each re-evaluating a per-run `case_filter`. Cost grew with the number of
  concurrent runs.
- **Leak**: each run added a sink + background thread + open file descriptor.
  If `cleanup_handlers` wasn't called (and it wasn't, on the training path),
  these accumulated until logging fell over / fds were exhausted.
- **HDFS stalls**: the sink flushed every record. On an HDFS/FUSE-backed
  `log_dir`, each flush is a synchronous remote `write()`; with a single shared
  writer thread, one slow flush blocked logging for *all* runs.
- `DEBUG_MODE` parsing treated `"0"`/`"false"`/`""` as enabled (non-empty string
  is truthy).
## What changed
`uni_agent/async_logging.py`
- **Single dispatch sink**: one `logger.add(_dispatch, enqueue=True)` routes each
  record to its run's file in O(1) by `run_id`, backed by one background writer
  thread.
- **Real cleanup**: `cleanup_handlers(run_id)` closes the run's file object and
  drops it from the registry (no more leaked sinks/threads/fds).
- **Block buffering, no per-line flush by default**: lines accumulate in-process
  and reach the OS ~every `io.DEFAULT_BUFFER_SIZE` or on `close()`, drastically
  cutting HDFS/FUSE `write()` frequency. Set `LOG_FLUSH_EACH_LINE=1` for
  near-real-time tailing on local disks.
- **Narrowed lock scope**: the lock only guards the registry lookup; file I/O
  runs outside it, so a slow write can't block run registration/cleanup. The
  write-after-close race is handled by catching `ValueError`/`OSError`.
- **Fixed `DEBUG_MODE` parsing** via explicit truthy-value parsing.
`uni_agent/agent_loop.py`
- Call `cleanup_handlers(self.run_id)` in `UniAgentLoop.run()`'s `finally` block
  so the per-run file is closed on the training path (success and failure).
