### PR TITLE
[llm_router]feat: support kvcache-aware router

### DIFF
--- a/examples/llm_router/README.md
+++ b/examples/llm_router/README.md
@@ -1,0 +1,173 @@
+# llm-router Inference Quick Start
+
+## What is llm-router
+
+llm-router provides intelligent routing for Agentic RL based on KV cache status and load awareness. It serves as a pluggable load balancer for veRL's multi-replica (data-parallel) vLLM inference, replacing the default `global_sticky_inflight` router.
+
+Core components:
+- `KVCAwareBalancer` — routing framework, manages component lifecycle and routing decisions
+- `Collector` — Transport + Decoder composition, collects metrics for decisions (vLLM KV events and Prometheus metrics)
+- `Strategy` — scoring strategy, computes combined scores based on KV cache hit rate and load
+- `Store` — singleton storage, caches collected metrics and KV block states
+
+---
+
+## Setup and Usage Guide
+
+### 1. Clone the project
+
+```bash
+git clone https://github.com/verl-project/uni-agent.git
+```
+
+### 2. Create Docker container
+
+```bash
+# Optional env vars (with defaults): CONTAINER_NAME=hgq-swe  IMAGE_NAME=verlai/verl:vllm018.dev1  SHM_SIZE=10g
+# DATA_DIR: host data disk path (models/datasets/wheels), replace with your actual path
+CONTAINER_NAME=swe-xxx IMAGE_NAME=verlai/verl:vllm018.dev1 SHM_SIZE=10g \
+docker run -d \
+  --name ${CONTAINER_NAME:-hgq-swe} \
+  --gpus all \
+  --device /dev/fuse \
+  --cap-add SYS_ADMIN \
+  --shm-size=${SHM_SIZE:-10g} \
+  -v <DATA_DIR>:<DATA_DIR> \
+  -v /tmp:/tmp \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /usr/bin/docker:/usr/bin/docker \
+  --entrypoint sleep \
+  ${IMAGE_NAME:-verlai/verl:vllm018.dev1} \
+  infinity
+
+# Verify GPU visibility
+docker exec ${CONTAINER_NAME:-hgq-swe} nvidia-smi --query-gpu=name,memory.total --format=csv,noheader
+```
+
+> `<DATA_DIR>` is the host data disk path (models, datasets, swe-rex wheels). Replace with your actual path (e.g. `/data1`). This path is mounted into the container and must match the swe-rex wheels mount source in `agent_config_localdocker.yaml` (see §4.5).
+
+### 3. Enter container and install dependencies
+
+```bash
+docker exec -it swe-xxx bash
+cd /path/to/uni-agent
+
+# Init git submodule + install verl and dependencies
+git submodule update --init --recursive
+pip install --no-deps -e verl
+pip install swe-rex loguru pydantic pydantic_settings boto3
+pip install --no-cache-dir swebench
+```
+
+### 4. Prepare dataset
+
+```bash
+# Default (modal) — works with local docker sandbox
+DEPLOYMENT=modal python examples/data_preprocess/swe_bench_verified.py --local-save-dir examples/llm_router
+
+# Specify deployment backend
+DEPLOYMENT=vefaas python examples/data_preprocess/swe_bench_verified.py --local-save-dir examples/llm_router
+```
+
+| DEPLOYMENT | Generated image name | Use case |
+|------------|---------------------|----------|
+| `modal` | `swebench/sweb.eval.x86_64.*` | local docker / modal |
+| `vefaas` | Alibaba Cloud veFaaS image | veFaaS only |
+| `local` | Not implemented yet | — |
+
+Output: `examples/llm_router/swe_bench_verified_<deployment>.parquet`
+
+### 4.5 Pre-download swe-rex wheels + pull SWE-bench images (first-time setup)
+
+**Problem 1: Concurrent pip throttle** — Each sandbox runs `pip install swe-rex`. With 500 concurrent sandboxes, pip will throttle/timeout.
+
+**Solution**: Pre-download swe-rex + all dependency wheels to a local directory for offline install:
+
+```bash
+# <WHEELS_DIR> should be under <DATA_DIR> (mounted in §2), e.g. /data1/swe_wheels
+pip download swe-rex -d <WHEELS_DIR>
+```
+
+**Problem 2: Find image list + pull SWE-bench images**
+
+Image names are stored in the parquet `extra_info` field (format: `swebench/sweb.eval.x86_64.<instance>`). Parse with pyarrow:
+
+```python
+import json, pyarrow.parquet as pq
+t = pq.read_table("examples/llm_router/swe_bench_verified_modal.parquet")
+imgs = set()
+for e in t.column("extra_info").to_pylist():
+    e = json.loads(e) if isinstance(e, str) else e
+    def find(o):
+        if isinstance(o, dict):
+            for v in o.values(): find(v)
+        elif isinstance(o, str) and "sweb.eval" in o:
+            imgs.add(o)
+    find(e)
+print(imgs)
+```
+
+Pull from Docker Hub (or a CN mirror like Volcano Engine CR if Docker Hub is slow):
+
+```bash
+docker pull swebench/sweb.eval.x86_64.<instance>:latest
+```
+
+### 5. Run inference
+
+`examples/llm_router/run_infer.sh` is a thin wrapper around `parallel_infer.py`. **Defaults (defined in parallel_infer.py) = 2-GPU single-replica smoke test (1 sample)**. The first 3 args are positional; the rest are forwarded to `parallel_infer.py` via `$@`.
+
+```bash
+# Smoke test (defaults: 2 GPUs, TP=1, 1 sample)
+bash examples/llm_router/run_infer.sh /path/to/Qwen3-4B
+
+# Full 8-GPU data-parallel
+bash examples/llm_router/run_infer.sh /path/to/Qwen3-4B \
+    --num-workers 8 --n-gpus-per-node 8 --tensor-parallel-size 2 \
+    --max-num-seqs 64 --max-samples -1 --prompt-length 31744
+
+# With MooncakeStoreConnector (cross-replica KV sharing; requires mooncake_master)
+bash examples/llm_router/run_infer.sh /path/to/Qwen3-4B --enable-mooncake
+
+# With KVCAware router
+bash examples/llm_router/run_infer.sh /path/to/Qwen3-4B \
+    --router-config-path pkg://uni_agent.llm_router.configs/kvc_aware_router.yaml
+```
+
+Positional args:
+
+| Arg | Position | Default | Description |
+|-----|----------|---------|-------------|
+| `MODEL_PATH` | 1st | **required** | Model path |
+| `DATA_PATH` | 2nd | Same dir `swe_bench_verified_modal.parquet` | Dataset path |
+| `AGENT_CONFIG` | 3rd | Same dir `agent_config_localdocker.yaml` | Agent config path |
+
+Key CLI args (forwarded to `parallel_infer.py`, see `--help` for all):
+
+| Arg | Default | Description |
+|-----|---------|-------------|
+| `--num-workers` | `1` | Agent rollout workers (use 8 for full runs) |
+| `--n-gpus-per-node` | `2` | GPUs per node (use 8 for full runs) |
+| `--tensor-parallel-size` | `1` | Tensor parallel (use 2 for full runs) |
+| `--max-num-seqs` | `256` | Concurrent sequences per engine (use 64 on 24GB cards) |
+| `--max-samples` | `-1` | Number of samples (-1 = full dataset) |
+| `--prompt-length` | `4096` | Prompt length (use 31744 for full runs) |
+| `--response-length` | `8192` | Response length |
+| `--max-model-len` | unset | Model context length (unset = engine default) |
+| `--n` | `1` | Rollouts per prompt (use 4 for full runs) |
+| `--enable-mooncake` | off | Attach MooncakeStoreConnector (cross-replica KV sharing) |
+| `--mooncake-config-path` | `mooncake_config.json` | Mooncake config path (with `--enable-mooncake`) |
+| `--router-config-path` | unset | External router YAML (e.g. `pkg://...`) |
+
+> Set `CUDA_VISIBLE_DEVICES` before calling run_infer.sh (e.g. `CUDA_VISIBLE_DEVICES=6,7 bash run_infer.sh ...`). Concurrency is configured in the agent_config YAML.
+
+> **1-token degradation**: verl's `max_tokens = min(response_length, prompt_length + response_length - prompt)`. Once a multi-turn prompt exceeds this sum, `max_tokens` collapses to 1. Keep the sum below the model's native context (e.g. Qwen3-8B 40960 → use 31744+8192=39936).
+
+### 6. Known issues: transformers / numpy errors
+
+On older Docker/kernel/OS versions (Docker 20.10, kernel 4.15, Ubuntu 18.04), the same image may trigger runtime exceptions. On newer environments (Docker 26.x, kernel 5.4, Ubuntu 20.04) these work out of the box.
+
+| Symptom | Root cause | Fix (run once in container) |
+|---------|-----------|-----------------------------|
+| `import transformers` fails with `Backend should be defined in BACKENDS_MAPPING` | transformers 5.3.0 backend check fails on old envs | `pip install "transformers==4.57.6"` |
+| vllm worker fails, `RecursionError` (numpy `issubdtype` ↔ `__repr__` recursion) | numpy 2.x overlay triggers dtype repr loop on old envs | `pip uninstall -y numpy && pip install "numpy==1.26.4"` |

--- a/examples/llm_router/README_cn.md
+++ b/examples/llm_router/README_cn.md
@@ -1,0 +1,212 @@
+# llm-router 推理快速开始
+
+## 什么是 llm-router
+
+llm-router 提供 Agentic RL 场景下基于 KV cache 状态 + 负载感知的智能路由。它作为 veRL 的可插拔负载均衡器，用于多副本（data-parallel）vLLM 推理，替代默认的 `global_sticky_inflight` 路由器。
+
+核心组件：
+- `KVCAwareBalancer` — 路由框架，管理组件生命周期与路由决策
+- `Collector` — Transport + Decoder 组合，采集用于决策的指标，如vLLM 的 KV 事件与 Prometheus 指标
+- `Strategy` — 评分策略，基于 KV cache 命中率与负载计算综合得分
+- `Store` — 单例存储，缓存采集到的指标与 KV block 状态
+
+---
+
+## 部署和运行指南
+
+以下步骤从零开始部署 llm-router 推理环境。
+
+## 1. 克隆项目
+
+```bash
+git clone https://github.com/verl-project/uni-agent.git
+```
+
+## 2. 创建 Docker 容器
+
+```bash
+# 可选环境变量（带默认值）：CONTAINER_NAME=hgq-swe  IMAGE_NAME=verlai/verl:vllm018.dev1  SHM_SIZE=10g
+# DATA_DIR: 宿主数据盘路径（模型/数据集/wheels 都放这），按实际环境替换
+CONTAINER_NAME=swe-xxx IMAGE_NAME=verlai/verl:vllm018.dev1 SHM_SIZE=10g \
+docker run -d \
+  --name ${CONTAINER_NAME:-hgq-swe} \
+  --gpus all \
+  --device /dev/fuse \
+  --cap-add SYS_ADMIN \
+  --shm-size=${SHM_SIZE:-10g} \
+  -v <DATA_DIR>:<DATA_DIR> \
+  -v /tmp:/tmp \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /usr/bin/docker:/usr/bin/docker \
+  --entrypoint sleep \
+  ${IMAGE_NAME:-verlai/verl:vllm018.dev1} \
+  infinity
+
+# 验证 GPU 可见
+docker exec ${CONTAINER_NAME:-hgq-swe} nvidia-smi --query-gpu=name,memory.total --format=csv,noheader
+```
+
+> `<DATA_DIR>` 是宿主数据盘路径（模型、数据集、swe-rex wheels 都放这），按实际环境替换（如 `/data1`）。该路径会挂载进容器，且需与 `agent_config_localdocker.yaml` 里 swe-rex wheels 的挂载源路径一致（见 §4.5）。
+
+可选环境变量：
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `CONTAINER_NAME` | `hgq-swe` | 容器名称 |
+| `IMAGE_NAME` | `verlai/verl:vllm018.dev1` | 镜像名称 |
+| `SHM_SIZE` | `10g` | 共享内存大小 |
+
+## 3. 进入 Docker 容器并安装依赖
+
+```bash
+docker exec -it swe-xxx bash
+cd /path/to/uni-agent
+
+# 初始化 git submodule + 安装 verl 及依赖（清华源）
+git submodule update --init --recursive
+pip install --no-deps -e verl -i https://pypi.tuna.tsinghua.edu.cn/simple
+pip install swe-rex loguru pydantic pydantic_settings boto3 -i https://pypi.tuna.tsinghua.edu.cn/simple
+pip install --no-cache-dir swebench -i https://pypi.tuna.tsinghua.edu.cn/simple
+```
+
+## 4. 准备数据集
+
+```bash
+# 使用默认值 (modal) —— local docker 沙箱用 modal 即可
+DEPLOYMENT=modal python examples/data_preprocess/swe_bench_verified.py --local-save-dir examples/llm_router
+
+# 指定部署后端
+DEPLOYMENT=vefaas python examples/data_preprocess/swe_bench_verified.py --local-save-dir examples/llm_router
+```
+
+DEPLOYMENT 决定写入 parquet 的沙箱镜像名：
+
+| 值 | 生成的镜像名 | 适用场景 |
+|------|------|------|
+| `modal` | `swebench/sweb.eval.x86_64.*` | local docker / modal 部署 |
+| `vefaas` | 阿里云 veFaaS 镜像 | 仅 veFaaS 部署 |
+| `local` | 尚未实现 | — |
+
+> **使用 local docker 沙箱时，`DEPLOYMENT=modal` 即可**（默认值），docker 会自动拉取 `swebench/sweb.eval.x86_64.*` 镜像。
+
+输出文件：`examples/llm_router/swe_bench_verified_<deployment>.parquet`
+
+## 4.5 预下载 swe-rex wheels + 拉取 SWE-bench 镜像（首次必做）
+
+多并发推理前需解决两个问题，否则沙箱起不来导致大量样本 fail：
+
+### 问题 1：500 沙箱并发 pip 打爆镜像源
+
+每个沙箱启动都要 `pip install swe-rex`，500 个沙箱并发 pip 会把清华源打满（超时/卡死）。
+
+**解决**：预下载 swe-rex + 全部依赖 wheels 到本地目录，沙箱挂载后 offline 安装（秒级，不走网络）：
+
+```bash
+# <WHEELS_DIR> 放在 §2 挂载的 <DATA_DIR> 下，使其容器内可见，如 /data1/swe_wheels
+pip download swe-rex -d <WHEELS_DIR> -i https://pypi.tuna.tsinghua.edu.cn/simple
+```
+
+`agent_config_localdocker.yaml` 已配置把该目录挂载到沙箱 `/wheels`（只读）+ `--find-links /wheels`（清华源作 fallback，兼容 pydantic-core 等平台相关包）。注意 yaml 里的挂载源路径要和实际的 `<WHEELS_DIR>` 一致。
+
+### 问题 2：从 parquet 找镜像列表 + 国内拉取 SWE-bench 镜像
+
+**找镜像列表**：沙箱镜像名写在 parquet 的 `extra_info` 字段里（格式 `swebench/sweb.eval.x86_64.<instance>`）。用 pyarrow 解析：
+
+```python
+import json, pyarrow.parquet as pq
+t = pq.read_table("examples/llm_router/swe_bench_verified_modal.parquet")
+imgs = set()
+for e in t.column("extra_info").to_pylist():
+    e = json.loads(e) if isinstance(e, str) else e
+    def find(o):
+        if isinstance(o, dict):
+            for v in o.values(): find(v)
+        elif isinstance(o, str) and "sweb.eval" in o:
+            imgs.add(o)
+    find(e)
+print(imgs)  # 完整镜像列表
+```
+
+**国内拉取**：Docker Hub 国内拉 `swebench/*` 镜像超时。用火山引擎 CR（国内快）拉源镜像再 tag 成 parquet 期望的格式：
+
+```bash
+# 火山引擎 CR 源：enterprise-public-cn-beijing.cr.volces.com/swe-bench-verified/<instance>:v2
+# tag 成 parquet 期望的：swebench/<instance>:latest
+docker pull enterprise-public-cn-beijing.cr.volces.com/swe-bench-verified/sweb.eval.x86_64.<instance>:v2
+docker tag enterprise-public-cn-beijing.cr.volces.com/swe-bench-verified/sweb.eval.x86_64.<instance>:v2 swebench/sweb.eval.x86_64.<instance>:latest
+```
+
+对上面找到的每个镜像循环执行 pull+tag（已 tag 的可跳过）。可自行写循环脚本，或手动拉需要的子集。
+
+## 5. 运行推理
+
+`examples/llm_router/run_infer.sh` 是 `parallel_infer.py` 的薄包装。**默认参数（在 parallel_infer.py 中定义）= 2 卡单副本冒烟测试（1 样本）**。前 3 个是位置参数，其余通过 `$@` 透传给 `parallel_infer.py`。
+
+```bash
+# 冒烟测试（默认：2 卡、TP=1、1 样本）
+bash examples/llm_router/run_infer.sh /path/to/Qwen3-4B
+
+# 指定模型 + 数据集 + agent 配置
+bash examples/llm_router/run_infer.sh /path/to/Qwen3-4B /path/to/dataset.parquet my_config.yaml
+
+# 全量 8-GPU data-parallel（覆盖默认参数）
+bash examples/llm_router/run_infer.sh /path/to/Qwen3-4B \
+    --num-workers 8 --n-gpus-per-node 8 --tensor-parallel-size 2 \
+    --max-num-seqs 64 --max-samples -1 --prompt-length 31744
+
+# 带 MooncakeStoreConnector（跨副本 KV 共享，需先起 mooncake_master）
+bash examples/llm_router/run_infer.sh /path/to/Qwen3-4B --enable-mooncake
+
+# 带外部 KVCAware router
+bash examples/llm_router/run_infer.sh /path/to/Qwen3-4B \
+    --router-config-path pkg://uni_agent.llm_router.configs/kvc_aware_router.yaml
+```
+
+位置参数：
+
+| 参数 | 位置 | 默认值 | 说明 |
+|------|------|--------|------|
+| `MODEL_PATH` | 第 1 个 | **无（必传）** | 模型路径 |
+| `DATA_PATH` | 第 2 个 | 同目录 `swe_bench_verified_modal.parquet` | 数据集路径 |
+| `AGENT_CONFIG` | 第 3 个 | 同目录 `agent_config_localdocker.yaml` | Agent 配置路径 |
+
+主要 CLI 参数（透传给 `parallel_infer.py`，详见 `--help`）：
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--num-workers` | `1` | agent rollout worker 数（全量用 8） |
+| `--n-gpus-per-node` | `2` | 每节点 GPU 数（全量用 8） |
+| `--tensor-parallel-size` | `1` | tensor parallel（全量用 2） |
+| `--max-num-seqs` | `256` | 每实例 vLLM 并发序列（24GB 卡用 64） |
+| `--max-samples` | `-1` | 样本数（-1 = 全量） |
+| `--prompt-length` | `4096` | prompt 长度（全量 1-token 退化修复用 31744） |
+| `--response-length` | `8192` | response 长度 |
+| `--max-model-len` | 空=引擎默认 | 模型上下文长度 |
+| `--n` | `1` | 每 prompt rollout 数（全量用 4） |
+| `--enable-mooncake` | 关 | 附加 MooncakeStoreConnector（跨副本 KV 共享） |
+| `--mooncake-config-path` | `mooncake_config.json` | mooncake 配置路径（配合 `--enable-mooncake`） |
+| `--router-config-path` | 空 | 外部 router YAML（如 `pkg://...`） |
+
+> `CUDA_VISIBLE_DEVICES` 在 run_infer.sh 调用前通过 shell 环境设（如 `CUDA_VISIBLE_DEVICES=6,7 bash run_infer.sh ...`）。concurrency 在 agent_config yaml 中配置。
+
+> **PROMPT_LEN + RESPONSE_LEN 的 1-token 退化**：verl 的 max_tokens = min(response_length, prompt_length+response_length-prompt)，多轮 prompt 累积达到该和时 max_tokens 塌缩到 1。全量跑时把和控制在模型原生上下文以内（如 Qwen3-8B 40960 → 用 31744+8192=39936）。
+
+run_infer.sh 会在启动前检查 MODEL_PATH / DATA_PATH / AGENT_CONFIG 是否存在，缺失则报错退出。
+
+> **前置条件（全量多并发）**：必须先跑过 Step 4.5（预下载 wheels + 拉镜像），否则沙箱起不来。
+
+> **日志重定向**：
+> ```bash
+> setsid nohup bash examples/llm_router/run_infer.sh /path/to/Qwen3-4B > logs/run.log 2>&1 &
+> ```
+
+## 6. 已知问题：transformers / numpy 异常
+
+在 Docker / 内核 / 系统版本较旧的环境（如 Docker 20.10、内核 4.15、Ubuntu 18.04）下，同一镜像会触发以下两个运行时异常，导致推理起不来；在较新环境（如 Docker 26.x、内核 5.4、Ubuntu 20.04）上开箱即用，可跳过本节。根因是宿主运行时环境差异，非包/版本本身。
+
+| 现象 | 根因 | 解决方案（容器内执行一次） |
+|------|------|--------------------------|
+| `import transformers` 报 `Backend should be defined in the BACKENDS_MAPPING. Offending backend: tf` | 旧环境下 transformers 5.3.0 backend 检查异常 | `pip install -i https://pypi.tuna.tsinghua.edu.cn/simple "transformers==4.57.6"` |
+| vllm worker 起不来，`RecursionError`（numpy `issubdtype`↔`__repr__` 递归，根源 `np.dtype(bfloat16)`） | 旧环境下 numpy 混入的 2.x overlay 触发 dtype repr 死循环 | `pip uninstall -y numpy && rm -rf /usr/local/lib/python3.12/dist-packages/numpy /usr/local/lib/python3.12/dist-packages/numpy-1.26.4.dist-info && pip install -i https://pypi.tuna.tsinghua.edu.cn/simple "numpy==1.26.4"` |
+
+> `transformers==4.57.6` 会顺带降级 `huggingface_hub`→0.36.2；numpy 重装后 `pip check` 报 `opencv-python-headless requires numpy>=2` 可忽略。`rm` 类命令在共享机上执行前先审批。

--- a/examples/llm_router/agent_config_localdocker.yaml
+++ b/examples/llm_router/agent_config_localdocker.yaml
@@ -1,0 +1,35 @@
+- name: swe_agent
+
+  _target_: uni_agent.agent_loop.UniAgentLoop
+
+  concurrency: 32
+  log_dir: /tmp/swebench_llm_router
+  mask_abnormal_exit_traj: false
+
+  interaction:
+    action_timeout: 300
+    max_turns: 100
+
+  env:
+    deployment:
+      type: local
+      startup_timeout: 1200
+      container_runtime: docker
+    env_variables:
+      PIP_PROGRESS_BAR: "off"
+      PIP_CACHE_DIR: "~/.cache/pip"
+      PAGER: "cat"
+      MANPAGER: "cat"
+      LESS: "-R"
+      TQDM_DISABLE: "1"
+      GIT_PAGER: "cat"
+
+  tool_parser: hermes
+
+  tools:
+    - name: str_replace_editor
+    - name: execute_bash
+    - name: submit
+
+  reward:
+    eval_timeout: 600

--- a/examples/llm_router/agent_config_simulated.yaml
+++ b/examples/llm_router/agent_config_simulated.yaml
@@ -1,0 +1,55 @@
+# Simulated sandbox agent config — for performance / routing testing.
+#
+# The LLM (vLLM replicas + router) runs for real; only the sandbox is simulated
+# (type: simulated — canned observations, no real swe-rex container). Use this as the
+# 3rd arg to run_infer.sh so the full stack (AgentLoopManager -> UniAgentLoop ->
+# AgentEnv) runs without the docker-sandbox overhead (and the high-concurrency
+# uvloop fd issues of real sandboxes):
+#
+#   bash examples/llm_router/run_infer.sh <MODEL_PATH> <DATA_PATH> examples/llm_router/agent_config_simulated.yaml
+#
+# Tunables under env.deployment:
+#   seed:             null = random each run; an int = reproducible sampling
+#   observation_scale: 1.0 = as-authored; >1 stresses KV/prefill load
+#   timeout:          simulated command timeouts (CommandTimeoutError ->
+#                     recoverable ActionTimeoutError). disabled by default.
+#   terminal_dead:    simulated terminal death (fatal TerminalNotAliveError).
+#                     disabled by default.
+#
+# Observation templates live in uni_agent/deployment/simulated/observations.yaml;
+# edit weights / add long-tail entries there without touching code.
+
+- name: swe_agent
+
+  _target_: uni_agent.agent_loop.UniAgentLoop
+
+  concurrency: 128
+  log_dir: /tmp/swebench_llm_router_simulated
+  mask_abnormal_exit_traj: false
+
+  interaction:
+    action_timeout: 300
+    max_turns: 100
+
+  env:
+    deployment:
+      type: simulated
+      seed: null
+      observation_scale: 1.0
+      timeout:
+        enabled: false
+        probability: 0.05
+        delay_seconds: 0.5
+      terminal_dead:
+        enabled: false
+        probability: 0.01
+
+  tool_parser: hermes
+
+  tools:
+    - name: str_replace_editor
+    - name: execute_bash
+    - name: submit
+
+  reward:
+    eval_timeout: 600

--- a/examples/llm_router/parallel_infer.py
+++ b/examples/llm_router/parallel_infer.py
@@ -1,0 +1,265 @@
+import argparse
+import json
+import logging
+import os
+from pathlib import Path
+
+import numpy as np
+import ray
+from datasets import load_dataset
+from omegaconf import DictConfig
+
+import verl
+from verl import DataProto
+from verl.experimental.agent_loop import AgentLoopManager
+from verl.protocol import pad_dataproto_to_divisor, unpad_dataproto
+from verl.workers.rollout.llm_server import LLMServerManager
+
+# Setup basic logging
+logging.basicConfig(
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=os.getenv("VERL_LOGGING_LEVEL", "INFO")
+)
+logger = logging.getLogger(__name__)
+
+# Ray's default idle-worker reaper (~10 s) kills agent workers between
+# dispatch gaps, ending the job prematurely.  Use a very large threshold
+# so long-running agent loops are not interrupted.
+_RAY_IDLE_WORKER_TIMEOUT_MS = int(os.getenv("RAY_IDLE_WORKER_TIMEOUT_MS", str(2**30 - 1)))
+
+
+def init_config(args: argparse.Namespace) -> DictConfig:
+    """Initialize the configuration from hydra and override with command-line arguments."""
+    from hydra import compose, initialize_config_dir
+
+    config_dir = str(Path(verl.__file__).resolve().parent / "trainer" / "config")
+    with initialize_config_dir(config_dir=config_dir, version_base=None):
+        config = compose(config_name="ppo_trainer")
+
+    # Override rollout configs
+    config.actor_rollout_ref.rollout.agent.agent_loop_config_path = os.path.expanduser(args.agent_config_path)
+    config.actor_rollout_ref.rollout.agent.num_workers = args.num_workers
+    config.actor_rollout_ref.rollout.multi_turn.max_assistant_turns = args.max_turns
+    config.actor_rollout_ref.rollout.multi_turn.max_parallel_calls = 1
+
+    # Router config (optional): enable an external router via plugin_extension.
+    # When set, VeRL loads the YAML (router_class) and instantiates the router
+    # as the rollout load balancer.  Unset = VeRL built-in router.
+    if args.router_config_path:
+        config.actor_rollout_ref.rollout.router.router_strategy = "plugin_extension"
+        config.actor_rollout_ref.rollout.router.router_config_path = args.router_config_path
+
+    # Sampling kwargs
+    config.actor_rollout_ref.rollout.temperature = args.temperature
+    config.actor_rollout_ref.rollout.top_p = args.top_p
+
+    # Hardware configs
+    config.actor_rollout_ref.rollout.nnodes = args.nnodes
+    config.actor_rollout_ref.rollout.n_gpus_per_node = args.n_gpus_per_node
+    config.trainer.nnodes = args.nnodes
+    config.trainer.n_gpus_per_node = args.n_gpus_per_node
+
+    # Model and engine configs
+    config.actor_rollout_ref.model.path = os.path.expanduser(args.model_path)
+    config.actor_rollout_ref.rollout.name = args.engine
+    config.actor_rollout_ref.rollout.mode = "async"
+    config.actor_rollout_ref.rollout.prompt_length = args.prompt_length
+    config.actor_rollout_ref.rollout.response_length = args.response_length
+    config.actor_rollout_ref.rollout.n = args.n
+    config.actor_rollout_ref.rollout.tensor_model_parallel_size = args.tensor_parallel_size
+    config.actor_rollout_ref.rollout.gpu_memory_utilization = 0.9
+    config.actor_rollout_ref.rollout.max_num_seqs = args.max_num_seqs
+    if args.max_model_len is not None:
+        config.actor_rollout_ref.rollout.max_model_len = args.max_model_len
+    config.actor_rollout_ref.rollout.disable_log_stats = False  # expose engine metrics on /metrics endpoint
+
+    # Data configs
+    config.data.return_raw_chat = True
+    config.data.max_prompt_length = args.prompt_length
+    config.data.max_response_length = args.response_length
+
+    # Optionally attach MooncakeStoreConnector for cross-replica KV sharing.
+    if args.enable_mooncake:
+        config.actor_rollout_ref.rollout.engine_kwargs = {
+            "vllm": {
+                "kv_transfer_config": {
+                    "kv_connector": "MooncakeStoreConnector",
+                    "kv_role": "kv_both",
+                    "kv_connector_extra_config": {
+                        "mooncake_config_path": args.mooncake_config_path,
+                    },
+                }
+            }
+        }
+
+    return config
+
+
+def run_inference(args: argparse.Namespace):
+    """Run the inference pipeline using the provided arguments."""
+    # 1. Init Ray — disable idle-worker reaper so agent workers survive
+    # dispatch gaps (default ~10 s threshold would kill them prematurely).
+    ray.init(_system_config={"idle_worker_killing_time_threshold_ms": _RAY_IDLE_WORKER_TIMEOUT_MS})
+
+    # 2. Init rollout manager
+    logger.info("Initializing configuration and AgentLoopManager...")
+    config = init_config(args)
+    llm_server_manager = LLMServerManager.create(config=config)
+    agent_loop_manager = AgentLoopManager.create(
+        config=config,
+        llm_client=llm_server_manager.get_client(),
+    )
+
+    # 3. Load dataset
+    data_path = os.path.expanduser(args.data_path)
+    logger.info(f"Loading dataset from: {data_path}")
+    samples = load_dataset("parquet", data_files=data_path, split="train").to_list()
+
+    # Limit number of samples (-1 = no limit)
+    if args.max_samples > 0:
+        samples = samples[: args.max_samples]
+        logger.info("Using first %d samples (--max-samples=%d)", len(samples), args.max_samples)
+
+    # 4. Prepare batch data
+    logger.info("Preparing data batch...")
+    batch = DataProto(
+        non_tensor_batch={
+            "raw_prompt": np.array([sample["prompt"] for sample in samples], dtype=object),
+            "agent_name": np.array([sample["agent_name"] for sample in samples], dtype=object),
+            "tools_kwargs": np.array([sample["extra_info"]["tools_kwargs"] for sample in samples], dtype=object),
+        },
+        meta_info={"validate": True},
+    ).repeat(config.actor_rollout_ref.rollout.n)
+
+    # 5. Generate sequences
+    logger.info("Starting sequence generation...")
+    size_divisor = config.actor_rollout_ref.rollout.agent.num_workers
+    batch_padded, pad_size = pad_dataproto_to_divisor(batch, size_divisor)
+    output_padded = agent_loop_manager.generate_sequences(batch_padded)
+    output = unpad_dataproto(output_padded, pad_size=pad_size)
+
+    # 6. Process results
+    rm_scores = output.batch["rm_scores"].sum(dim=-1).tolist()
+    mean_score = float(np.mean(rm_scores)) if len(rm_scores) > 0 else 0.0
+
+    logger.info(f"Generation completed. Mean RM Score: {mean_score:.4f}")
+    print(f"\n=> Mean RM Score: {mean_score:.4f}\n")
+
+    # 7. Optionally persist a machine-readable result file (used by eval_checkpoints.py).
+    if args.result_path:
+        result_path = os.path.expanduser(args.result_path)
+        os.makedirs(os.path.dirname(result_path) or ".", exist_ok=True)
+        result = {
+            "model_path": os.path.expanduser(args.model_path),
+            "data_path": data_path,
+            "agent_config_path": os.path.expanduser(args.agent_config_path),
+            "n": config.actor_rollout_ref.rollout.n,
+            "num_samples": len(rm_scores),
+            "mean_rm_score": mean_score,
+            "rm_scores": rm_scores,
+        }
+        with open(result_path, "w") as f:
+            json.dump(result, f, indent=2)
+        logger.info(f"Wrote result file to: {result_path}")
+
+    return mean_score
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Uni-Agent Inference Runner")
+
+    # Input / Output configs
+    parser.add_argument(
+        "--data-path",
+        type=str,
+        default=None,
+        help="Path to the input dataset (Parquet format).",
+    )
+    parser.add_argument(
+        "--model-path",
+        "--model",
+        type=str,
+        default=None,
+        help="Path to the local model checkpoint.",
+    )
+    parser.add_argument(
+        "--agent-config-path",
+        type=str,
+        default=None,
+        help="Path to the agent loop configuration YAML.",
+    )
+    parser.add_argument(
+        "--result-path",
+        type=str,
+        default=None,
+        help="Optional path to write a JSON result file (mean reward and per-rollout scores).",
+    )
+    parser.add_argument(
+        "--router-config-path",
+        type=str,
+        default=None,
+        help=(
+            "Optional router config YAML (e.g. pkg://...). When set, enables "
+            "plugin_extension router strategy; the YAML's router_class is "
+            "instantiated as the rollout load balancer. Default None = VeRL "
+            "built-in router."
+        ),
+    )
+
+    # Inference parameters
+    parser.add_argument("--max-turns", type=int, default=100, help="Maximum number of interaction turns per episode.")
+    parser.add_argument("--prompt-length", type=int, default=4096, help="Maximum prompt length (tokens).")
+    parser.add_argument("--response-length", type=int, default=8192, help="Maximum response length (tokens).")
+    parser.add_argument("--temperature", type=float, default=0.8, help="Sampling temperature.")
+    parser.add_argument("--top-p", type=float, default=0.9, help="Sampling top-p (nucleus sampling).")
+    parser.add_argument("--n", type=int, default=1, help="Number of rollouts per prompt (N).")
+    parser.add_argument(
+        "--max-samples",
+        type=int,
+        default=-1,
+        help="Max number of samples to run. Use -1 for no limit (full dataset).",
+    )
+
+    # Execution / Engine configs
+    parser.add_argument(
+        "--engine",
+        type=str,
+        default="vllm",
+        choices=["vllm", "sglang"],
+        help="Inference engine backend (e.g., vllm or sglang).",
+    )
+    parser.add_argument("--num-workers", type=int, default=1, help="Number of agent rollout workers.")
+    parser.add_argument("--nnodes", type=int, default=1, help="Number of nodes to run the job.")
+    parser.add_argument("--n-gpus-per-node", type=int, default=2, help="Number of GPUs per node.")
+    parser.add_argument(
+        "--tensor-parallel-size", "--tp", type=int, default=1, help="Tensor parallel size for the model."
+    )
+    parser.add_argument(
+        "--max-model-len",
+        type=int,
+        default=None,
+        help="Maximum model context length (tokens). If unset the engine default is used.",
+    )
+    parser.add_argument(
+        "--max-num-seqs",
+        type=int,
+        default=256,
+        help="Maximum number of concurrent sequences per engine.",
+    )
+    parser.add_argument(
+        "--enable-mooncake",
+        action="store_true",
+        help="Attach MooncakeStoreConnector for cross-replica KV sharing (a mooncake master must run separately).",
+    )
+    parser.add_argument(
+        "--mooncake-config-path",
+        type=str,
+        default="mooncake_config.json",
+        help="Path to the mooncake config JSON (used with --enable-mooncake).",
+    )
+
+    args = parser.parse_args()
+    run_inference(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/llm_router/run_infer.sh
+++ b/examples/llm_router/run_infer.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Inference runner — a thin wrapper around parallel_infer.py.
+# Defaults (set in parallel_infer.py) are a 2-GPU single-replica smoke test
+# (1 sample). Pass extra flags after the positional args to scale up.
+#
+# Usage:
+#   bash examples/llm_router/run_infer.sh MODEL_PATH [DATA_PATH] [AGENT_CONFIG] [...extra flags...]
+#
+# Examples:
+#   # smoke test
+#   bash examples/llm_router/run_infer.sh /data/models/Qwen3-4B
+#
+#   # full 8-GPU data-parallel
+#   bash examples/llm_router/run_infer.sh /data/models/Qwen3-4B \
+#       --num-workers 8 --n-gpus-per-node 8 --tensor-parallel-size 2 --max-samples -1
+#
+#   # with MooncakeStoreConnector
+#   bash examples/llm_router/run_infer.sh /data/models/Qwen3-4B --enable-mooncake
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Positional args: MODEL_PATH (required), DATA_PATH / AGENT_CONFIG (default to same dir).
+MODEL_PATH=${1:?ERROR: MODEL_PATH is required}
+DATA_PATH=${2:-${SCRIPT_DIR}/swe_bench_verified_modal.parquet}
+AGENT_CONFIG=${3:-${SCRIPT_DIR}/agent_config_localdocker.yaml}
+shift 3 2>/dev/null || set --  # drop the first 3; "$@" = remaining flags
+
+# Pre-flight checks
+for var_name in DATA_PATH MODEL_PATH AGENT_CONFIG; do
+    path="${!var_name}"
+    if [ ! -e "$path" ]; then
+        echo "ERROR: ${var_name} not found: ${path}" >&2
+        exit 1
+    fi
+done
+
+python "${SCRIPT_DIR}/parallel_infer.py" \
+    --data-path "${DATA_PATH}" \
+    --model-path "${MODEL_PATH}" \
+    --agent-config-path "${AGENT_CONFIG}" \
+    "$@"

--- a/tests/uni_agent/deployment/test_simulated_agent_env_integration.py
+++ b/tests/uni_agent/deployment/test_simulated_agent_env_integration.py
@@ -1,0 +1,63 @@
+"""Integration: drive a real AgentEnv end-to-end with a simulated deployment.
+
+This is the proof that ``type: simulated`` plugs into the production path with
+zero changes above AgentEnv. The env's start -> install_tools -> run_action
+-> close lifecycle must complete without docker/swe-rex, the install-phase
+commands (which/chmod/export/mkdir) must all succeed, and a real tool call
+(str_replace_editor view) must come back as a representative observation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("swerex")
+
+from uni_agent.deployment import SimulatedDeploymentConfig  # noqa: E402
+from uni_agent.interaction.env import AgentEnv, AgentEnvConfig  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_agent_env_lifecycle_with_simulated_deployment() -> None:
+    """Full AgentEnv lifecycle on a simulated sandbox installs tools and returns a
+    representative observation for a real tool command."""
+    env_config = AgentEnvConfig(
+        deployment=SimulatedDeploymentConfig(seed=1, observation_scale=1.0),
+        env_variables={"FOO": "bar"},
+    )
+    env = AgentEnv(run_id="it-1", env_config=env_config)
+
+    await env.start()  # must not touch docker/swe-rex
+    try:
+        # install-phase commands the AgentEnv would issue (PATH/which/chmod)
+        # must all succeed (exit 0) -- the simulated routes them to install.
+        out = await env.communicate("which str_replace_editor", check="raise")
+        assert isinstance(out, str)
+        out = await env.communicate("export PATH=/usr/local/bin:$PATH", check="raise")
+
+        # A real tool call routed to editor:view returns a representative
+        # (non-empty) observation, not an install-style empty one.
+        obs = await env.run_action(
+            "str_replace_editor --command view --path /testbed/x.py",
+            action_timeout=10,
+        )
+        assert "Observation:" in obs
+        assert len(obs) > len("Observation:")
+    finally:
+        await env.close()
+
+
+@pytest.mark.asyncio
+async def test_agent_env_finish_action_via_simulated() -> None:
+    """The submit tool's fixed ``echo '<<<Finished>>>'`` command surfaces the
+    terminal signal through the real run_action wrapper."""
+    env = AgentEnv(
+        run_id="it-2",
+        env_config=AgentEnvConfig(deployment=SimulatedDeploymentConfig()),
+    )
+    await env.start()
+    try:
+        obs = await env.run_action("echo '<<<Finished>>>'", action_timeout=10)
+        assert "<<<Finished>>>" in obs
+    finally:
+        await env.close()

--- a/tests/uni_agent/deployment/test_simulated_config.py
+++ b/tests/uni_agent/deployment/test_simulated_config.py
@@ -1,0 +1,92 @@
+"""Config + discriminated-union registration tests for the simulated deployment.
+
+Verifies that ``type: simulated`` routes through the ``DeployConfig`` discriminated
+union to ``SimulatedDeploymentConfig`` / ``SimulatedDeployment``, the same way every
+other deployment (host/local/modal/...) does. This is what makes the simulated
+selectable from ``agent_config`` with zero changes above ``AgentEnv``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("swerex")
+
+from pydantic import BaseModel, Field  # noqa: E402
+
+from uni_agent.deployment import DeployConfig, SimulatedDeployment, SimulatedDeploymentConfig  # noqa: E402
+
+
+class _EnvLikeConfig(BaseModel):
+    """Mirror of AgentEnvConfig's deployment field: the discriminated union
+    only takes effect when it's a *field* of a pydantic model, not as a bare
+    Annotated alias."""
+
+    deployment: DeployConfig = Field(default_factory=SimulatedDeploymentConfig)
+
+
+def test_simulated_config_defaults() -> None:
+    """The discriminator and tunables have the agreed defaults."""
+    cfg = SimulatedDeploymentConfig()
+    assert cfg.type == "simulated"
+    assert cfg.seed is None  # default = random
+    assert cfg.observation_scale == 1.0
+
+
+def test_simulated_config_tolerates_docker_only_overrides() -> None:
+    """The swebench dataset carries per-sample docker-only fields (image,
+    command, container_runtime) in tools_kwargs, which the agent loop deep-
+    merges onto the deployment block. SimulatedDeploymentConfig must IGNORE these
+    (not reject) so the same dataset drives both local and simulated deployments.
+
+    Regression for the ValidationError that killed the first simulated perf run:
+    ``deployment.simulated.image: Extra inputs are not permitted``.
+    """
+    cfg = SimulatedDeploymentConfig.model_validate(
+        {
+            "type": "simulated",
+            "image": "swebench/sweb.eval.x86_64.astropy_1776_astropy-13033",
+            "command": "python3 -m swerex.server --auth-token {token}",
+            "container_runtime": "docker",
+            "extra_run_args": ["-v", "/wheels:/wheels:ro"],
+        }
+    )
+    assert cfg.type == "simulated"
+    assert cfg.seed is None  # docker-only keys silently dropped
+
+
+def test_simulated_config_accepts_seed_and_scale() -> None:
+    cfg = SimulatedDeploymentConfig(seed=42, observation_scale=2.0)
+    assert cfg.seed == 42
+    assert cfg.observation_scale == 2.0
+
+
+def test_discriminated_union_routes_type_simulated() -> None:
+    """A plain dict with ``type: simulated`` must parse via the union into the
+    SimulatedDeploymentConfig subclass -- this is the wire format coming from YAML
+    once it lands in an AgentEnvConfig.deployment field."""
+    cfg = _EnvLikeConfig.model_validate({"deployment": {"type": "simulated"}})
+    assert isinstance(cfg.deployment, SimulatedDeploymentConfig)
+
+
+def test_get_deployment_returns_simulated() -> None:
+    """The factory hands back a SimulatedDeployment carrying the seeded SimulatedRuntime."""
+    cfg = SimulatedDeploymentConfig(seed=7, observation_scale=1.5)
+    dep = cfg.get_deployment(run_id="run-1")
+    assert isinstance(dep, SimulatedDeployment)
+    assert dep.run_id == "run-1"
+
+
+@pytest.mark.asyncio
+async def test_simulated_deployment_exposes_seeded_runtime() -> None:
+    """SimulatedDeployment must construct its SimulatedRuntime with seed/scale so the
+    route/render behavior is configured before start()."""
+    cfg = SimulatedDeploymentConfig(seed=7, observation_scale=1.5)
+    dep = cfg.get_deployment(run_id="run-1")
+    await dep.start()
+    try:
+        rt = dep.runtime
+        assert rt._seed == 7
+        assert rt.observation_scale == 1.5
+    finally:
+        await dep.stop()

--- a/tests/uni_agent/deployment/test_simulated_example_config.py
+++ b/tests/uni_agent/deployment/test_simulated_example_config.py
@@ -1,0 +1,58 @@
+"""Validate the shipped agent_config_simulated.yaml example.
+
+A bad example config (typo, wrong field, missing type) is the kind of thing
+that only blows up at perf-run time. This test loads the real YAML file and
+asserts its deployment block parses into a SimulatedDeploymentConfig with sane
+defaults, so the example can't silently rot.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytest.importorskip("swerex")
+
+from uni_agent.deployment import SimulatedDeploymentConfig  # noqa: E402
+from uni_agent.interaction.env import AgentEnvConfig  # noqa: E402
+
+
+def _example_config_path() -> Path:
+    """Locate scripts/agent_config_simulated.yaml relative to the repo root.
+
+    Prefer the test file's own location; fall back to cwd (tests are always
+    run from the repo root). __file__ alone is unreliable here because the
+    uni_agent package is a namespace package (no __init__.py), which makes
+    pytest surface a cwd-relative module path that .resolve() mishandles.
+    """
+    candidates = [
+        Path(__file__).resolve().parents[3],
+        Path.cwd(),
+    ]
+    for root in candidates:
+        p = root / "scripts" / "agent_config_simulated.yaml"
+        if p.is_file():
+            return p
+    raise FileNotFoundError("agent_config_simulated.yaml not found under repo root")
+
+
+def test_example_config_parses_as_simulated() -> None:
+    raw = yaml.safe_load(_example_config_path().read_text())
+    # the agent config is a one-element list whose first item has `env.deployment`
+    deployment_dict = raw[0]["env"]["deployment"]
+    env_cfg = AgentEnvConfig.model_validate({"deployment": deployment_dict})
+    assert isinstance(env_cfg.deployment, SimulatedDeploymentConfig)
+    assert env_cfg.deployment.type == "simulated"
+
+
+def test_example_config_disabled_failure_sims_by_default() -> None:
+    """The shipped example must NOT enable timeout/terminal_dead by default --
+    a perf baseline run should measure the LLM serving layer, not the
+    failure-slow paths (which are opt-in)."""
+    raw = yaml.safe_load(_example_config_path().read_text())
+    dep = raw[0]["env"]["deployment"]
+    assert dep["timeout"]["enabled"] is False
+    assert dep["terminal_dead"]["enabled"] is False
+    assert dep["observation_scale"] == 1.0

--- a/tests/uni_agent/deployment/test_simulated_failure.py
+++ b/tests/uni_agent/deployment/test_simulated_failure.py
@@ -1,0 +1,205 @@
+"""Failure-simulation tests for SimulatedRuntime.
+
+Three failure modes, all probability-driven and seed-reproducible:
+
+1. Command timeout: sleep(delay) then raise swerex CommandTimeoutError.
+   AgentEnv catches it -> ActionTimeoutError (recoverable: timeout_budget--).
+2. Terminal death: modeled as a dead flag. The command first times out
+   (CommandTimeoutError), which makes AgentEnv probe liveness via
+   ``echo 'terminal still alive'``; once dead, that probe returns no marker,
+   so AgentEnv itself raises TerminalNotAliveError (fatal: episode ends).
+   This is the *only* way to get the correct ``terminal_dead`` semantics,
+   because env.py raises TerminalNotAliveError from its own probe logic --
+   it is never thrown by the runtime.
+3. Observation-layer failure: a template returns failure text (traceback /
+   "command not found") with exit_code != 0; the sandbox itself does NOT
+   raise -- the model sees the failure and the loop continues.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("swerex")
+
+from swerex.exceptions import CommandTimeoutError  # noqa: E402
+from swerex.runtime.abstract import BashAction  # noqa: E402
+
+from uni_agent.deployment.simulated.config import (  # noqa: E402
+    SimulatedDeploymentConfig,
+    TerminalDeadConfig,
+    TimeoutSimConfig,
+)
+from uni_agent.deployment.simulated.deployment import SimulatedRuntime  # noqa: E402
+from uni_agent.interaction.env import AgentEnv, AgentEnvConfig, TerminalNotAliveError  # noqa: E402
+
+
+def _bash(command: str, timeout: int = 10) -> BashAction:
+    return BashAction(command=command, timeout=timeout)
+
+
+def _runtime(**kw) -> SimulatedRuntime:
+    base = dict(run_id="t")
+    base.update(kw)
+    return SimulatedRuntime(**base)
+
+
+# ---------------------------------------------------------------------------
+# Timeout simulation (runtime-level: raises swerex CommandTimeoutError)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_timeout_disabled_by_default_does_not_raise() -> None:
+    rt = _runtime(seed=1)
+    for _ in range(50):
+        obs = await rt.run_in_session(_bash("python /testbed/repro.py"))
+        assert obs.exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_timeout_enabled_always_raises_command_timeout() -> None:
+    rt = _runtime(seed=1, timeout=TimeoutSimConfig(enabled=True, probability=1.0, delay_seconds=0.01))
+    with pytest.raises(CommandTimeoutError):
+        await rt.run_in_session(_bash("python /testbed/repro.py"))
+
+
+@pytest.mark.asyncio
+async def test_timeout_probability_is_seed_reproducible() -> None:
+    """Same seed -> same commands time out (by index)."""
+    cmds = [f"python /testbed/r{i}.py" for i in range(40)]
+    cfg = TimeoutSimConfig(enabled=True, probability=0.3, delay_seconds=0.0)
+
+    async def which_timeout(seed: int) -> list[int]:
+        rt = _runtime(seed=seed, timeout=cfg)
+        idx: list[int] = []
+        for i, c in enumerate(cmds):
+            try:
+                await rt.run_in_session(_bash(c))
+            except CommandTimeoutError:
+                idx.append(i)
+        return idx
+
+    a = await which_timeout(42)
+    b = await which_timeout(42)
+    assert a == b
+    assert len(a) > 0
+
+
+# ---------------------------------------------------------------------------
+# Terminal death (end-to-end through AgentEnv -> env.py raises TerminalNotAliveError)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_terminal_dead_makes_env_raise_terminal_not_alive() -> None:
+    """With terminal_dead enabled, a command must drive AgentEnv to raise
+    TerminalNotAliveError -- the fatal path, not the recoverable timeout path."""
+    env = AgentEnv(
+        run_id="dead-1",
+        env_config=AgentEnvConfig(
+            deployment=SimulatedDeploymentConfig(
+                seed=1,
+                terminal_dead=TerminalDeadConfig(enabled=True, probability=1.0),
+            )
+        ),
+    )
+    await env.start()
+    try:
+        with pytest.raises(TerminalNotAliveError):
+            await env.run_action("python /testbed/repro.py", action_timeout=10)
+    finally:
+        await env.close()
+
+
+@pytest.mark.asyncio
+async def test_terminal_dead_probability_is_seed_reproducible() -> None:
+    """Across many short episodes, the set of episodes that die must be
+    reproducible under a fixed seed."""
+    cmds = [f"python /testbed/r{i}.py" for i in range(40)]
+    cfg = TerminalDeadConfig(enabled=True, probability=0.3)
+
+    async def which_dead(seed: int) -> list[int]:
+        rt = _runtime(seed=seed, terminal_dead=cfg)
+        idx: list[int] = []
+        for i, c in enumerate(cmds):
+            # once dead, the runtime stays dead: every subsequent call is a
+            # failed liveness probe. We only record the FIRST death index.
+            try:
+                await rt.run_in_session(_bash(c))
+            except CommandTimeoutError:
+                # terminal_dead triggers via a timeout + dead probe; record if
+                # the runtime entered the dead state on this call.
+                if rt._dead:
+                    idx.append(i)
+                    break
+        return idx
+
+    a = await which_dead(7)
+    b = await which_dead(7)
+    assert a == b
+    assert len(a) > 0
+
+
+@pytest.mark.asyncio
+async def test_dead_runtime_probes_fail_with_no_marker() -> None:
+    """Once dead, the liveness probe command must return NO 'terminal still
+    alive' marker, which is what makes env.py decide the terminal is dead."""
+    rt = _runtime(seed=1, terminal_dead=TerminalDeadConfig(enabled=True, probability=1.0))
+    # trigger the dead state (this times out via CommandTimeoutError)
+    with pytest.raises(CommandTimeoutError):
+        await rt.run_in_session(_bash("python /testbed/repro.py"))
+    assert rt._dead
+    # the probe command env.py issues:
+    probe = await rt.run_in_session(_bash("echo 'terminal still alive'"))
+    assert "terminal still alive" not in probe.output
+
+
+# ---------------------------------------------------------------------------
+# Observation-layer failure (content failure, sandbox does not raise)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_observation_layer_failure_does_not_raise() -> None:
+    """A failed observation (python traceback / command not found) must come
+    back as an Observation, not as a sandbox exception."""
+    rt = _runtime(seed=1)
+    seen_failure = False
+    for _ in range(50):
+        obs = await rt.run_in_session(_bash("python /testbed/repro.py"))
+        if "Traceback" in obs.output or "command not found" in obs.output:
+            seen_failure = True
+            break
+    assert seen_failure
+
+
+# ---------------------------------------------------------------------------
+# Independence: timeout and terminal_dead use separate RNG streams
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_timeout_and_terminal_dead_are_independent_streams() -> None:
+    cmds = [f"python /testbed/r{i}.py" for i in range(40)]
+    tcfg = TimeoutSimConfig(enabled=True, probability=0.3, delay_seconds=0.0)
+    pcfg = TerminalDeadConfig(enabled=True, probability=0.3)
+
+    async def run_once(seed: int) -> tuple[list[int], int]:
+        rt = _runtime(seed=seed, timeout=tcfg, terminal_dead=pcfg)
+        timeouts: list[int] = []
+        first_dead = -1
+        for i, c in enumerate(cmds):
+            try:
+                await rt.run_in_session(_bash(c))
+            except CommandTimeoutError:
+                timeouts.append(i)
+                if rt._dead and first_dead < 0:
+                    first_dead = i
+                    break
+        return timeouts, first_dead
+
+    t1, d1 = await run_once(100)
+    t2, d2 = await run_once(100)
+    assert (t1, d1) == (t2, d2)  # reproducible
+    assert len(t1) > 0

--- a/tests/uni_agent/deployment/test_simulated_render.py
+++ b/tests/uni_agent/deployment/test_simulated_render.py
@@ -1,0 +1,104 @@
+"""Render + determinism tests for SimulatedRuntime.run_in_session.
+
+Covers the core performance-test guarantees:
+- returns an Observation (routed by the command)
+- finish / install produce their fixed canned outputs
+- with a seed, the same command sequence reproduces identical observations
+- with a different seed (or None), sampling may differ
+- observation_scale stretches the output length
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("swerex")
+
+from swerex.runtime.abstract import BashAction, BashInterruptAction  # noqa: E402
+
+from uni_agent.deployment.simulated.deployment import SimulatedRuntime  # noqa: E402
+
+
+def _has_attrs(obj, *names) -> bool:
+    """swerex's Observation is an Annotated union alias, not isinstance-able;
+    assert on the duck-typed attributes the loop relies on instead."""
+    return all(hasattr(obj, n) for n in names)
+
+
+def _bash(command: str, timeout: int = 10) -> BashAction:
+    return BashAction(command=command, timeout=timeout)
+
+
+@pytest.mark.asyncio
+async def test_finish_command_returns_terminal_signal() -> None:
+    rt = SimulatedRuntime(run_id="t")
+    obs = await rt.run_in_session(_bash("echo '<<<Finished>>>'"))
+    assert _has_attrs(obs, "output", "exit_code")
+    assert obs.exit_code == 0
+    assert "<<<Finished>>>" in obs.output
+
+
+@pytest.mark.asyncio
+async def test_install_commands_succeed_with_empty_output() -> None:
+    rt = SimulatedRuntime(run_id="t")
+    for cmd in ("which str_replace_editor", "export PATH=/x:$PATH", "chmod +x /x", "mkdir -p /opt/s"):
+        obs = await rt.run_in_session(_bash(cmd))
+        assert obs.exit_code == 0, cmd
+        assert obs.output == "", cmd
+
+
+@pytest.mark.asyncio
+async def test_interrupt_action_returns_nonzero_exit() -> None:
+    rt = SimulatedRuntime(run_id="t")
+    obs = await rt.run_in_session(BashInterruptAction(timeout=5))
+    assert _has_attrs(obs, "output", "exit_code")
+    assert obs.exit_code == 130
+
+
+@pytest.mark.asyncio
+async def test_non_install_command_produces_representative_output() -> None:
+    """A real tool call (editor view) must return a non-empty canned
+    observation, not empty like install."""
+    rt = SimulatedRuntime(run_id="t")
+    obs = await rt.run_in_session(_bash("str_replace_editor --command view --path /testbed/x.py"))
+    assert obs.exit_code == 0
+    assert len(obs.output) > 0
+
+
+@pytest.mark.asyncio
+async def test_same_seed_reproduces_identical_sequence() -> None:
+    """Reproducibility: two runtimes with the same seed run the same command
+    sequence -> identical outputs, byte for byte."""
+    cmds = [
+        "str_replace_editor --command view --path /testbed/a.py",
+        "python /testbed/repro.py",
+        "grep -rn foo /testbed",
+        "str_replace_editor --command view --path /testbed/b.py",
+    ]
+    rt1 = SimulatedRuntime(run_id="t1", seed=42)
+    rt2 = SimulatedRuntime(run_id="t2", seed=42)
+    out1 = [await rt1.run_in_session(_bash(c)) for c in cmds]
+    out2 = [await rt2.run_in_session(_bash(c)) for c in cmds]
+    assert [o.output for o in out1] == [o.output for o in out2]
+
+
+@pytest.mark.asyncio
+async def test_different_seed_likely_differs() -> None:
+    """With many distinct templates, two different seeds should not produce
+    an identical full sequence (probabilistic, but robust with enough pulls)."""
+    cmd = "python /testbed/repro.py"
+    pulls = 30
+    a = [await SimulatedRuntime(run_id="a", seed=1).run_in_session(_bash(cmd)) for _ in range(pulls)]
+    b = [await SimulatedRuntime(run_id="b", seed=2).run_in_session(_bash(cmd)) for _ in range(pulls)]
+    assert [o.output for o in a] != [o.output for o in b]
+
+
+@pytest.mark.asyncio
+async def test_observation_scale_stretches_length() -> None:
+    """observation_scale multiplies the template length (>=1x grows it)."""
+    rt_small = SimulatedRuntime(run_id="t", seed=7, observation_scale=1.0)
+    rt_big = SimulatedRuntime(run_id="t", seed=7, observation_scale=2.0)
+    cmd = "str_replace_editor --command view --path /testbed/x.py"
+    a = await rt_small.run_in_session(_bash(cmd))
+    b = await rt_big.run_in_session(_bash(cmd))
+    assert len(b.output) > len(a.output)

--- a/tests/uni_agent/deployment/test_simulated_routing.py
+++ b/tests/uni_agent/deployment/test_simulated_routing.py
@@ -1,0 +1,60 @@
+"""Routing tests for SimulatedRuntime: bash command string -> route key.
+
+SimulatedRuntime is the CPU-only sandbox stub used for performance testing
+(LLM real, sandbox simulated). The router decides which representative
+observation template a given tool command maps to.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("swerex")
+
+from uni_agent.deployment.simulated.deployment import SimulatedRuntime  # noqa: E402
+
+
+def _make_runtime():
+    """Build a SimulatedRuntime without going through a real swerex session.
+
+    The router is a pure function of the command string; it must be
+    exercisable without start()/network/docker.
+    """
+    return SimulatedRuntime(run_id="test-route")
+
+
+@pytest.mark.parametrize(
+    "command, expected",
+    [
+        # submit/finish tool emits this fixed string
+        ("echo '<<<Finished>>>'", "finish"),
+        # str_replace_editor subcommands (CLI argv, --command <X>)
+        ("str_replace_editor --command view --path /testbed", "editor:view"),
+        ("str_replace_editor --command create --path /testbed/x.py --file_text a=1", "editor:create"),
+        ("str_replace_editor --command str_replace --path /testbed/x.py", "editor:str_replace"),
+        ("str_replace_editor --command insert --path /testbed/x.py", "editor:insert"),
+        ("str_replace_editor --command undo_edit --path /testbed/x.py", "editor:undo_edit"),
+        # install_tools phase commands must route to install (no-op success)
+        ("which str_replace_editor", "install"),
+        ("export PATH=/usr/local/bin:$PATH", "install"),
+        ("chmod +x /usr/local/bin/execute_bash", "install"),
+        ("mkdir -p /opt/uni-agent/skills", "install"),
+        ("python -m pip install tree-sitter", "install"),
+        # execute_bash sub-routing by first token
+        ("python -m pytest tests/test_card.py", "test_output"),
+        ("pytest -x tests/", "test_output"),
+        ("python /testbed/reproduce_issue.py", "python_script"),
+        ("python3 /testbed/repro.py", "python_script"),
+        ("find /testbed -name *.py", "listing"),
+        ("ls -la /testbed", "listing"),
+        ("grep -rn Count /testbed/x.py", "search"),
+        ("cat /testbed/x.py", "file_view"),
+        ("head -50 /testbed/x.py", "file_view"),
+        ("git diff", "default"),
+        ("git log --oneline", "default"),
+        ("cd /testbed && ls", "default"),
+    ],
+)
+def test_route_maps_command_to_key(command: str, expected: str) -> None:
+    rt = _make_runtime()
+    assert rt._route(command) == expected, f"command={command!r}"

--- a/tests/uni_agent/deployment/test_simulated_templates_yaml.py
+++ b/tests/uni_agent/deployment/test_simulated_templates_yaml.py
@@ -1,0 +1,113 @@
+"""Template-pool YAML loading tests.
+
+The observation templates live in a standalone YAML so perf runs can tune
+weights / add long-tail entries without touching code. ``SimulatedRuntime`` loads
+the bundled default; an explicit ``templates_path`` overrides it.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+pytest.importorskip("swerex")
+
+from swerex.runtime.abstract import BashAction  # noqa: E402
+
+from uni_agent.deployment.simulated.deployment import SimulatedRuntime, load_templates  # noqa: E402
+
+
+def _bash(command: str, timeout: int = 10) -> BashAction:
+    return BashAction(command=command, timeout=10)
+
+
+def test_load_default_templates_has_all_route_keys() -> None:
+    """The bundled default pool covers every route key the router can emit."""
+    pool = load_templates()
+    for key in (
+        "editor:view",
+        "editor:create",
+        "editor:str_replace",
+        "editor:insert",
+        "editor:undo_edit",
+        "test_output",
+        "python_script",
+        "listing",
+        "search",
+        "file_view",
+        "default",
+    ):
+        assert key in pool, key
+        assert len(pool[key]) >= 1
+        # each entry is (weight:int, text:str)
+        for entry in pool[key]:
+            assert isinstance(entry, tuple) and len(entry) == 2
+            assert isinstance(entry[0], int) and entry[0] > 0
+            assert isinstance(entry[1], str)
+
+
+def test_each_pool_entry_has_positive_weight() -> None:
+    pool = load_templates()
+    for key, entries in pool.items():
+        assert sum(w for w, _ in entries) > 0, key
+
+
+def test_templates_path_overrides_pool(tmp_path) -> None:
+    """An external YAML replaces the default pool; its weights/text win."""
+    yaml_path = tmp_path / "obs.yaml"
+    yaml_path.write_text(
+        textwrap.dedent(
+            """\
+            python_script:
+              - weight: 10
+                text: "MARKER_PY_OK"
+              - weight: 1
+                text: "MARKER_PY_FAIL"
+            default:
+              - weight: 1
+                text: "MARKER_DEFAULT"
+            """
+        )
+    )
+    rt = SimulatedRuntime(run_id="t", seed=1, templates_path=str(yaml_path))
+    # weight 10:1 -> in 60 pulls the ok marker must dominate
+    draws = [await_marker(rt) for _ in range(60)]
+    assert draws.count("MARKER_PY_OK") > draws.count("MARKER_PY_FAIL")
+
+
+def await_marker(rt: SimulatedRuntime) -> str:
+    import asyncio
+
+    return asyncio.run(_one_draw(rt))
+
+
+async def _one_draw(rt: SimulatedRuntime) -> str:
+    obs = await rt.run_in_session(_bash("python /testbed/repro.py"))
+    return obs.output.strip()
+
+
+@pytest.mark.asyncio
+async def test_overridden_pool_seed_reproducible(tmp_path) -> None:
+    yaml_path = tmp_path / "obs.yaml"
+    yaml_path.write_text(
+        textwrap.dedent(
+            """\
+            python_script:
+              - weight: 5
+                text: "A"
+              - weight: 5
+                text: "B"
+              - weight: 5
+                text: "C"
+            default:
+              - weight: 1
+                text: "D"
+            """
+        )
+    )
+    rt1 = SimulatedRuntime(run_id="t", seed=9, templates_path=str(yaml_path))
+    rt2 = SimulatedRuntime(run_id="t", seed=9, templates_path=str(yaml_path))
+    seq1 = [o.output.strip() for o in [await rt1.run_in_session(_bash(f"python /r{i}.py")) for i in range(20)]]
+    seq2 = [o.output.strip() for o in [await rt2.run_in_session(_bash(f"python /r{i}.py")) for i in range(20)]]
+    assert seq1 == seq2

--- a/tests/uni_agent/llm_router/balancer/_helpers.py
+++ b/tests/uni_agent/llm_router/balancer/_helpers.py
@@ -1,0 +1,120 @@
+"""Helpers for balancer unit tests.
+
+Defines ``_FakeProvider`` and patch helpers.  The provider patch
+(``_collectors_mod.RouteDataProvider = _FakeProvider``) is applied via a
+session-scoped autouse fixture — NOT at import time — so it only takes
+effect while balancer unit tests are running and never leaks to Ray
+workers in other test modules.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+from omegaconf import OmegaConf
+
+
+# ── Fake provider (no module-level patch) ───────────────────────────────
+
+class _FakeProvider:
+    """Stand-in for RouteDataProvider — no real collectors run."""
+
+    def __init__(self, collectors_config, collection_names,
+                 server_addresses=None, kv_event_endpoints=None):
+        self.collectors_config = collectors_config
+        self.collection_names = collection_names
+        self.server_addresses = server_addresses
+        self.kv_event_endpoints = kv_event_endpoints
+        self.started = False
+        self.stopped = False
+
+    def start(self):
+        self.started = True
+
+    def stop(self):
+        self.stopped = True
+
+    def get_metric(self, replica_id, key):
+        return 0.0
+
+    def get_metrics(self, replica_id):
+        return {}
+
+    def get_gpu_prefix_hit_rate(self, prompt_ids):
+        return {}
+
+    def get_tier_prefix_hit_rate(self, replica_id, prompt_ids, tier):
+        return 0.0
+
+
+# ── Helpers used by test classes ─────────────────────────────────────────
+
+def _router_config(weight: float = 1.0):
+    """Build a minimal router_config (OmegaConf) the Balancer accepts."""
+    return OmegaConf.create({
+        "router_class": "uni_agent.llm_router.balancer.KVCAwareBalancer",
+        "strategies": [
+            {
+                "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                "weight": weight,
+                "collector_names": ["vllm_zmq"],
+            },
+        ],
+    })
+
+
+def _fake_init_provider(self):
+    """Replacement for KVCAwareBalancer._init_provider in unit tests."""
+    collection_names = sorted(
+        {name for cfg in self._config.strategies for name in cfg.collector_names}
+    )
+    self._provider = _FakeProvider(
+        self._config.collector, collection_names,
+    )
+    self._provider.start()
+
+
+def _make_balancer(servers=None):
+    """Build a balancer over the given servers (default two)."""
+    from uni_agent.llm_router.balancer import KVCAwareBalancer
+    if servers is None:
+        servers = {"s0": "h0", "s1": "h1"}
+    return KVCAwareBalancer(servers, _router_config())
+
+
+# ── Patch fixture (session-scoped, only for ut balancer tests) ──────────
+# Replaces the old module-level patch + restore pattern.  The fixture is
+# autouse so every test in this directory gets the patch, and it is properly
+# torn down so Ray workers in other test directories never see _FakeProvider.
+
+@pytest.fixture(autouse=True, scope="session")
+def _patch_provider():
+    """Patch RouteDataProvider + _init_provider for the entire balancer/ut session.
+
+    Applied AFTER import (via fixture), so no import-time side effects.
+    Restored on teardown so st-cpu/e2e Ray workers get the real provider.
+    """
+    import uni_agent.llm_router.collectors as _collectors_mod
+    from uni_agent.llm_router.balancer import KVCAwareBalancer
+
+    # Save originals
+    _orig_provider = _collectors_mod.RouteDataProvider
+    _orig_init = KVCAwareBalancer._init_provider
+
+    # Patch RouteDataProvider so balancer.py (which imports it at top level)
+    # gets _FakeProvider when it's first imported by this test session.
+    # But balancer.py was already imported by other tests (strategies/route).
+    # The patch only affects KVCAwareBalancer._init_provider's construction
+    # path, which calls RouteDataProvider(...) — so patching the class
+    # attribute on the module is sufficient even if balancer.py is already
+    # loaded, because it looks up RouteDataProvider from the module at
+    # call time (not import time).
+    _collectors_mod.RouteDataProvider = _FakeProvider
+    KVCAwareBalancer._init_provider = _fake_init_provider
+
+    yield
+
+    # Restore — Ray workers forked AFTER this will get the real provider
+    _collectors_mod.RouteDataProvider = _orig_provider
+    KVCAwareBalancer._init_provider = _orig_init

--- a/tests/uni_agent/llm_router/balancer/_helpers.py
+++ b/tests/uni_agent/llm_router/balancer/_helpers.py
@@ -9,19 +9,16 @@ workers in other test modules.
 
 from __future__ import annotations
 
-import sys
-
 import pytest
 from omegaconf import OmegaConf
 
-
 # ── Fake provider (no module-level patch) ───────────────────────────────
+
 
 class _FakeProvider:
     """Stand-in for RouteDataProvider — no real collectors run."""
 
-    def __init__(self, collectors_config, collection_names,
-                 server_addresses=None, kv_event_endpoints=None):
+    def __init__(self, collectors_config, collection_names, server_addresses=None, kv_event_endpoints=None):
         self.collectors_config = collectors_config
         self.collection_names = collection_names
         self.server_addresses = server_addresses
@@ -50,27 +47,29 @@ class _FakeProvider:
 
 # ── Helpers used by test classes ─────────────────────────────────────────
 
+
 def _router_config(weight: float = 1.0):
     """Build a minimal router_config (OmegaConf) the Balancer accepts."""
-    return OmegaConf.create({
-        "router_class": "uni_agent.llm_router.balancer.KVCAwareBalancer",
-        "strategies": [
-            {
-                "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                "weight": weight,
-                "collector_names": ["vllm_zmq"],
-            },
-        ],
-    })
+    return OmegaConf.create(
+        {
+            "router_class": "uni_agent.llm_router.balancer.KVCAwareBalancer",
+            "strategies": [
+                {
+                    "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                    "weight": weight,
+                    "collector_names": ["vllm_zmq"],
+                },
+            ],
+        }
+    )
 
 
 def _fake_init_provider(self):
     """Replacement for KVCAwareBalancer._init_provider in unit tests."""
-    collection_names = sorted(
-        {name for cfg in self._config.strategies for name in cfg.collector_names}
-    )
+    collection_names = sorted({name for cfg in self._config.strategies for name in cfg.collector_names})
     self._provider = _FakeProvider(
-        self._config.collector, collection_names,
+        self._config.collector,
+        collection_names,
     )
     self._provider.start()
 
@@ -78,6 +77,7 @@ def _fake_init_provider(self):
 def _make_balancer(servers=None):
     """Build a balancer over the given servers (default two)."""
     from uni_agent.llm_router.balancer import KVCAwareBalancer
+
     if servers is None:
         servers = {"s0": "h0", "s1": "h1"}
     return KVCAwareBalancer(servers, _router_config())
@@ -87,6 +87,7 @@ def _make_balancer(servers=None):
 # Replaces the old module-level patch + restore pattern.  The fixture is
 # autouse so every test in this directory gets the patch, and it is properly
 # torn down so Ray workers in other test directories never see _FakeProvider.
+
 
 @pytest.fixture(autouse=True, scope="session")
 def _patch_provider():

--- a/tests/uni_agent/llm_router/balancer/conftest.py
+++ b/tests/uni_agent/llm_router/balancer/conftest.py
@@ -1,0 +1,40 @@
+"""conftest for balancer tests.
+
+Applies the _FakeProvider patch ONLY when balancer ut tests are being run.
+When st-cpu/e2e tests run (different pytest invocation, different -m filter),
+no balancer ut tests are selected, so the patch is a no-op.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _conditional_patch(request):
+    """Patch RouteDataProvider + _init_provider — only if balancer ut tests run."""
+    has_balancer_ut = any(
+        "balancer" in str(item.fspath) and item.get_closest_marker("ut")
+        for item in request.session.items
+    )
+    if not has_balancer_ut:
+        yield
+        return
+
+    from tests.uni_agent.llm_router.balancer._helpers import (
+        _FakeProvider,
+        _fake_init_provider,
+    )
+    import uni_agent.llm_router.collectors as _collectors_mod
+    from uni_agent.llm_router.balancer import KVCAwareBalancer
+
+    _orig_provider = _collectors_mod.RouteDataProvider
+    _orig_init = KVCAwareBalancer._init_provider
+
+    _collectors_mod.RouteDataProvider = _FakeProvider
+    KVCAwareBalancer._init_provider = _fake_init_provider
+
+    yield
+
+    _collectors_mod.RouteDataProvider = _orig_provider
+    KVCAwareBalancer._init_provider = _orig_init

--- a/tests/uni_agent/llm_router/balancer/conftest.py
+++ b/tests/uni_agent/llm_router/balancer/conftest.py
@@ -14,18 +14,17 @@ import pytest
 def _conditional_patch(request):
     """Patch RouteDataProvider + _init_provider — only if balancer ut tests run."""
     has_balancer_ut = any(
-        "balancer" in str(item.fspath) and item.get_closest_marker("ut")
-        for item in request.session.items
+        "balancer" in str(item.fspath) and item.get_closest_marker("ut") for item in request.session.items
     )
     if not has_balancer_ut:
         yield
         return
 
-    from tests.uni_agent.llm_router.balancer._helpers import (
-        _FakeProvider,
-        _fake_init_provider,
-    )
     import uni_agent.llm_router.collectors as _collectors_mod
+    from tests.uni_agent.llm_router.balancer._helpers import (
+        _fake_init_provider,
+        _FakeProvider,
+    )
     from uni_agent.llm_router.balancer import KVCAwareBalancer
 
     _orig_provider = _collectors_mod.RouteDataProvider

--- a/tests/uni_agent/llm_router/balancer/test_balancer_ray_integration.py
+++ b/tests/uni_agent/llm_router/balancer/test_balancer_ray_integration.py
@@ -1,0 +1,113 @@
+"""End-to-end integration tests for KVCAwareBalancer via VeRL's drop-in path.
+
+These exercise the **wiring** — VeRL ``get_router_handle`` → ``ray.remote`` →
+KVCAwareBalancer Protocol methods across the Ray actor boundary — NOT the
+routing quality. ``route()`` is a placeholder ranking (input order); the real
+KV-aware algorithm lands with the strategy-module design. So acquire tests
+assert handle-correctness for whatever id comes back, not which id is chosen.
+Per detailed_balancer.md §5.3B.
+"""
+
+from __future__ import annotations
+
+import pytest
+import ray
+
+from verl.workers.config.rollout import RouterConfig
+from verl.workers.rollout.router import get_router_handle
+
+pytestmark = [pytest.mark.st, pytest.mark.cpu]
+
+
+# Package-relative router config. VeRL resolves pkg:// via importlib (see
+# detailed_balancer.md §2.1), so this is robust to CWD / install location and
+# matches how the router is configured in production.
+_ROUTER_YAML = "pkg://uni_agent.llm_router.configs/kvc_aware_router.yaml"
+
+
+@pytest.fixture(scope="session")
+def ray_runtime():
+    ray.init(ignore_reinit_error=True)
+    yield
+    ray.shutdown()
+
+
+def _router_config() -> RouterConfig:
+    return RouterConfig(
+        router_strategy="plugin_extension", router_config_path=_ROUTER_YAML
+    )
+
+
+class TestPluginExtensionEndToEnd:
+    """I01-I05: full VeRL drop-in flow over a Ray actor (flow, not scheduling)."""
+
+    def test_i01_actor_lists_servers_and_acquires_valid_handle(self, ray_runtime):
+        """
+        Feature: a freshly created actor lists its servers and acquire returns a valid handle
+        Description: get_router_handle → get_all_servers; then acquire → (id, handle)
+        Expectation: get_all_servers returns the provided ids; acquire returns an id in the pool
+                     whose handle matches
+        """
+        servers = {"s0": "h0", "s1": "h1", "s2": "h2"}
+        handle = get_router_handle(servers, _router_config())
+        assert set(ray.get(handle.get_all_servers.remote())) == set(servers)
+        server_id, actor_handle = ray.get(handle.acquire_server.remote("r1", [1, 2, 3]))
+        assert server_id in servers
+        assert actor_handle == servers[server_id]
+
+    def test_i02_acquire_release_acquire_over_ray(self, ray_runtime):
+        """
+        Feature: release is a no-op and does not break subsequent routing
+        Description: acquire → release → acquire over the Ray actor
+        Expectation: release returns None; both acquires return valid (id, handle)
+        """
+        handle = get_router_handle({"s0": "h0"}, _router_config())
+        sid1, h1 = ray.get(handle.acquire_server.remote("r1", [1, 2]))
+        rel = ray.get(handle.release_server.remote(sid1))
+        sid2, h2 = ray.get(handle.acquire_server.remote("r2", [1, 2]))
+        assert rel is None
+        assert {sid1, sid2} <= {"s0"}
+        assert h1 == "h0" and h2 == "h0"
+
+    def test_i03_add_remove_reflected_in_pool(self, ray_runtime):
+        """
+        Feature: pool mutations are visible through the actor
+        Description: add_servers then get_all_servers; remove_servers then get_all_servers
+        Expectation: pool reflects the add and the remove
+        """
+        handle = get_router_handle({"s0": "h0"}, _router_config())
+        ray.get(handle.add_servers.remote({"s3": "h3"}))
+        assert "s3" in ray.get(handle.get_all_servers.remote())
+        ray.get(handle.remove_servers.remote(["s0"]))
+        assert "s0" not in ray.get(handle.get_all_servers.remote())
+
+    def test_i04_concurrent_acquires_both_valid(self, ray_runtime):
+        """
+        Feature: a single actor handles concurrent acquire calls without crashing
+        Description: two concurrent acquire_server.remote() resolved together
+        Expectation: both return a valid (id, handle) pair (v1 does not track inflight)
+        """
+        servers = {"s0": "h0", "s1": "h1"}
+        handle = get_router_handle(servers, _router_config())
+        (sid1, h1), (sid2, h2) = ray.get(
+            [handle.acquire_server.remote("r1", [1]), handle.acquire_server.remote("r2", [2])]
+        )
+        for sid, h in [(sid1, h1), (sid2, h2)]:
+            assert sid in servers
+            assert h == servers[sid]
+
+    def test_i05_construction_state_and_route_invocation(self, ray_runtime):
+        """
+        Feature: construction wires provider/strategies, and acquire invokes route()
+        Description: get_router_handle → get_status (construction) → acquire → get_status (route called)
+        Expectation: before acquire, provider=RouteDataProvider, strategy materialized, route_calls=0;
+                     after one acquire, route_calls=1
+        """
+        handle = get_router_handle({"s0": "h0", "s1": "h1"}, _router_config())
+        status = ray.get(handle.get_status.remote())
+        assert status["provider"] == "RouteDataProvider"
+        assert status["strategies"] == [{"type": "KVCacheAwareStrategy", "weight": 1.0}]
+        assert set(status["servers"]) == {"s0", "s1"}
+        assert status["route_calls"] == 0
+        ray.get(handle.acquire_server.remote("r1", [1, 2, 3]))
+        assert ray.get(handle.get_status.remote())["route_calls"] == 1

--- a/tests/uni_agent/llm_router/balancer/test_balancer_ray_integration.py
+++ b/tests/uni_agent/llm_router/balancer/test_balancer_ray_integration.py
@@ -33,9 +33,7 @@ def ray_runtime():
 
 
 def _router_config() -> RouterConfig:
-    return RouterConfig(
-        router_strategy="plugin_extension", router_config_path=_ROUTER_YAML
-    )
+    return RouterConfig(router_strategy="plugin_extension", router_config_path=_ROUTER_YAML)
 
 
 class TestPluginExtensionEndToEnd:

--- a/tests/uni_agent/llm_router/balancer/test_balancer_sticky.py
+++ b/tests/uni_agent/llm_router/balancer/test_balancer_sticky.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import pytest
+from omegaconf import OmegaConf
+
+from uni_agent.llm_router.balancer import KVCAwareBalancer
+
+from ._helpers import (
+    _FakeProvider,
+    _router_config,
+    _fake_init_provider,
+)
+
+pytestmark = [pytest.mark.ut, pytest.mark.cpu]
+
+
+# ============================================================
+# Sticky-session end-to-end (real strategy, no route monkeypatch)
+# ============================================================
+
+
+class _MetricsProvider:
+    """Metrics-aware fake provider for sticky e2e tests.
+
+    Configured per-replica metrics; returns real KV/load numbers so the real
+    KVCacheAwareStrategy can compute s_load and decide overload + stickiness.
+    get_gpu_prefix_hit_rate / get_tier_prefix_hit_rate return empty → combined
+    scoring degrades to load-only (no cache term), which is fine for sticky
+    behavior: the deciding factor is whether the bound replica is overloaded.
+    """
+
+    def __init__(self, metrics: dict[str, dict] | None = None):
+        self._metrics = metrics or {}
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def get_metrics(self, replica_id):
+        return dict(self._metrics.get(replica_id, {}))
+
+    def get_metric(self, replica_id, key):
+        return self.get_metrics(replica_id).get(key, 0.0)
+
+    def get_gpu_prefix_hit_rate(self, prompt_ids):
+        return {}
+
+    def get_tier_prefix_hit_rate(self, replica_id, prompt_ids, tier):
+        return 0.0
+
+    def get_gpu_prefix_hit_rate(self, prompt_ids):
+        return {}
+
+    def get_tier_prefix_hit_rate(self, replica_id, prompt_ids, tier):
+        return 0.0
+
+
+def _kv_metrics(per_replica: dict[str, dict]) -> dict[str, dict]:
+    """Normalize {sid: {kv, running, waiting}} into MetricKey-keyed dicts.
+
+    Defaults: kv=0.3 (→ load=0.12, NOT overloaded under load_threshold 0.9),
+    running=0, waiting=0.
+    """
+    from uni_agent.llm_router.metric_spec import MetricKey
+
+    out = {}
+    for sid, m in per_replica.items():
+        out[sid] = {
+            MetricKey.KV_CACHE_USAGE_PERC: m.get("kv", 0.3),
+            MetricKey.NUM_REQUESTS_RUNNING: m.get("running", 0),
+            MetricKey.NUM_REQUESTS_WAITING: m.get("waiting", 0),
+        }
+    return out
+
+
+class TestStickyEndToEnd:
+    """Real KVCacheAwareStrategy + real route(): sticky affinity across turns."""
+
+    def _make_balancer_with_metrics(self, servers, metrics):
+        """Build a balancer whose provider returns the given per-replica metrics."""
+        import uni_agent.llm_router.balancer as balancer_mod
+        from uni_agent.llm_router import metric_spec
+
+        provider = _MetricsProvider(metrics)
+
+        def fake_init(self):
+            self._provider = provider
+
+        orig = KVCAwareBalancer._init_provider
+        KVCAwareBalancer._init_provider = fake_init
+        try:
+            return KVCAwareBalancer(servers, _router_config())
+        finally:
+            KVCAwareBalancer._init_provider = orig
+
+    def test_second_turn_same_request_stays_sticky(self):
+        """Feature: bound + not overloaded → second turn routes to same server.
+        Description: turn1 acquires (cold start, picks some server); turn2 same
+        request_id with that server still healthy must return the SAME server.
+        Expectation: turn1.sid == turn2.sid (sticky hit)
+        """
+        # s0/s1 both healthy (kv=0.3 → load=0.12, not overloaded)
+        balancer = self._make_balancer_with_metrics(
+            {"s0": "h0", "s1": "h1"}, _kv_metrics({"s0": {}, "s1": {}}),
+        )
+        sid1, _ = balancer.acquire_server("r1", [1, 2])
+        sid2, _ = balancer.acquire_server("r1", [1, 2])
+        assert sid1 == sid2
+
+    def test_overloaded_sticky_falls_back_to_healthy(self, monkeypatch):
+        """Feature: bound replica becomes saturated (load>0.9) → rebind to a healthy one.
+        Description: turn1 binds r1→s0; then s0 saturated (kv=1,r=64,w=1000 → load≈0.98),
+        s1 healthy (kv=0.3 → load=0.12).
+        Expectation: turn2 routes to s1 (not the saturated s0), and rebinds r1→s1
+        """
+        monkeypatch.setenv("MAX_NUM_SEQS", "64")  # pin the load formula's running term
+        # turn1: both healthy, cold start
+        balancer = self._make_balancer_with_metrics(
+            {"s0": "h0", "s1": "h1"}, _kv_metrics({"s0": {}, "s1": {}}),
+        )
+        sid1, _ = balancer.acquire_server("r1", [1, 2])
+        # mutate metrics: s0 now saturated (load>0.9), s1 healthy
+        balancer._provider._metrics = _kv_metrics({
+            "s0": {"kv": 1.0, "running": 64, "waiting": 1000},
+            "s1": {"kv": 0.3},
+        })
+        sid2, _ = balancer.acquire_server("r1", [1, 2])
+        assert sid2 == "s1", f"expected fallback to s1, got {sid2} (turn1 was {sid1})"
+
+    def test_removed_sticky_server_reselects(self):
+        """Feature: bound server removed → reselect from remaining pool.
+        Description: turn1 binds r1→s0; remove s0; turn2 must pick from {s1,s2}.
+        Expectation: turn2 sid in {s1,s2}, no crash, sticky rebound
+        """
+        balancer = self._make_balancer_with_metrics(
+            {"s0": "h0", "s1": "h1", "s2": "h2"},
+            _kv_metrics({"s0": {}, "s1": {}, "s2": {}}),
+        )
+        sid1, _ = balancer.acquire_server("r1", [1, 2])
+        balancer.remove_servers(["s0"])
+        sid2, _ = balancer.acquire_server("r1", [1, 2])
+        assert sid2 in {"s1", "s2"}
+        # sticky binding to s0 should have been invalidated
+        assert balancer._sticky.get("r1") in {"s1", "s2"}
+
+    def test_get_status_reports_sticky_size(self):
+        """Feature: get_status() includes sticky_size.
+        Description: acquire two distinct request_ids; check status
+        Expectation: sticky_size == 2
+        """
+        balancer = self._make_balancer_with_metrics(
+            {"s0": "h0", "s1": "h1"}, _kv_metrics({"s0": {}, "s1": {}}),
+        )
+        balancer.acquire_server("r1", [1])
+        balancer.acquire_server("r2", [1])
+        status = balancer.get_status()
+        assert status["sticky_size"] == 2
+
+    def test_sticky_respects_configured_max_size(self):
+        """Feature: KVCAwareConfig.sticky_max_size flows to the sticky table.
+        Description: build a balancer with sticky_max_size overridden in config
+        Expectation: balancer._sticky.max_size == overridden value
+        """
+        cfg = OmegaConf.create({
+            "router_class": "uni_agent.llm_router.balancer.KVCAwareBalancer",
+            "sticky_max_size": 42,
+            "strategies": [
+                {
+                    "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                    "weight": 1.0,
+                    "collector_names": ["vllm_zmq"],
+                },
+            ],
+        })
+        orig = KVCAwareBalancer._init_provider
+        KVCAwareBalancer._init_provider = lambda self: setattr(
+            self, "_provider", _MetricsProvider(_kv_metrics({"s0": {}})),
+        )
+        try:
+            balancer = KVCAwareBalancer({"s0": "h0"}, cfg)
+            assert balancer._sticky.max_size == 42
+        finally:
+            KVCAwareBalancer._init_provider = orig

--- a/tests/uni_agent/llm_router/balancer/test_balancer_sticky.py
+++ b/tests/uni_agent/llm_router/balancer/test_balancer_sticky.py
@@ -6,9 +6,7 @@ from omegaconf import OmegaConf
 from uni_agent.llm_router.balancer import KVCAwareBalancer
 
 from ._helpers import (
-    _FakeProvider,
     _router_config,
-    _fake_init_provider,
 )
 
 pytestmark = [pytest.mark.ut, pytest.mark.cpu]
@@ -50,12 +48,6 @@ class _MetricsProvider:
     def get_tier_prefix_hit_rate(self, replica_id, prompt_ids, tier):
         return 0.0
 
-    def get_gpu_prefix_hit_rate(self, prompt_ids):
-        return {}
-
-    def get_tier_prefix_hit_rate(self, replica_id, prompt_ids, tier):
-        return 0.0
-
 
 def _kv_metrics(per_replica: dict[str, dict]) -> dict[str, dict]:
     """Normalize {sid: {kv, running, waiting}} into MetricKey-keyed dicts.
@@ -80,8 +72,6 @@ class TestStickyEndToEnd:
 
     def _make_balancer_with_metrics(self, servers, metrics):
         """Build a balancer whose provider returns the given per-replica metrics."""
-        import uni_agent.llm_router.balancer as balancer_mod
-        from uni_agent.llm_router import metric_spec
 
         provider = _MetricsProvider(metrics)
 
@@ -103,7 +93,8 @@ class TestStickyEndToEnd:
         """
         # s0/s1 both healthy (kv=0.3 → load=0.12, not overloaded)
         balancer = self._make_balancer_with_metrics(
-            {"s0": "h0", "s1": "h1"}, _kv_metrics({"s0": {}, "s1": {}}),
+            {"s0": "h0", "s1": "h1"},
+            _kv_metrics({"s0": {}, "s1": {}}),
         )
         sid1, _ = balancer.acquire_server("r1", [1, 2])
         sid2, _ = balancer.acquire_server("r1", [1, 2])
@@ -118,14 +109,17 @@ class TestStickyEndToEnd:
         monkeypatch.setenv("MAX_NUM_SEQS", "64")  # pin the load formula's running term
         # turn1: both healthy, cold start
         balancer = self._make_balancer_with_metrics(
-            {"s0": "h0", "s1": "h1"}, _kv_metrics({"s0": {}, "s1": {}}),
+            {"s0": "h0", "s1": "h1"},
+            _kv_metrics({"s0": {}, "s1": {}}),
         )
         sid1, _ = balancer.acquire_server("r1", [1, 2])
         # mutate metrics: s0 now saturated (load>0.9), s1 healthy
-        balancer._provider._metrics = _kv_metrics({
-            "s0": {"kv": 1.0, "running": 64, "waiting": 1000},
-            "s1": {"kv": 0.3},
-        })
+        balancer._provider._metrics = _kv_metrics(
+            {
+                "s0": {"kv": 1.0, "running": 64, "waiting": 1000},
+                "s1": {"kv": 0.3},
+            }
+        )
         sid2, _ = balancer.acquire_server("r1", [1, 2])
         assert sid2 == "s1", f"expected fallback to s1, got {sid2} (turn1 was {sid1})"
 
@@ -151,7 +145,8 @@ class TestStickyEndToEnd:
         Expectation: sticky_size == 2
         """
         balancer = self._make_balancer_with_metrics(
-            {"s0": "h0", "s1": "h1"}, _kv_metrics({"s0": {}, "s1": {}}),
+            {"s0": "h0", "s1": "h1"},
+            _kv_metrics({"s0": {}, "s1": {}}),
         )
         balancer.acquire_server("r1", [1])
         balancer.acquire_server("r2", [1])
@@ -163,20 +158,24 @@ class TestStickyEndToEnd:
         Description: build a balancer with sticky_max_size overridden in config
         Expectation: balancer._sticky.max_size == overridden value
         """
-        cfg = OmegaConf.create({
-            "router_class": "uni_agent.llm_router.balancer.KVCAwareBalancer",
-            "sticky_max_size": 42,
-            "strategies": [
-                {
-                    "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                    "weight": 1.0,
-                    "collector_names": ["vllm_zmq"],
-                },
-            ],
-        })
+        cfg = OmegaConf.create(
+            {
+                "router_class": "uni_agent.llm_router.balancer.KVCAwareBalancer",
+                "sticky_max_size": 42,
+                "strategies": [
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 1.0,
+                        "collector_names": ["vllm_zmq"],
+                    },
+                ],
+            }
+        )
         orig = KVCAwareBalancer._init_provider
         KVCAwareBalancer._init_provider = lambda self: setattr(
-            self, "_provider", _MetricsProvider(_kv_metrics({"s0": {}})),
+            self,
+            "_provider",
+            _MetricsProvider(_kv_metrics({"s0": {}})),
         )
         try:
             balancer = KVCAwareBalancer({"s0": "h0"}, cfg)

--- a/tests/uni_agent/llm_router/balancer/test_balancer_unit.py
+++ b/tests/uni_agent/llm_router/balancer/test_balancer_unit.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+import pytest
+from omegaconf import OmegaConf
+
+from uni_agent.llm_router.balancer import KVCAwareBalancer
+from uni_agent.llm_router.strategies import KVCacheAwareStrategy
+
+from ._helpers import (
+    _FakeProvider,
+    _router_config,
+    _fake_init_provider,
+    _make_balancer,
+)
+
+pytestmark = [pytest.mark.ut, pytest.mark.cpu]
+
+
+# ============================================================
+# 5.1 / construction
+# ============================================================
+
+
+class TestKVCAwareBalancerConstruction:
+    """B01-Bnn: __init__ wiring and validation."""
+
+    def test_b01_normal_construction_wires_components(self):
+        """
+        Feature: construction wires config/provider/strategies/servers
+        Description: KVCAwareBalancer({"s0": h0}, router_config)
+        Expectation: _provider built and started; _strategies wired with weight
+        """
+        balancer = KVCAwareBalancer({"s0": "h0"}, _router_config())
+        assert balancer._provider.started is True
+        assert balancer._provider.collection_names == ["vllm_zmq"]
+        assert len(balancer._strategies) == 1
+        strat, weight = balancer._strategies[0]
+        assert isinstance(strat, KVCacheAwareStrategy)
+        assert weight == 1.0
+
+    def test_b02_empty_servers_raises_value_error(self):
+        """
+        Feature: empty servers pool is rejected
+        Description: KVCAwareBalancer({}, router_config)
+        Expectation: raises ValueError
+        """
+        with pytest.raises(ValueError):
+            KVCAwareBalancer({}, _router_config())
+
+    def test_b02b_missing_strategies_raises_config_error(self):
+        """
+        Feature: a config missing strategies is rejected (delegated to from_config)
+        Description: KVCAwareBalancer with an empty router_config
+        Expectation: raises ConfigError
+        """
+        from uni_agent.llm_router import ConfigError
+
+        with pytest.raises(ConfigError):
+            KVCAwareBalancer({"s0": "h0"}, OmegaConf.create({}))
+
+    def test_b03_construction_starts_provider(self):
+        """
+        Feature: construction starts the provider (lifecycle)
+        Description: construct balancer (autouse _FakeProvider) and check start()
+        Expectation: the provider's start() is invoked during __init__
+        """
+        balancer = KVCAwareBalancer({"s0": "h0"}, _router_config())
+        assert balancer._provider.started is True
+
+
+# ============================================================
+# trivial methods: get_all_servers / get_status / release_server
+# ============================================================
+
+
+class TestTrivialMethods:
+    """B04-B06: the no-algorithm Protocol methods."""
+
+    def test_b04_get_all_servers_returns_ids(self):
+        """
+        Feature: get_all_servers returns the server ids in the pool
+        Description: get_all_servers() on a two-server balancer
+        Expectation: returns exactly the pool's ids
+        """
+        balancer = _make_balancer({"s0": "h0", "s1": "h1"})
+        assert set(balancer.get_all_servers()) == {"s0", "s1"}
+
+    def test_b05_get_status_reports_construction_state(self):
+        """
+        Feature: get_status reports the balancer's construction state
+        Description: get_status() on a freshly constructed balancer
+        Expectation: reports provider type, materialized strategy, pool ids, route_calls=0
+        """
+        balancer = _make_balancer({"s0": "h0"})
+        status = balancer.get_status()
+        # provider is the injected _FakeProvider in unit tests; real env reports
+        # "RouteDataProvider". Assert it matches the constructed provider's type.
+        assert status["provider"] == type(balancer._provider).__name__
+        assert status["strategies"] == [{"type": "KVCacheAwareStrategy", "weight": 1.0}]
+        assert status["servers"] == ["s0"]
+        assert status["route_calls"] == 0
+
+    def test_b06_release_server_is_noop(self):
+        """
+        Feature: release_server is a no-op (v1 does not track inflight)
+        Description: release_server on a known and an unknown id
+        Expectation: returns None for both; pool unchanged
+        """
+        balancer = _make_balancer({"s0": "h0"})
+        assert balancer.release_server("s0") is None
+        assert balancer.release_server("s999") is None
+        assert set(balancer.get_all_servers()) == {"s0"}
+
+
+# ============================================================
+# acquire_server — route() delegation
+# ============================================================
+
+
+class TestAcquireServer:
+    """B07-Bnn: acquire_server delegates to route() and maps back to a handle."""
+
+    def test_b07_returns_top_ranked_server_and_handle(self, monkeypatch):
+        """
+        Feature: acquire_server returns the top-ranked server and its handle
+        Description: mock route() to return ["s0","s1","s2"]
+        Expectation: returns (s0, h0)
+        """
+        import uni_agent.llm_router.balancer as balancer_mod
+
+        monkeypatch.setattr(balancer_mod, "route", lambda *a, **k: ["s0", "s1", "s2"])
+        balancer = _make_balancer({"s0": "h0", "s1": "h1", "s2": "h2"})
+        assert balancer.acquire_server("r1", [1, 2, 3]) == ("s0", "h0")
+
+    def test_b08_prompt_ids_and_replicas_passed_to_route(self, monkeypatch):
+        """
+        Feature: prompt_ids and pool replicas are forwarded to route()
+        Description: spy on route() and capture its arguments
+        Expectation: prompt_ids matches the call; replicas carry every pool id
+        """
+        import uni_agent.llm_router.balancer as balancer_mod
+
+        seen = {}
+
+        def fake_route(strategies, prompt_ids, provider, replicas, *args, **kwargs):
+            seen["prompt_ids"] = prompt_ids
+            seen["replica_ids"] = [r.replica_id for r in replicas]
+            return ["s0"]
+
+        monkeypatch.setattr(balancer_mod, "route", fake_route)
+        balancer = _make_balancer({"s0": "h0", "s1": "h1"})
+        balancer.acquire_server("r1", [7, 8, 9])
+        assert seen["prompt_ids"] == [7, 8, 9]
+        assert set(seen["replica_ids"]) == {"s0", "s1"}
+
+    def test_b09_maps_returned_id_to_handle(self, monkeypatch):
+        """
+        Feature: the returned top id maps to its actor handle
+        Description: mock route() to return ["s1","s0"]
+        Expectation: returns (s1, h1) — not the first pool entry
+        """
+        import uni_agent.llm_router.balancer as balancer_mod
+
+        monkeypatch.setattr(balancer_mod, "route", lambda *a, **k: ["s1", "s0"])
+        balancer = _make_balancer({"s0": "h0", "s1": "h1"})
+        assert balancer.acquire_server("r1", [1]) == ("s1", "h1")
+
+    def test_b10_empty_ranking_raises_runtime_error(self, monkeypatch):
+        """
+        Feature: an empty ranking (no available / all blacklisted) raises
+        Description: mock route() to return []
+        Expectation: raises RuntimeError
+        """
+        import uni_agent.llm_router.balancer as balancer_mod
+
+        monkeypatch.setattr(balancer_mod, "route", lambda *a, **k: [])
+        balancer = _make_balancer({"s0": "h0"})
+        with pytest.raises(RuntimeError):
+            balancer.acquire_server("r1", [1])
+
+    def test_b11_none_prompt_ids_passes_through(self, monkeypatch):
+        """
+        Feature: prompt_ids=None is forwarded unchanged (strategy degrades to load)
+        Description: acquire_server("r1", None); spy on route()
+        Expectation: route receives prompt_ids is None; acquire returns normally
+        """
+        import uni_agent.llm_router.balancer as balancer_mod
+
+        seen = {}
+
+        def fake_route(strategies, prompt_ids, provider, replicas, *args, **kwargs):
+            seen["prompt_ids"] = prompt_ids
+            return ["s0"]
+
+        monkeypatch.setattr(balancer_mod, "route", fake_route)
+        balancer = _make_balancer({"s0": "h0"})
+        assert balancer.acquire_server("r1", None) == ("s0", "h0")
+        assert seen["prompt_ids"] is None
+
+
+# ============================================================
+# add_servers / remove_servers — pool mutations
+# (provider is global / not keyed by the pool, so only _servers is touched)
+# ============================================================
+
+
+class TestServerPoolMutations:
+    """B12-Bnn: add/remove mutate the server pool."""
+
+    def test_b12_add_servers_grows_pool(self):
+        """
+        Feature: add_servers grows the pool
+        Description: add_servers({"s1":h1,"s2":h2}) on a one-server balancer
+        Expectation: pool has s0/s1/s2
+        """
+        balancer = _make_balancer({"s0": "h0"})
+        balancer.add_servers({"s1": "h1", "s2": "h2"})
+        assert set(balancer.get_all_servers()) == {"s0", "s1", "s2"}
+
+    def test_b13_add_servers_empty_dict_is_noop(self):
+        """
+        Feature: adding an empty dict changes nothing
+        Description: add_servers({}) on a one-server balancer
+        Expectation: pool unchanged
+        """
+        balancer = _make_balancer({"s0": "h0"})
+        balancer.add_servers({})
+        assert set(balancer.get_all_servers()) == {"s0"}
+
+    def test_b14_add_servers_duplicate_overwrites_handle(self):
+        """
+        Feature: adding an existing id overwrites its handle (bulk-add semantics)
+        Description: add_servers({"s0": new}) when s0 already in pool
+        Expectation: handle overwritten; no error raised
+        """
+        balancer = _make_balancer({"s0": "h0"})
+        balancer.add_servers({"s0": "h0_new"})
+        assert balancer._servers["s0"] == "h0_new"
+
+    def test_b15_remove_servers_shrinks_pool(self):
+        """
+        Feature: remove_servers shrinks the pool
+        Description: remove_servers(["s0"]) on a two-server balancer
+        Expectation: pool keeps only s1
+        """
+        balancer = _make_balancer({"s0": "h0", "s1": "h1"})
+        balancer.remove_servers(["s0"])
+        assert set(balancer.get_all_servers()) == {"s1"}
+
+    def test_b16_remove_servers_unknown_id_is_noop(self):
+        """
+        Feature: removing an unknown id changes nothing and does not raise
+        Description: remove_servers(["s999"]) on a one-server balancer
+        Expectation: pool unchanged
+        """
+        balancer = _make_balancer({"s0": "h0"})
+        balancer.remove_servers(["s999"])
+        assert set(balancer.get_all_servers()) == {"s0"}
+
+
+# ============================================================
+# 5.3A end-to-end flows (balancer directly, route() mocked)
+# ============================================================
+
+
+class TestEndToEndFlows:
+    """B17-B18: multi-step flows over the balancer (route() mocked)."""
+
+    def test_b17_acquire_release_acquire(self, monkeypatch):
+        """
+        Feature: release does not affect subsequent routing
+        Description: acquire → release → acquire with route() returning s0
+        Expectation: both acquires return a valid server; release is None
+        """
+        import uni_agent.llm_router.balancer as balancer_mod
+
+        monkeypatch.setattr(balancer_mod, "route", lambda *a, **k: ["s0"])
+        balancer = _make_balancer({"s0": "h0"})
+        first = balancer.acquire_server("r1", [1, 2])
+        assert balancer.release_server("s0") is None
+        second = balancer.acquire_server("r2", [1, 2])
+        assert first == ("s0", "h0")
+        assert second == ("s0", "h0")
+
+    def test_b18_dynamic_add_remove_then_route(self, monkeypatch):
+        """
+        Feature: pool mutations take effect for subsequent routing
+        Description: route() returns pool replicas in order; add then remove between acquires
+        Expectation: after remove, the removed id is no longer routable
+        """
+        import uni_agent.llm_router.balancer as balancer_mod
+
+        def fake_route(strategies, prompt_ids, provider, replicas, *args, **kwargs):
+            return [r.replica_id for r in replicas]
+
+        monkeypatch.setattr(balancer_mod, "route", fake_route)
+        balancer = _make_balancer({"s0": "h0"})
+
+        balancer.add_servers({"s3": "h3"})
+        assert balancer.acquire_server("r1", [1])[0] in {"s0", "s3"}
+
+        balancer.remove_servers(["s0"])
+        assert "s0" not in balancer.get_all_servers()
+        assert balancer.acquire_server("r2", [1])[0] == "s3"
+
+    def test_b19_router_class_fqn_importable(self):
+        """
+        Feature: the YAML router_class FQN resolves to KVCAwareBalancer
+        Description: importlib.import_module + getattr on the documented FQN
+        Expectation: returns the KVCAwareBalancer class (VeRL's drop-in lookup step)
+        """
+        import importlib
+
+        mod = importlib.import_module("uni_agent.llm_router.balancer")
+        assert getattr(mod, "KVCAwareBalancer") is KVCAwareBalancer
+
+
+# ============================================================
+# Sticky-session end-to-end (real strategy, no route monkeypatch)
+# ============================================================
+
+
+class _MetricsProvider:
+    """Metrics-aware fake provider for sticky e2e tests.
+
+    Configured per-replica metrics; returns real KV/load numbers so the real
+    KVCacheAwareStrategy can compute s_load and decide overload + stickiness.
+    get_gpu_prefix_hit_rate / get_tier_prefix_hit_rate return empty → combined
+    scoring degrades to load-only (no cache term), which is fine for sticky
+    behavior: the deciding factor is whether the bound replica is overloaded.
+    """
+
+    def __init__(self, metrics: dict[str, dict] | None = None):
+        self._metrics = metrics or {}
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def get_metrics(self, replica_id):
+        return dict(self._metrics.get(replica_id, {}))
+
+    def get_metric(self, replica_id, key):
+        return self.get_metrics(replica_id).get(key, 0.0)
+
+    def get_gpu_prefix_hit_rate(self, prompt_ids):
+        return {}
+
+    def get_tier_prefix_hit_rate(self, replica_id, prompt_ids, tier):
+        return 0.0
+
+    def get_gpu_prefix_hit_rate(self, prompt_ids):
+        return {}
+
+    def get_tier_prefix_hit_rate(self, replica_id, prompt_ids, tier):
+        return 0.0
+
+
+def _kv_metrics(per_replica: dict[str, dict]) -> dict[str, dict]:
+    """Normalize {sid: {kv, running, waiting}} into MetricKey-keyed dicts.
+
+    Defaults: kv=0.3 (→ load=0.12, NOT overloaded under load_threshold 0.9),
+    running=0, waiting=0.
+    """
+    from uni_agent.llm_router.metric_spec import MetricKey
+
+    out = {}
+    for sid, m in per_replica.items():
+        out[sid] = {
+            MetricKey.KV_CACHE_USAGE_PERC: m.get("kv", 0.3),
+            MetricKey.NUM_REQUESTS_RUNNING: m.get("running", 0),
+            MetricKey.NUM_REQUESTS_WAITING: m.get("waiting", 0),
+        }
+    return out
+
+

--- a/tests/uni_agent/llm_router/balancer/test_balancer_unit.py
+++ b/tests/uni_agent/llm_router/balancer/test_balancer_unit.py
@@ -7,10 +7,8 @@ from uni_agent.llm_router.balancer import KVCAwareBalancer
 from uni_agent.llm_router.strategies import KVCacheAwareStrategy
 
 from ._helpers import (
-    _FakeProvider,
-    _router_config,
-    _fake_init_provider,
     _make_balancer,
+    _router_config,
 )
 
 pytestmark = [pytest.mark.ut, pytest.mark.cpu]
@@ -312,7 +310,7 @@ class TestEndToEndFlows:
         import importlib
 
         mod = importlib.import_module("uni_agent.llm_router.balancer")
-        assert getattr(mod, "KVCAwareBalancer") is KVCAwareBalancer
+        assert mod.KVCAwareBalancer is KVCAwareBalancer
 
 
 # ============================================================
@@ -351,12 +349,6 @@ class _MetricsProvider:
     def get_tier_prefix_hit_rate(self, replica_id, prompt_ids, tier):
         return 0.0
 
-    def get_gpu_prefix_hit_rate(self, prompt_ids):
-        return {}
-
-    def get_tier_prefix_hit_rate(self, replica_id, prompt_ids, tier):
-        return 0.0
-
 
 def _kv_metrics(per_replica: dict[str, dict]) -> dict[str, dict]:
     """Normalize {sid: {kv, running, waiting}} into MetricKey-keyed dicts.
@@ -374,5 +366,3 @@ def _kv_metrics(per_replica: dict[str, dict]) -> dict[str, dict]:
             MetricKey.NUM_REQUESTS_WAITING: m.get("waiting", 0),
         }
     return out
-
-

--- a/tests/uni_agent/llm_router/ci_test.sh
+++ b/tests/uni_agent/llm_router/ci_test.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# ci_test.sh — full CI test suite for llm_router.
+#
+# Four test stages, ordered by increasing weight:
+#   ut      — pure unit tests (config, strategies, balancer logic). No Ray, no GPU.
+#   st-cpu  — system tests on CPU (balancer integration over a real Ray cluster).
+#   st-gpu  — integration tests against a real vLLM service (PollingCollector &
+#             KVEventCollector). Needs GPU + a local model.
+#   e2e     — end-to-end tests via run_infer.sh (KVCAware router + mooncake).
+#             Needs GPU + full vLLM + Ray agent loop. Standalone (no conftest sharing).
+#
+# Each test carries pytest markers (registered in conftest.py) on two dimensions:
+#   type:     ``ut`` / ``st`` / ``e2e``
+#   resource: ``cpu`` / ``gpu``
+# Stages are selected with ``-m``:
+#   pytest -m ut                  # the ut stage
+#   pytest -m "st and cpu"        # the st-cpu stage
+#   pytest -m "st and gpu"        # the st-gpu stage
+#   pytest -m e2e                 # the e2e stage
+#
+# Stages are independent. Residual Ray/vLLM processes are cleaned up between
+# stages so a prior stage never leaves GPU/IPC state that breaks the next.
+#
+# Environment variables (st-gpu / e2e):
+#   VLLM_MODEL       — model ID or local path (default: Qwen/Qwen3-4B)
+#   VLLM_HOST        — host to bind vLLM server (default: 127.0.0.1)
+#   VLLM_PORT        — port for vLLM server (default: 8000)
+#   ZMQ_SUB_PORT     — ZMQ PUB socket port (default: 5555)
+#   ZMQ_REPLAY_PORT  — ZMQ ROUTER replay port (default: 5556)
+#   CUDA_VISIBLE_DEVICES — GPUs visible to st-gpu/e2e (e.g. 0,1,2,3,4,5,6,7)
+#
+# Usage:
+#   ./ci_test.sh                          # run all stages
+#   ./ci_test.sh --ut                     # unit tests only
+#   ./ci_test.sh --st-cpu                 # CPU system tests only
+#   ./ci_test.sh --st-gpu                 # GPU integration tests only
+#   ./ci_test.sh --e2e                    # end-to-end tests only
+#   ./ci_test.sh --ut --st-cpu            # unit + CPU system tests
+
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────
+export VLLM_MODEL="${VLLM_MODEL:-Qwen/Qwen3-4B}"
+export VLLM_HOST="${VLLM_HOST:-127.0.0.1}"
+export VLLM_PORT="${VLLM_PORT:-8000}"
+export ZMQ_SUB_PORT="${ZMQ_SUB_PORT:-5555}"
+export ZMQ_REPLAY_PORT="${ZMQ_REPLAY_PORT:-5556}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Stage selection ───────────────────────────────────────────────────────
+RUN_UT=false
+RUN_ST_CPU=false
+RUN_ST_GPU=false
+RUN_E2E=false
+RUN_ALL=true
+
+for arg in "$@"; do
+    case "$arg" in
+        --ut)     RUN_ALL=false; RUN_UT=true ;;
+        --st-cpu) RUN_ALL=false; RUN_ST_CPU=true ;;
+        --st-gpu) RUN_ALL=false; RUN_ST_GPU=true ;;
+        --e2e)    RUN_ALL=false; RUN_E2E=true ;;
+        *)
+            echo "Unknown option: $arg" >&2
+            echo "Usage: $0 [--ut] [--st-cpu] [--st-gpu] [--e2e]" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if $RUN_ALL; then RUN_UT=true; RUN_ST_CPU=true; RUN_ST_GPU=true; RUN_E2E=true; fi
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+cleanup_processes() {
+    pkill -9 -f "vllm.entrypoints" 2>/dev/null || true
+    pkill -9 -f "ray::" 2>/dev/null || true
+    pkill -9 -f "raylet" 2>/dev/null || true
+    pkill -9 -f "gcs_server" 2>/dev/null || true
+    pkill -9 -f "mooncake_master" 2>/dev/null || true
+    sleep 2
+}
+
+print_summary() {
+    local label="$1" code="$2"
+    if [ "$code" -eq 0 ]; then
+        echo ">>> $label: PASS"
+    else
+        echo ">>> $label: FAIL (exit $code)"
+    fi
+}
+
+OVERALL=0
+
+echo "=== llm_router CI tests ==="
+STAGES=""
+$RUN_UT     && STAGES="${STAGES}ut "
+$RUN_ST_CPU && STAGES="${STAGES}st-cpu "
+$RUN_ST_GPU && STAGES="${STAGES}st-gpu "
+$RUN_E2E    && STAGES="${STAGES}e2e"
+echo "  Stages       : ${STAGES}"
+echo "  Model        : ${VLLM_MODEL}"
+echo "  vLLM Host    : ${VLLM_HOST}:${VLLM_PORT}"
+echo "  ZMQ Sub/Repl : ${ZMQ_SUB_PORT}/${ZMQ_REPLAY_PORT}"
+echo ""
+
+# ── ut: pure unit tests (no Ray, no GPU) ─────────────────────────────────
+if $RUN_UT; then
+    echo "--- ut: unit tests (config / strategies / balancer logic) ---"
+    cleanup_processes
+    set +e
+    python -m pytest "${SCRIPT_DIR}" -m "ut" -v
+    code=$?
+    set -e
+    print_summary "ut" "$code"
+    [ "$code" -ne 0 ] && OVERALL=$code
+fi
+
+# ── st-cpu: Ray actor integration on CPU ─────────────────────────────────
+if $RUN_ST_CPU; then
+    echo ""
+    echo "--- st-cpu: balancer integration over Ray (CPU) ---"
+    cleanup_processes
+    set +e
+    python -m pytest "${SCRIPT_DIR}" -m "st and cpu" -v
+    code=$?
+    set -e
+    print_summary "st-cpu" "$code"
+    [ "$code" -ne 0 ] && OVERALL=$code
+fi
+
+# ── st-gpu: real vLLM + GPU integration (collector tests) ────────────────
+if $RUN_ST_GPU; then
+    echo ""
+    echo "--- st-gpu: PollingCollector + KVEventCollector against real vLLM ---"
+    cleanup_processes
+    set +e
+    VLLM_PORT=${VLLM_PORT} ZMQ_SUB_PORT=${ZMQ_SUB_PORT} ZMQ_REPLAY_PORT=${ZMQ_REPLAY_PORT} \
+        python -m pytest "${SCRIPT_DIR}" -m "st and gpu" -v
+    code=$?
+    set -e
+    cleanup_processes
+    print_summary "st-gpu" "$code"
+    [ "$code" -ne 0 ] && OVERALL=$code
+fi
+
+# ── e2e: end-to-end via run_infer.sh (KVCAware router + mooncake) ────────
+if $RUN_E2E; then
+    echo ""
+    echo "--- e2e: KVCAware router + mooncake end-to-end via run_infer.sh ---"
+    cleanup_processes
+    set +e
+    python -m pytest "${SCRIPT_DIR}/e2e/" -m "e2e" -v
+    code=$?
+    set -e
+    cleanup_processes
+    print_summary "e2e" "$code"
+    [ "$code" -ne 0 ] && OVERALL=$code
+fi
+
+echo ""
+echo "=== All tests done (overall exit ${OVERALL}) ==="
+exit $OVERALL

--- a/tests/uni_agent/llm_router/collectors/conftest.py
+++ b/tests/uni_agent/llm_router/collectors/conftest.py
@@ -1,0 +1,141 @@
+"""Shared fixtures and helpers for collectors integration tests.
+
+All three test modules (vllm_kv_event_collector, vllm_polling_collector,
+route_data_provider_gpu_prefix_hit_rate) share one vLLM process for the
+entire pytest session, avoiding redundant model loading.
+
+The session-scoped ``vllm_kv_service`` fixture starts vLLM with ZMQ KV events
+enabled.  Polling tests also use this server via the ``vllm_service`` alias —
+the polling collector only reads the HTTP ``/metrics`` endpoint, which works
+regardless of whether ZMQ events are enabled.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+
+import pytest
+import httpx
+
+
+# ── Shared configuration constants ───────────────────────────────────────
+
+VLLM_MODEL = os.environ.get("VLLM_MODEL", "Qwen/Qwen3-4B")
+VLLM_HOST = os.environ.get("VLLM_HOST", "127.0.0.1")
+VLLM_PORT = int(os.environ.get("VLLM_PORT", "8000"))
+NODE_ID = f"{VLLM_HOST}:{VLLM_PORT}"
+
+ZMQ_SUB_PORT = int(os.environ.get("ZMQ_SUB_PORT", "5555"))
+ZMQ_REPLAY_PORT = int(os.environ.get("ZMQ_REPLAY_PORT", "5556"))
+
+
+# ── Shared helper ────────────────────────────────────────────────────────
+
+def send_inference_request(node_id: str, model: str, prompt: str = "hello") -> bool:
+    """POST a chat-completions request to trigger KV cache events.
+
+    Returns True on HTTP 200, False on any error.
+    """
+    try:
+        resp = httpx.post(
+            f"http://{node_id}/v1/chat/completions",
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": 50,
+                "temperature": 0.7,
+            },
+            timeout=30.0,
+        )
+        return resp.status_code == 200
+    except Exception:
+        return False
+
+
+# ── Session-scoped vLLM fixture ──────────────────────────────────────────
+
+@pytest.fixture(scope="session")
+def vllm_kv_service():
+    """Start one vLLM server with ZMQ KV events for the entire test session.
+
+    Binds:
+      - HTTP API at http://<VLLM_HOST>:<VLLM_PORT>   (metrics + completions)
+      - ZMQ PUB  at tcp://*:<ZMQ_SUB_PORT>            (KV-cache event stream)
+      - ZMQ REP  at tcp://*:<ZMQ_REPLAY_PORT>          (event replay)
+
+    Yields ``node_id`` (``"host:port"``).  The process is SIGTERM'd on teardown.
+    """
+    kv_events_config = json.dumps({
+        "enable_kv_cache_events": True,
+        "publisher": "zmq",
+        "topic": "kv-events",
+        "endpoint": f"tcp://*:{ZMQ_SUB_PORT}",
+        "replay_endpoint": f"tcp://*:{ZMQ_REPLAY_PORT}",
+    })
+
+    cmd = [
+        sys.executable, "-m", "vllm.entrypoints.openai.api_server",
+        "--model", VLLM_MODEL,
+        "--host", VLLM_HOST,
+        "--port", str(VLLM_PORT),
+        "--trust-remote-code",
+        "--tensor_parallel_size", "2",
+        "--dtype", "bfloat16",
+        "--gpu_memory_utilization", "0.6",
+        "--max-model-len", "8192",
+        "--override_generation_config",
+        '{"temperature": 0.8, "top_k": -1, "top_p": 0.9, "repetition_penalty": 1.0, "max_new_tokens": 4096}',
+        "--kv-events-config", kv_events_config,
+    ]
+
+    proc = subprocess.Popen(cmd)
+
+    metrics_url = f"http://{NODE_ID}/metrics"
+    max_wait = 360
+    deadline = time.time() + max_wait
+    ready = False
+
+    while time.time() < deadline:
+        try:
+            resp = httpx.get(metrics_url, timeout=5.0)
+            if resp.status_code == 200:
+                ready = True
+                break
+        except (httpx.ConnectError, httpx.TimeoutException):
+            pass
+        time.sleep(3)
+
+    if not ready:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+        pytest.skip(
+            f"vLLM server for {VLLM_MODEL} did not become ready within {max_wait}s"
+        )
+
+    yield NODE_ID
+
+    proc.send_signal(signal.SIGTERM)
+    try:
+        proc.wait(timeout=15)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+@pytest.fixture(scope="session")
+def vllm_service(vllm_kv_service):
+    """Alias: polling tests reuse the session-shared vLLM server.
+
+    The polling collector only reads HTTP ``/metrics``; ZMQ KV events
+    being enabled on the same server has no effect on polling tests.
+    """
+    return vllm_kv_service

--- a/tests/uni_agent/llm_router/collectors/conftest.py
+++ b/tests/uni_agent/llm_router/collectors/conftest.py
@@ -19,9 +19,8 @@ import subprocess
 import sys
 import time
 
-import pytest
 import httpx
-
+import pytest
 
 # ── Shared configuration constants ───────────────────────────────────────
 
@@ -35,6 +34,7 @@ ZMQ_REPLAY_PORT = int(os.environ.get("ZMQ_REPLAY_PORT", "5556"))
 
 
 # ── Shared helper ────────────────────────────────────────────────────────
+
 
 def send_inference_request(node_id: str, model: str, prompt: str = "hello") -> bool:
     """POST a chat-completions request to trigger KV cache events.
@@ -59,6 +59,7 @@ def send_inference_request(node_id: str, model: str, prompt: str = "hello") -> b
 
 # ── Session-scoped vLLM fixture ──────────────────────────────────────────
 
+
 @pytest.fixture(scope="session")
 def vllm_kv_service():
     """Start one vLLM server with ZMQ KV events for the entire test session.
@@ -70,27 +71,39 @@ def vllm_kv_service():
 
     Yields ``node_id`` (``"host:port"``).  The process is SIGTERM'd on teardown.
     """
-    kv_events_config = json.dumps({
-        "enable_kv_cache_events": True,
-        "publisher": "zmq",
-        "topic": "kv-events",
-        "endpoint": f"tcp://*:{ZMQ_SUB_PORT}",
-        "replay_endpoint": f"tcp://*:{ZMQ_REPLAY_PORT}",
-    })
+    kv_events_config = json.dumps(
+        {
+            "enable_kv_cache_events": True,
+            "publisher": "zmq",
+            "topic": "kv-events",
+            "endpoint": f"tcp://*:{ZMQ_SUB_PORT}",
+            "replay_endpoint": f"tcp://*:{ZMQ_REPLAY_PORT}",
+        }
+    )
 
     cmd = [
-        sys.executable, "-m", "vllm.entrypoints.openai.api_server",
-        "--model", VLLM_MODEL,
-        "--host", VLLM_HOST,
-        "--port", str(VLLM_PORT),
+        sys.executable,
+        "-m",
+        "vllm.entrypoints.openai.api_server",
+        "--model",
+        VLLM_MODEL,
+        "--host",
+        VLLM_HOST,
+        "--port",
+        str(VLLM_PORT),
         "--trust-remote-code",
-        "--tensor_parallel_size", "2",
-        "--dtype", "bfloat16",
-        "--gpu_memory_utilization", "0.6",
-        "--max-model-len", "8192",
+        "--tensor_parallel_size",
+        "2",
+        "--dtype",
+        "bfloat16",
+        "--gpu_memory_utilization",
+        "0.6",
+        "--max-model-len",
+        "8192",
         "--override_generation_config",
         '{"temperature": 0.8, "top_k": -1, "top_p": 0.9, "repetition_penalty": 1.0, "max_new_tokens": 4096}',
-        "--kv-events-config", kv_events_config,
+        "--kv-events-config",
+        kv_events_config,
     ]
 
     proc = subprocess.Popen(cmd)
@@ -117,9 +130,7 @@ def vllm_kv_service():
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait()
-        pytest.skip(
-            f"vLLM server for {VLLM_MODEL} did not become ready within {max_wait}s"
-        )
+        pytest.skip(f"vLLM server for {VLLM_MODEL} did not become ready within {max_wait}s")
 
     yield NODE_ID
 

--- a/tests/uni_agent/llm_router/collectors/test_vllm_kv_event_collector.py
+++ b/tests/uni_agent/llm_router/collectors/test_vllm_kv_event_collector.py
@@ -1,0 +1,154 @@
+"""Tests for vLLM ZMQ KV-cache event collection with real vLLM service.
+
+Test flow:
+1. Launch a real vLLM model service (Qwen3-4B) with kv-events-config enabled.
+2. Create a Collector(ZMQTransport, VLLMKVDecoder) via BUILTIN_REGISTRY.
+3. Call start() — the decoder writes KV events to KVCacheStore.
+4. Send an inference request to trigger BlockStored events.
+5. Verify that KVCacheStore receives block data via ZMQ events.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from conftest import NODE_ID, ZMQ_SUB_PORT, ZMQ_REPLAY_PORT, VLLM_MODEL, send_inference_request
+from uni_agent.llm_router.collectors.registry import BUILTIN_REGISTRY
+from uni_agent.llm_router.store.kv_cache_store import KVCacheStore
+
+pytestmark = [pytest.mark.st, pytest.mark.gpu]
+
+
+def _make_collector():
+    return BUILTIN_REGISTRY.get_collector(
+        "vllm_zmq",
+        endpoints={NODE_ID: [f"127.0.0.1:{ZMQ_SUB_PORT}", f"127.0.0.1:{ZMQ_REPLAY_PORT}"]},
+    )
+
+
+class TestVLLMKVEventCollectorWithRealService:
+    """Integration tests: vLLM ZMQ KV-cache collector against a live vLLM ZMQ publisher."""
+
+    def test_start_and_kv_store_updated(self, vllm_kv_service):
+        """
+        Feature: Collector receives ZMQ events and updates KVCacheStore
+        Expectation:
+            KVCacheStore.block_size is set (learned from first event).
+            replicas_by_block is non-empty.
+            NODE_ID appears in at least one block's replica set.
+        """
+        store = KVCacheStore.default()
+        collector = _make_collector()
+
+        collector.start()
+        time.sleep(5.0)
+        send_inference_request(vllm_kv_service, VLLM_MODEL, "hello world")
+        time.sleep(5.0)
+        collector.stop()
+
+        assert store.block_size is not None, "block_size should be learned from KV events"
+        assert store.block_size > 0
+        assert len(store.replicas_by_block) > 0, (
+            "replicas_by_block should be non-empty after BlockStored events"
+        )
+        replica_found = any(NODE_ID in replicas for replicas in store.replicas_by_block.values())
+        assert replica_found, f"Expected NODE_ID '{NODE_ID}' in at least one block's replica set"
+
+    def test_block_size_learned(self, vllm_kv_service):
+        """
+        Feature: block_size is learned from the first BlockStored KV event
+        Expectation:
+            block_size is a positive integer (vLLM default is 16).
+        """
+        store = KVCacheStore.default()
+        collector = _make_collector()
+
+        collector.start()
+        time.sleep(5.0)
+        send_inference_request(vllm_kv_service, VLLM_MODEL)
+        time.sleep(5.0)
+        collector.stop()
+
+        assert isinstance(store.block_size, int)
+        assert store.block_size > 0
+        assert store.block_size == 16, f"Expected block_size=16 (vLLM default), got {store.block_size}"
+
+    def test_multiple_inferences_accumulate_blocks(self, vllm_kv_service):
+        """
+        Feature: Multiple inference requests accumulate more blocks in the store
+        Expectation:
+            After multiple requests, replicas_by_block has entries.
+        """
+        store = KVCacheStore.default()
+        collector = _make_collector()
+
+        collector.start()
+        time.sleep(5.0)
+        for prompt in [
+            "What is machine learning?",
+            "Explain quantum computing briefly.",
+            "Tell me about deep reinforcement learning.",
+        ]:
+            send_inference_request(vllm_kv_service, VLLM_MODEL, prompt)
+            time.sleep(3.0)
+        time.sleep(3.0)
+        collector.stop()
+
+        assert len(store.replicas_by_block) > 0, "Expected blocks after multiple inferences"
+
+    def test_clear_replica_removes_all_blocks(self, vllm_kv_service):
+        """
+        Feature: KVCacheStore.clear_replica removes all blocks for a replica
+        Expectation:
+            After clear_replica, no block in replicas_by_block contains NODE_ID.
+        """
+        store = KVCacheStore.default()
+        collector = _make_collector()
+
+        collector.start()
+        time.sleep(5.0)
+        send_inference_request(vllm_kv_service, VLLM_MODEL)
+        time.sleep(5.0)
+        collector.stop()
+
+        if len(store.replicas_by_block) == 0:
+            pytest.skip("No blocks received from KV events")
+
+        store.clear_replica(NODE_ID)
+
+        for block_hash, replicas in store.replicas_by_block.items():
+            assert NODE_ID not in replicas, (
+                f"NODE_ID '{NODE_ID}' should not be in block '{block_hash}' after clear_replica"
+            )
+
+    def test_decoder_hash_mapping_populated(self, vllm_kv_service):
+        """
+        Feature: VLLMKVDecoder.remote_to_local_block_hash is populated after events
+        Description:
+            Verify that the decoder's hash mapping tracks remote→local block hashes,
+            and that every local hash appears in KVCacheStore.replicas_by_block.
+        Expectation:
+            remote_to_local_block_hash is non-empty.
+            All local hashes are present in store.replicas_by_block.
+        """
+        store = KVCacheStore.default()
+        collector = _make_collector()
+
+        collector.start()
+        time.sleep(5.0)
+        send_inference_request(vllm_kv_service, VLLM_MODEL)
+        time.sleep(5.0)
+        collector.stop()
+
+        mapping = collector._decoder.remote_to_local_block_hash
+        assert len(mapping) > 0, (
+            "remote_to_local_block_hash should have entries after processing events"
+        )
+        for remote_bh, local_bh in mapping.items():
+            assert isinstance(remote_bh, str)
+            assert isinstance(local_bh, str)
+            assert local_bh in store.replicas_by_block, (
+                f"Local hash '{local_bh}' from mapping not found in store.replicas_by_block"
+            )

--- a/tests/uni_agent/llm_router/collectors/test_vllm_kv_event_collector.py
+++ b/tests/uni_agent/llm_router/collectors/test_vllm_kv_event_collector.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 import time
 
 import pytest
+from conftest import NODE_ID, VLLM_MODEL, ZMQ_REPLAY_PORT, ZMQ_SUB_PORT, send_inference_request
 
-from conftest import NODE_ID, ZMQ_SUB_PORT, ZMQ_REPLAY_PORT, VLLM_MODEL, send_inference_request
 from uni_agent.llm_router.collectors.registry import BUILTIN_REGISTRY
 from uni_agent.llm_router.store.kv_cache_store import KVCacheStore
 
@@ -50,9 +50,7 @@ class TestVLLMKVEventCollectorWithRealService:
 
         assert store.block_size is not None, "block_size should be learned from KV events"
         assert store.block_size > 0
-        assert len(store.replicas_by_block) > 0, (
-            "replicas_by_block should be non-empty after BlockStored events"
-        )
+        assert len(store.replicas_by_block) > 0, "replicas_by_block should be non-empty after BlockStored events"
         replica_found = any(NODE_ID in replicas for replicas in store.replicas_by_block.values())
         assert replica_found, f"Expected NODE_ID '{NODE_ID}' in at least one block's replica set"
 
@@ -143,9 +141,7 @@ class TestVLLMKVEventCollectorWithRealService:
         collector.stop()
 
         mapping = collector._decoder.remote_to_local_block_hash
-        assert len(mapping) > 0, (
-            "remote_to_local_block_hash should have entries after processing events"
-        )
+        assert len(mapping) > 0, "remote_to_local_block_hash should have entries after processing events"
         for remote_bh, local_bh in mapping.items():
             assert isinstance(remote_bh, str)
             assert isinstance(local_bh, str)

--- a/tests/uni_agent/llm_router/collectors/test_vllm_polling_collector.py
+++ b/tests/uni_agent/llm_router/collectors/test_vllm_polling_collector.py
@@ -1,0 +1,112 @@
+"""Tests for vLLM HTTP metrics collection with real vLLM service.
+
+Test flow:
+1. Launch a real vLLM model service (Qwen3-4B).
+2. Create a Collector(HTTPTransport, VLLMMetricsDecoder) via BUILTIN_REGISTRY.
+3. Call start() to begin metrics polling; the decoder writes to MetricsStore.
+4. Verify that expected metrics exist in the store.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from conftest import NODE_ID, VLLM_MODEL
+from uni_agent.llm_router.collectors.registry import BUILTIN_REGISTRY
+from uni_agent.llm_router.metric_spec import MetricKey
+from uni_agent.llm_router.store.metrics_store import MetricsStore
+
+pytestmark = [pytest.mark.st, pytest.mark.gpu]
+
+
+POLL_INTERVAL = 2.0
+HTTP_TIMEOUT = 10.0
+
+
+def _make_collector():
+    return BUILTIN_REGISTRY.get_collector(
+        "vllm_metrics",
+        endpoints={NODE_ID: NODE_ID},
+        interval=POLL_INTERVAL,
+        http_timeout=HTTP_TIMEOUT,
+    )
+
+
+class TestVLLMMetricsCollectorWithRealService:
+    """Integration tests: vLLM HTTP metrics collector against a live vLLM server."""
+
+    def test_start_and_metrics_exist(self, vllm_service):
+        """
+        Feature: Collector writes real metrics to MetricsStore after start()
+        Expectation:
+            MetricsStore contains NODE_ID after one polling cycle.
+            kv_cache_usage_perc → float, num_requests_running/waiting → int.
+        """
+        store = MetricsStore.default()
+        collector = _make_collector()
+
+        collector.start()
+        time.sleep(POLL_INTERVAL + 3.0)
+        collector.stop()
+
+        assert NODE_ID in store.all_ids(), (
+            f"Expected node_id '{NODE_ID}' in store, got {store.all_ids()}"
+        )
+        assert isinstance(store.get(NODE_ID, MetricKey.KV_CACHE_USAGE_PERC), float)
+        assert isinstance(store.get(NODE_ID, MetricKey.NUM_REQUESTS_RUNNING), int)
+        assert isinstance(store.get(NODE_ID, MetricKey.NUM_REQUESTS_WAITING), int)
+
+    def test_metrics_values_are_sane(self, vllm_service):
+        """
+        Feature: Collected metric values are within reasonable bounds
+        Expectation:
+            kv_cache_usage_perc >= 0.0
+            num_requests_running >= 0
+            num_requests_waiting >= 0
+        """
+        store = MetricsStore.default()
+        collector = _make_collector()
+
+        collector.start()
+        time.sleep(POLL_INTERVAL + 3.0)
+        collector.stop()
+
+        assert store.get(NODE_ID, MetricKey.KV_CACHE_USAGE_PERC) >= 0.0
+        assert store.get(NODE_ID, MetricKey.NUM_REQUESTS_RUNNING) >= 0
+        assert store.get(NODE_ID, MetricKey.NUM_REQUESTS_WAITING) >= 0
+
+    def test_store_get_node_dict(self, vllm_service):
+        """
+        Feature: MetricsStore.get(node_id) returns the full node metrics dict
+        Expectation:
+            Dict contains kv_cache_usage_perc, num_requests_running, num_requests_waiting.
+        """
+        store = MetricsStore.default()
+        collector = _make_collector()
+
+        collector.start()
+        time.sleep(POLL_INTERVAL + 3.0)
+        collector.stop()
+
+        node_metrics = store.get(NODE_ID)
+        assert isinstance(node_metrics, dict)
+        assert MetricKey.KV_CACHE_USAGE_PERC in node_metrics
+        assert MetricKey.NUM_REQUESTS_RUNNING in node_metrics
+        assert MetricKey.NUM_REQUESTS_WAITING in node_metrics
+
+    def test_multiple_poll_cycles_refresh(self, vllm_service):
+        """
+        Feature: Multiple polling cycles refresh the store with updated values
+        Expectation:
+            After 3 polling cycles the store contains data and values are reasonable.
+        """
+        store = MetricsStore.default()
+        collector = _make_collector()
+
+        collector.start()
+        time.sleep(POLL_INTERVAL * 3 + 2.0)
+        collector.stop()
+
+        assert len(store.get(NODE_ID)) > 0, "Store should have metrics after multiple poll cycles"

--- a/tests/uni_agent/llm_router/collectors/test_vllm_polling_collector.py
+++ b/tests/uni_agent/llm_router/collectors/test_vllm_polling_collector.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 import time
 
 import pytest
+from conftest import NODE_ID
 
-from conftest import NODE_ID, VLLM_MODEL
 from uni_agent.llm_router.collectors.registry import BUILTIN_REGISTRY
 from uni_agent.llm_router.metric_spec import MetricKey
 from uni_agent.llm_router.store.metrics_store import MetricsStore
@@ -51,9 +51,7 @@ class TestVLLMMetricsCollectorWithRealService:
         time.sleep(POLL_INTERVAL + 3.0)
         collector.stop()
 
-        assert NODE_ID in store.all_ids(), (
-            f"Expected node_id '{NODE_ID}' in store, got {store.all_ids()}"
-        )
+        assert NODE_ID in store.all_ids(), f"Expected node_id '{NODE_ID}' in store, got {store.all_ids()}"
         assert isinstance(store.get(NODE_ID, MetricKey.KV_CACHE_USAGE_PERC), float)
         assert isinstance(store.get(NODE_ID, MetricKey.NUM_REQUESTS_RUNNING), int)
         assert isinstance(store.get(NODE_ID, MetricKey.NUM_REQUESTS_WAITING), int)

--- a/tests/uni_agent/llm_router/conftest.py
+++ b/tests/uni_agent/llm_router/conftest.py
@@ -1,0 +1,28 @@
+"""Root conftest for the llm_router test suite.
+
+Registers the marker vocabulary so pytest recognises them and does not emit
+``PytestUnknownMarkWarning``.  Two orthogonal dimensions:
+
+  type     — ``ut`` (pure unit tests) / ``st`` (system/integration) / ``e2e`` (end-to-end)
+  resource — ``cpu`` (no GPU) / ``gpu`` (needs a real vLLM + GPU)
+
+Select tests with ``-m``, e.g.::
+
+    pytest -m "ut and cpu"        # unit tests
+    pytest -m "st and cpu"        # Ray actor integration
+    pytest -m "st and gpu"        # collector integration (conftest vLLM)
+    pytest -m "e2e and gpu"       # end-to-end (run_infer.sh)
+"""
+
+from __future__ import annotations
+
+
+def pytest_configure(config):  # type: ignore[no-untyped-def]
+    for marker, desc in (
+        ("ut", "pure unit test — no Ray, no GPU, no external services"),
+        ("st", "system / integration test — exercises real subsystems"),
+        ("e2e", "end-to-end test via run_infer.sh; standalone vLLM (no conftest sharing)"),
+        ("cpu", "runs on CPU (no GPU required)"),
+        ("gpu", "needs a real GPU + vLLM service"),
+    ):
+        config.addinivalue_line("markers", f"{marker}: {desc}")

--- a/tests/uni_agent/llm_router/e2e/test_mooncake_e2e.py
+++ b/tests/uni_agent/llm_router/e2e/test_mooncake_e2e.py
@@ -1,0 +1,143 @@
+"""E2E test: KVCAware router + mooncake via run_infer.sh.
+
+Launches ``run_infer.sh`` with ``--router-config-path`` + ``--enable-mooncake``,
+starts mooncake_master, waits for completion, then checks:
+  1. MooncakeStoreConnector created on vLLM replicas
+  2. Routing decisions produced ("routed to server")
+  3. Mean RM Score printed (end-to-end completion)
+  4. No TCP transport errors (no writeBody/batch_put -800 failures)
+  5. External prefix cache hit observed (cross-replica KV sharing working)
+
+This is a GPU test (needs real vLLM + GPU + model + dataset + mooncake_master).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.e2e, pytest.mark.gpu]
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_PROJECT_ROOT = os.path.abspath(os.path.join(_SCRIPT_DIR, "..", "..", "..", ".."))
+_RUN_INFER = os.path.join(_PROJECT_ROOT, "examples", "llm_router", "run_infer.sh")
+_AGENT_CONFIG = os.path.join(_PROJECT_ROOT, "examples", "llm_router", "agent_config_simulated.yaml")
+_MODEL = os.environ.get("VLLM_MODEL", "/data1/models/Qwen/Qwen3-4B-Instruct-2507")
+_DATASET = os.environ.get("SWEBENCH_DATASET",
+                          "/data1/hgq/uni-agent/scripts/swe_bench_verified_modal.parquet")
+_ROUTER = "pkg://uni_agent.llm_router.configs/kvc_aware_router.yaml"
+_MC_CONFIG = os.environ.get("MOONCAKE_CONFIG_PATH", "/data1/hgq/uni-agent/mooncake_config.json")
+_LOG_DIR = "/tmp/e2e_mooncake_logs"
+
+
+def _get_traj_dir() -> str:
+    """Read log_dir from the agent config YAML."""
+    with open(_AGENT_CONFIG) as f:
+        cfg = yaml.safe_load(f)
+    return cfg[0]["log_dir"]
+
+
+def _run_infer_with_mooncake(timeout: int = 600) -> str:
+    """Run run_infer.sh with router + mooncake. Returns log content."""
+    os.makedirs(_LOG_DIR, exist_ok=True)
+    log_file = os.path.join(_LOG_DIR, "mooncake_e2e.log")
+
+    # GPU config: CUDA_VISIBLE_DEVICES controls which GPUs Ray/vLLM see;
+    # --n-gpus-per-node must match the count.
+    cuda_vis = os.environ.get("CUDA_VISIBLE_DEVICES", "0,1,2,3,4,5,6,7")
+    num_gpus = len(cuda_vis.split(","))
+    cmd = [
+        "bash", _RUN_INFER,
+        _MODEL, _DATASET, _AGENT_CONFIG,
+        "--num-workers", "1",
+        "--n-gpus-per-node", str(num_gpus),
+        "--tensor-parallel-size", "2",
+        "--max-samples", "4",
+        "--n", "2",
+        "--max-model-len", "8192",
+        "--router-config-path", _ROUTER,
+        "--enable-mooncake",
+        "--mooncake-config-path", _MC_CONFIG,
+    ]
+    env = os.environ.copy()
+    env["HF_HUB_OFFLINE"] = "1"
+    env["TRANSFORMERS_OFFLINE"] = "1"
+    env["PYTHONHASHSEED"] = "0"
+    env["CUDA_VISIBLE_DEVICES"] = cuda_vis
+    env["MOONCAKE_CONFIG_PATH"] = _MC_CONFIG
+    env["MC_TCP_ENABLE_CONNECTION_POOL"] = "1"
+    env["MOONCAKE_CPU_STAGING"] = "1"
+
+    # Start mooncake_master
+    master_log = open(os.path.join(_LOG_DIR, "mooncake_master.log"), "w")
+    master_proc = subprocess.Popen(
+        ["mooncake_master", "--port", "50051", "--default_kv_lease_ttl", "60000"],
+        stdout=master_log, stderr=subprocess.STDOUT,
+    )
+    time.sleep(5)
+
+    with open(log_file, "w") as f:
+        subprocess.run(cmd, stdout=f, stderr=subprocess.STDOUT, env=env, timeout=timeout)
+
+    master_proc.terminate()
+    master_proc.wait(timeout=10)
+    master_log.close()
+
+    return open(log_file).read()
+
+
+class TestMooncakeRouterE2E:
+    """E2E: run_infer.sh with KVCAware router + mooncake connector."""
+
+    def test_mooncake_router_full_e2e(self):
+        """
+        Feature: KVCAware router + mooncake end-to-end via run_infer.sh
+        Description: run full agent loop with router + mooncake, verify:
+          - MooncakeStoreConnector created
+          - routing decisions produced
+          - Mean RM Score printed
+          - trajectory logs produced (agent loop actually ran)
+          - no TCP transport errors (no writeBody/batch_put -800)
+          - External prefix cache hit observed
+        """
+        log = _run_infer_with_mooncake()
+
+        # 1. MooncakeStoreConnector created
+        assert "MooncakeStoreConnector" in log, "MooncakeStoreConnector not found in log"
+
+        # 2. Routing decisions
+        assert "routed to server" in log, "No routing decisions in log"
+
+        # 3. End-to-end completion
+        assert "Mean RM Score" in log, "run_infer.sh did not complete"
+
+        # 4. Trajectory logs produced (log_dir from agent config yaml)
+        traj_dir = _get_traj_dir()
+        traj_count = len([d for d in os.listdir(traj_dir)
+                         if os.path.isfile(os.path.join(traj_dir, d, "interaction_result.json"))])
+        assert traj_count > 0, f"No trajectory logs in {traj_dir}"
+
+        # 5. No TCP transport errors
+        tcp_errors = log.count("writeBody failed") + log.count("batch_put failed")
+        assert tcp_errors == 0, (
+            f"Found {tcp_errors} TCP transport errors "
+            f"(writeBody/batch_put failures indicate port exhaustion or CUDA staging issues)"
+        )
+
+        # 6. External prefix cache hit (cross-replica KV sharing)
+        # Note: External hit requires sufficient concurrency + prefix overlap across
+        # replicas. Small-sample e2e (4 samples) may not trigger it reliably.
+        # We warn instead of asserting — the connector creation (check 1) and
+        # zero TCP errors (check 5) already prove mooncake is wired correctly.
+        if "External prefix cache hit" not in log:
+            import warnings
+            warnings.warn(
+                "No External prefix cache hit in log — small-sample e2e may not "
+                "produce enough cross-replica prefix overlap to trigger it. "
+                "Connector is created (check 1) and TCP is clean (check 5), "
+                "so mooncake wiring is correct."
+            )

--- a/tests/uni_agent/llm_router/e2e/test_mooncake_e2e.py
+++ b/tests/uni_agent/llm_router/e2e/test_mooncake_e2e.py
@@ -27,8 +27,7 @@ _PROJECT_ROOT = os.path.abspath(os.path.join(_SCRIPT_DIR, "..", "..", "..", ".."
 _RUN_INFER = os.path.join(_PROJECT_ROOT, "examples", "llm_router", "run_infer.sh")
 _AGENT_CONFIG = os.path.join(_PROJECT_ROOT, "examples", "llm_router", "agent_config_simulated.yaml")
 _MODEL = os.environ.get("VLLM_MODEL", "/data1/models/Qwen/Qwen3-4B-Instruct-2507")
-_DATASET = os.environ.get("SWEBENCH_DATASET",
-                          "/data1/hgq/uni-agent/scripts/swe_bench_verified_modal.parquet")
+_DATASET = os.environ.get("SWEBENCH_DATASET", "/data1/hgq/uni-agent/scripts/swe_bench_verified_modal.parquet")
 _ROUTER = "pkg://uni_agent.llm_router.configs/kvc_aware_router.yaml"
 _MC_CONFIG = os.environ.get("MOONCAKE_CONFIG_PATH", "/data1/hgq/uni-agent/mooncake_config.json")
 _LOG_DIR = "/tmp/e2e_mooncake_logs"
@@ -51,17 +50,28 @@ def _run_infer_with_mooncake(timeout: int = 600) -> str:
     cuda_vis = os.environ.get("CUDA_VISIBLE_DEVICES", "0,1,2,3,4,5,6,7")
     num_gpus = len(cuda_vis.split(","))
     cmd = [
-        "bash", _RUN_INFER,
-        _MODEL, _DATASET, _AGENT_CONFIG,
-        "--num-workers", "1",
-        "--n-gpus-per-node", str(num_gpus),
-        "--tensor-parallel-size", "2",
-        "--max-samples", "4",
-        "--n", "2",
-        "--max-model-len", "8192",
-        "--router-config-path", _ROUTER,
+        "bash",
+        _RUN_INFER,
+        _MODEL,
+        _DATASET,
+        _AGENT_CONFIG,
+        "--num-workers",
+        "1",
+        "--n-gpus-per-node",
+        str(num_gpus),
+        "--tensor-parallel-size",
+        "2",
+        "--max-samples",
+        "4",
+        "--n",
+        "2",
+        "--max-model-len",
+        "8192",
+        "--router-config-path",
+        _ROUTER,
         "--enable-mooncake",
-        "--mooncake-config-path", _MC_CONFIG,
+        "--mooncake-config-path",
+        _MC_CONFIG,
     ]
     env = os.environ.copy()
     env["HF_HUB_OFFLINE"] = "1"
@@ -76,7 +86,8 @@ def _run_infer_with_mooncake(timeout: int = 600) -> str:
     master_log = open(os.path.join(_LOG_DIR, "mooncake_master.log"), "w")
     master_proc = subprocess.Popen(
         ["mooncake_master", "--port", "50051", "--default_kv_lease_ttl", "60000"],
-        stdout=master_log, stderr=subprocess.STDOUT,
+        stdout=master_log,
+        stderr=subprocess.STDOUT,
     )
     time.sleep(5)
 
@@ -117,8 +128,9 @@ class TestMooncakeRouterE2E:
 
         # 4. Trajectory logs produced (log_dir from agent config yaml)
         traj_dir = _get_traj_dir()
-        traj_count = len([d for d in os.listdir(traj_dir)
-                         if os.path.isfile(os.path.join(traj_dir, d, "interaction_result.json"))])
+        traj_count = len(
+            [d for d in os.listdir(traj_dir) if os.path.isfile(os.path.join(traj_dir, d, "interaction_result.json"))]
+        )
         assert traj_count > 0, f"No trajectory logs in {traj_dir}"
 
         # 5. No TCP transport errors
@@ -135,9 +147,11 @@ class TestMooncakeRouterE2E:
         # zero TCP errors (check 5) already prove mooncake is wired correctly.
         if "External prefix cache hit" not in log:
             import warnings
+
             warnings.warn(
                 "No External prefix cache hit in log — small-sample e2e may not "
                 "produce enough cross-replica prefix overlap to trigger it. "
                 "Connector is created (check 1) and TCP is clean (check 5), "
-                "so mooncake wiring is correct."
+                "so mooncake wiring is correct.",
+                stacklevel=2,
             )

--- a/tests/uni_agent/llm_router/e2e/test_router_e2e.py
+++ b/tests/uni_agent/llm_router/e2e/test_router_e2e.py
@@ -1,0 +1,101 @@
+"""E2E test: KVCAware router via run_infer.sh — full agent loop with routing.
+
+Launches ``run_infer.sh`` with ``--router-config-path`` (KVCAware router),
+waits for completion, then checks:
+  1. Routing decisions produced ("routed to server")
+  2. COMBINED scoring (not falling back to random)
+  3. Mean RM Score printed (end-to-end completion)
+  4. Trajectory logs produced (agent loop actually ran)
+
+This is a GPU test (needs real vLLM + GPU + model + dataset).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.e2e, pytest.mark.gpu]
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_PROJECT_ROOT = os.path.abspath(os.path.join(_SCRIPT_DIR, "..", "..", "..", ".."))
+_RUN_INFER = os.path.join(_PROJECT_ROOT, "examples", "llm_router", "run_infer.sh")
+_AGENT_CONFIG = os.path.join(_PROJECT_ROOT, "examples", "llm_router", "agent_config_simulated.yaml")
+_MODEL = os.environ.get("VLLM_MODEL", "/data1/models/Qwen/Qwen3-4B-Instruct-2507")
+_DATASET = os.environ.get("SWEBENCH_DATASET",
+                          "/data1/hgq/uni-agent/scripts/swe_bench_verified_modal.parquet")
+_ROUTER = "pkg://uni_agent.llm_router.configs/kvc_aware_router.yaml"
+_LOG_DIR = "/tmp/e2e_router_logs"
+
+
+def _get_traj_dir() -> str:
+    """Read log_dir from the agent config YAML."""
+    with open(_AGENT_CONFIG) as f:
+        cfg = yaml.safe_load(f)
+    return cfg[0]["log_dir"]
+
+
+def _run_infer(timeout: int = 600) -> str:
+    """Run run_infer.sh with KVCAware router. Returns log content."""
+    os.makedirs(_LOG_DIR, exist_ok=True)
+    log_file = os.path.join(_LOG_DIR, "router_e2e.log")
+
+    # GPU config: CUDA_VISIBLE_DEVICES controls which GPUs Ray/vLLM see;
+    # --n-gpus-per-node must match the count.
+    cuda_vis = os.environ.get("CUDA_VISIBLE_DEVICES", "0,1,2,3,4,5,6,7")
+    num_gpus = len(cuda_vis.split(","))
+    cmd = [
+        "bash", _RUN_INFER,
+        _MODEL, _DATASET, _AGENT_CONFIG,
+        "--num-workers", "1",
+        "--n-gpus-per-node", str(num_gpus),
+        "--tensor-parallel-size", "2",
+        "--max-samples", "4",
+        "--n", "2",
+        "--max-model-len", "8192",
+        "--router-config-path", _ROUTER,
+    ]
+    env = os.environ.copy()
+    env["HF_HUB_OFFLINE"] = "1"
+    env["TRANSFORMERS_OFFLINE"] = "1"
+    env["PYTHONHASHSEED"] = "0"
+    env["CUDA_VISIBLE_DEVICES"] = cuda_vis
+
+    with open(log_file, "w") as f:
+        subprocess.run(cmd, stdout=f, stderr=subprocess.STDOUT, env=env, timeout=timeout)
+    return open(log_file).read()
+
+
+class TestKVCAwareRouterE2E:
+    """E2E: run_infer.sh with KVCAware router — full agent loop."""
+
+    def test_kvc_aware_router_full_e2e(self):
+        """
+        Feature: KVCAware router end-to-end via run_infer.sh
+        Description: run full agent loop with --router-config-path, verify:
+          - routing decisions ("routed to server" >= 1)
+          - COMBINED scoring (not random fallback)
+          - Mean RM Score printed (end-to-end completion)
+          - trajectory logs produced (interaction_result.json exists)
+        """
+        log = _run_infer()
+
+        # 1. Routing decisions
+        assert "routed to server" in log, "No routing decisions in log"
+        routing_count = log.count("routed to server")
+        assert routing_count >= 1, f"Expected >=1 routing decision, got {routing_count}"
+
+        # 2. COMBINED scoring (not random fallback)
+        assert "COMBINED" in log, "No COMBINED scoring — strategy may have failed"
+
+        # 3. End-to-end completion
+        assert "Mean RM Score" in log, "run_infer.sh did not complete (no RM Score)"
+
+        # 4. Trajectory logs produced (log_dir from agent config yaml)
+        traj_dir = _get_traj_dir()
+        traj_count = len([d for d in os.listdir(traj_dir)
+                         if os.path.isfile(os.path.join(traj_dir, d, "interaction_result.json"))])
+        assert traj_count > 0, f"No trajectory logs in {traj_dir}"

--- a/tests/uni_agent/llm_router/e2e/test_router_e2e.py
+++ b/tests/uni_agent/llm_router/e2e/test_router_e2e.py
@@ -25,8 +25,7 @@ _PROJECT_ROOT = os.path.abspath(os.path.join(_SCRIPT_DIR, "..", "..", "..", ".."
 _RUN_INFER = os.path.join(_PROJECT_ROOT, "examples", "llm_router", "run_infer.sh")
 _AGENT_CONFIG = os.path.join(_PROJECT_ROOT, "examples", "llm_router", "agent_config_simulated.yaml")
 _MODEL = os.environ.get("VLLM_MODEL", "/data1/models/Qwen/Qwen3-4B-Instruct-2507")
-_DATASET = os.environ.get("SWEBENCH_DATASET",
-                          "/data1/hgq/uni-agent/scripts/swe_bench_verified_modal.parquet")
+_DATASET = os.environ.get("SWEBENCH_DATASET", "/data1/hgq/uni-agent/scripts/swe_bench_verified_modal.parquet")
 _ROUTER = "pkg://uni_agent.llm_router.configs/kvc_aware_router.yaml"
 _LOG_DIR = "/tmp/e2e_router_logs"
 
@@ -48,15 +47,25 @@ def _run_infer(timeout: int = 600) -> str:
     cuda_vis = os.environ.get("CUDA_VISIBLE_DEVICES", "0,1,2,3,4,5,6,7")
     num_gpus = len(cuda_vis.split(","))
     cmd = [
-        "bash", _RUN_INFER,
-        _MODEL, _DATASET, _AGENT_CONFIG,
-        "--num-workers", "1",
-        "--n-gpus-per-node", str(num_gpus),
-        "--tensor-parallel-size", "2",
-        "--max-samples", "4",
-        "--n", "2",
-        "--max-model-len", "8192",
-        "--router-config-path", _ROUTER,
+        "bash",
+        _RUN_INFER,
+        _MODEL,
+        _DATASET,
+        _AGENT_CONFIG,
+        "--num-workers",
+        "1",
+        "--n-gpus-per-node",
+        str(num_gpus),
+        "--tensor-parallel-size",
+        "2",
+        "--max-samples",
+        "4",
+        "--n",
+        "2",
+        "--max-model-len",
+        "8192",
+        "--router-config-path",
+        _ROUTER,
     ]
     env = os.environ.copy()
     env["HF_HUB_OFFLINE"] = "1"
@@ -96,6 +105,7 @@ class TestKVCAwareRouterE2E:
 
         # 4. Trajectory logs produced (log_dir from agent config yaml)
         traj_dir = _get_traj_dir()
-        traj_count = len([d for d in os.listdir(traj_dir)
-                         if os.path.isfile(os.path.join(traj_dir, d, "interaction_result.json"))])
+        traj_count = len(
+            [d for d in os.listdir(traj_dir) if os.path.isfile(os.path.join(traj_dir, d, "interaction_result.json"))]
+        )
         assert traj_count > 0, f"No trajectory logs in {traj_dir}"

--- a/tests/uni_agent/llm_router/strategies/test_kvc_aware_strategy.py
+++ b/tests/uni_agent/llm_router/strategies/test_kvc_aware_strategy.py
@@ -1,0 +1,678 @@
+"""Unit tests for the LLM router strategy module (strategies/ package).
+
+Unified combined score (one pass, no fast/slow branching):
+    S = α·S_cache + (1-α)·S_load
+    S_cache = w_gpu·gpu_hit + w_cpu·cpu_hit + w_ssd·ssd_hit   (weights sum to 1)
+    S_load  = 1 - load                                         (bigger = less loaded)
+    load    = a·kv + b·min(1, running/max_num_seqs) + c·min(1, waiting/max_num_seqs)
+              (a+b+c=1; default 0.4/0.3/0.3; bigger = more loaded)
+
+Overload (used only by the sticky short-circuit): ``load > load_threshold``
+(default 0.9). Combined scoring never consults overload.
+Default cache weights: {gpu:0.7, cpu:0.2, ssd:0.1}.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from uni_agent.llm_router.strategies import (
+    KVCacheAwareStrategy,
+    RoutingStrategy,
+    StrategyError,
+    StrategyRegistry,
+    StickySessionTable,
+    route,
+)
+from uni_agent.llm_router.strategies.base import ReplicaInfo
+from uni_agent.llm_router.strategies.kvc_aware import STICKY_TOP_SCORE
+from uni_agent.llm_router.metric_spec import MetricKey
+
+
+
+pytestmark = [pytest.mark.ut, pytest.mark.cpu]
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+def _strat(**kwargs) -> KVCacheAwareStrategy:
+    """Build a KVCacheAwareStrategy with required boilerplate fields filled in.
+
+    ``max_num_seqs=64`` is pinned so the load formula's running term is
+    deterministic regardless of the ``MAX_NUM_SEQS`` env var.
+    """
+    defaults = dict(
+        alpha=0.7,
+        load_threshold=0.9,
+        layer_weights={"gpu": 0.7, "cpu": 0.2, "ssd": 0.1},
+        collector_names=["vllm_zmq"],
+        weight=1.0,
+        load_fn="normalized",
+        load_weights=(0.4, 0.3, 0.3),
+        max_num_seqs=64,
+    )
+    defaults.update(kwargs)
+    return KVCacheAwareStrategy(**defaults)
+
+
+def _replicas(*ids: str) -> list[ReplicaInfo]:
+    return [ReplicaInfo(replica_id=rid) for rid in ids]
+
+
+PROMPT_IDS = [1, 2, 3]
+
+
+# --------------------------------------------------------------------------- #
+# Test doubles
+# --------------------------------------------------------------------------- #
+class FakeRouteDataProvider:
+    """In-memory replica metrics for unit tests.
+
+    Each replica entry is a plain dict with the following optional keys:
+      kv_cache_usage_perc  – KV cache usage ratio (default 1.0)
+      num_requests_running – requests in flight (default 0)
+      num_requests_waiting – requests in the queue (default 0)
+      gpu_hit_pct          – GPU prefix cache hit percent 0-100 (default 0)
+      tiers                – dict mapping tier name to hit rate (default {})
+    """
+
+    def __init__(self, data: dict[str, dict]):
+        self._data = data
+
+    def get_metric(self, replica_id: str, key: str) -> float | int:
+        entry = self._data.get(replica_id, {})
+        if key == MetricKey.KV_CACHE_USAGE_PERC:
+            return entry.get("kv_cache_usage_perc", 1.0)
+        if key == MetricKey.NUM_REQUESTS_RUNNING:
+            return entry.get("num_requests_running", 0)
+        if key == MetricKey.NUM_REQUESTS_WAITING:
+            return entry.get("num_requests_waiting", 0)
+        return entry.get(key, 0.0)
+
+    def get_metrics(self, replica_id: str) -> dict:
+        entry = self._data.get(replica_id, {})
+        return {
+            MetricKey.KV_CACHE_USAGE_PERC: entry.get("kv_cache_usage_perc", 1.0),
+            MetricKey.NUM_REQUESTS_RUNNING: entry.get("num_requests_running", 0),
+            MetricKey.NUM_REQUESTS_WAITING: entry.get("num_requests_waiting", 0),
+        }
+
+    def get_gpu_prefix_hit_rate(self, prompt_ids: list[int]) -> dict[str, int]:
+        """Returns {replica_id: hit_percent 0-100} for replicas with hits."""
+        result = {}
+        for replica_id, entry in self._data.items():
+            pct = entry.get("gpu_hit_pct", 0)
+            if pct > 0:
+                result[replica_id] = pct
+        return result
+
+    def get_tier_prefix_hit_rate(self, replica_id: str, prompt_ids: list[int], tier: str) -> float:
+        return self._data.get(replica_id, {}).get("tiers", {}).get(tier, 0.0)
+
+
+class ConstantStrategy:
+    """Returns a fixed per-replica score list (for route() composition tests)."""
+
+    def __init__(self, scores: list[float]):
+        self._scores = scores
+
+    def score(self, prompt_ids, provider, replicas, request_id=None, sticky_table=None) -> list[float]:
+        return list(self._scores)
+
+
+class BadLengthStrategy:
+    """Returns a wrong-length list to exercise the contract check in route()."""
+
+    def score(self, prompt_ids, provider, replicas, request_id=None, sticky_table=None) -> list[float]:
+        return [1.0]
+
+
+class RaisingStrategy:
+    """Raises inside score() to exercise route()'s exception wrapping."""
+
+    def score(self, prompt_ids, provider, replicas, request_id=None, sticky_table=None) -> list[float]:
+        raise KeyError("boom")
+
+
+# --------------------------------------------------------------------------- #
+# Unified combined score (one pass: α·S_cache + (1-α)·S_load)
+# --------------------------------------------------------------------------- #
+
+pytestmark = [pytest.mark.ut, pytest.mark.cpu]
+
+class TestKVCAwareCombinedScore:
+    def test_three_layer_cache_weighted_sum(self):
+        """
+        Feature: S_cache is a three-layer weighted sum; load term from S_load
+        Description: two light-load replicas (running=0); rep_a has gpu+cpu+ssd hits
+        Expectation: scores = [0.766, 0.322]; rep_a ranks first
+          rep_a: load=0.4·0.2=0.08 → s_load=0.92; s_cache=0.70; score=0.7·0.70+0.3·0.92=0.766
+          rep_b: load=0.4·0.4=0.16 → s_load=0.84; s_cache=0.10; score=0.7·0.10+0.3·0.84=0.322
+        """
+        strat = _strat()
+        provider = FakeRouteDataProvider(
+            {
+                "rep_a": {"kv_cache_usage_perc": 0.2, "num_requests_running": 0, "num_requests_waiting": 0,
+                          "gpu_hit_pct": 80, "tiers": {"cpu": 0.6, "ssd": 0.2}},
+                "rep_b": {"kv_cache_usage_perc": 0.4, "num_requests_running": 0, "num_requests_waiting": 0,
+                          "gpu_hit_pct": 0, "tiers": {"cpu": 0.3, "ssd": 0.4}},
+            }
+        )
+        scores = strat.score(PROMPT_IDS, provider, _replicas("rep_a", "rep_b"))
+        assert scores == pytest.approx([0.766, 0.322])
+        assert route([(strat, 1.0)], PROMPT_IDS, provider, _replicas("rep_a", "rep_b")) == ["rep_a", "rep_b"]
+
+    def test_gpu_dominates_when_tiers_empty(self):
+        """
+        Feature: with no tier hits, S_cache = w_gpu·gpu_hit; load light
+        Description: rep_a gpu_hit_pct=70; rep_b none; both running=0
+        Expectation: scores = [0.619, 0.252]
+          rep_a: load=0.08→s_load=0.92; s_cache=0.49; score=0.7·0.49+0.3·0.92=0.619
+          rep_b: load=0.16→s_load=0.84; s_cache=0;    score=0.3·0.84=0.252
+        """
+        strat = _strat()
+        provider = FakeRouteDataProvider(
+            {
+                "rep_a": {"kv_cache_usage_perc": 0.2, "num_requests_running": 0, "num_requests_waiting": 0,
+                          "gpu_hit_pct": 70, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "rep_b": {"kv_cache_usage_perc": 0.4, "num_requests_running": 0, "num_requests_waiting": 0,
+                          "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+            }
+        )
+        scores = strat.score(PROMPT_IDS, provider, _replicas("rep_a", "rep_b"))
+        assert scores == pytest.approx([0.619, 0.252])
+
+    def test_high_load_penalizes_but_full_formula_applied(self):
+        """
+        Feature: a saturated replica (load>0.9) gets the FULL formula (no zeroing);
+        its s_load≈0 drags the score down despite high cache.
+        Description: "loaded" kv=1,r=64,w=1000 (load≈0.98); "light" kv=0.2,r=0 (load=0.08)
+        Expectation: light outranks loaded; loaded score still reflects its cache term (not zeroed)
+          loaded: waiting clamped (1000/64→1.0) → load=0.4+0.3+0.3=1.0→s_load=0; s_cache=0.63;
+                  score=0.7·0.63+0.3·0=0.441  (cache term 0.441 present despite saturation)
+          light:  load=0.08→s_load=0.92; s_cache=0.35; score=0.7·0.35+0.3·0.92=0.521
+        """
+        strat = _strat()
+        provider = FakeRouteDataProvider(
+            {
+                "loaded": {"kv_cache_usage_perc": 1.0, "num_requests_running": 64, "num_requests_waiting": 1000,
+                           "gpu_hit_pct": 90, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "light":  {"kv_cache_usage_perc": 0.2, "num_requests_running": 0, "num_requests_waiting": 0,
+                           "gpu_hit_pct": 50, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+            }
+        )
+        scores = strat.score(PROMPT_IDS, provider, _replicas("loaded", "light"))
+        assert scores == pytest.approx([0.441, 0.521], abs=1e-4)
+        assert scores[1] > scores[0]  # high load penalizes below light
+        # loaded's score equals the full formula — cache term (0.441) is NOT zeroed
+        # load=1.0 (waiting clamped) → s_load=0 → score = 0.7·0.63 + 0.3·0 = 0.441
+        assert scores[0] == pytest.approx(0.7 * 0.63 + 0.3 * 0.0, abs=1e-4)
+
+    def test_no_cache_pure_load(self):
+        """
+        Feature: with no cache hits, score collapses to (1-α)·s_load = (1-α)·(1-load)
+        Description: idle (load=0) vs kv-full (load=0.4); both no cache, running=0
+        Expectation: scores = [0.30, 0.18]
+        """
+        strat = _strat()
+        provider = FakeRouteDataProvider(
+            {
+                "idle": {"kv_cache_usage_perc": 0.0, "num_requests_running": 0, "num_requests_waiting": 0,
+                         "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "full": {"kv_cache_usage_perc": 1.0, "num_requests_running": 0, "num_requests_waiting": 0,
+                         "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+            }
+        )
+        scores = strat.score(PROMPT_IDS, provider, _replicas("idle", "full"))
+        assert scores == pytest.approx([0.30, 0.18])
+
+
+# --------------------------------------------------------------------------- #
+# StrategyRegistry
+# --------------------------------------------------------------------------- #
+
+class TestKVCAwareLoad:
+    def test_load_formula_monotonic_in_kv(self):
+        """
+        Feature: higher kv_usage → higher load → lower s_load → lower score
+        Description: three replicas with kv 0 / 0.5 / 1.0 (running=0); no cache
+        Expectation: scores decrease as kv rises
+          idle:   load=0    → s_load=1.0  → score=0.30
+          mid:    load=0.2  → s_load=0.8  → score=0.24
+          loaded: load=0.7  → s_load=0.3  → score=0.09   (kv=1,running=64: load=0.4+0.3=0.7)
+        """
+        strat = _strat()
+        provider = FakeRouteDataProvider(
+            {
+                "idle":    {"kv_cache_usage_perc": 0.0, "num_requests_running": 0, "num_requests_waiting": 0,
+                            "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "mid":     {"kv_cache_usage_perc": 0.5, "num_requests_running": 0, "num_requests_waiting": 0,
+                            "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "loaded":  {"kv_cache_usage_perc": 1.0, "num_requests_running": 64, "num_requests_waiting": 0,
+                            "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+            }
+        )
+        scores = strat.score(PROMPT_IDS, provider, _replicas("idle", "mid", "loaded"))
+        assert scores == pytest.approx([0.30, 0.24, 0.09])
+        assert scores[0] > scores[1] > scores[2]
+
+    def test_running_increases_load(self):
+        """
+        Feature: running/max_num_seqs contributes to load; clamped to 1.0
+        Description: kv=0.5 fixed; running 0 / 32 / 64; no cache
+        Expectation: scores decrease as running rises
+          r=0:  load=0.2        → s_load=0.80 → score=0.24
+          r=32: load=0.2+0.15=0.35 → s_load=0.65 → score=0.195
+          r=64: load=0.2+0.30=0.50 → s_load=0.50 → score=0.15
+        """
+        strat = _strat()
+        provider = FakeRouteDataProvider(
+            {
+                "r0":  {"kv_cache_usage_perc": 0.5, "num_requests_running": 0, "num_requests_waiting": 0,
+                        "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "r32": {"kv_cache_usage_perc": 0.5, "num_requests_running": 32, "num_requests_waiting": 0,
+                        "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "r64": {"kv_cache_usage_perc": 0.5, "num_requests_running": 64, "num_requests_waiting": 0,
+                        "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+            }
+        )
+        scores = strat.score(PROMPT_IDS, provider, _replicas("r0", "r32", "r64"))
+        assert scores == pytest.approx([0.24, 0.195, 0.15])
+        assert scores[0] > scores[1] > scores[2]
+
+    def test_waiting_increases_load(self):
+        """
+        Feature: min(1, waiting/max_num_seqs) contributes to load
+        Description: kv=0,running=0; waiting 0 vs 10; no cache
+        Expectation: waiting replica scores lower
+          w=0:  load=0 → s_load=1.0 → score=0.30
+          w=10: load=0.3·(10/64)=0.0469 → s_load=0.9531 → score=0.2859
+        """
+        strat = _strat()
+        provider = FakeRouteDataProvider(
+            {
+                "w0":  {"kv_cache_usage_perc": 0.0, "num_requests_running": 0, "num_requests_waiting": 0,
+                        "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "w10": {"kv_cache_usage_perc": 0.0, "num_requests_running": 0, "num_requests_waiting": 10,
+                        "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+            }
+        )
+        scores = strat.score(PROMPT_IDS, provider, _replicas("w0", "w10"))
+        assert scores == pytest.approx([0.30, 0.3 * (1 - 0.3 * (10 / 64))])
+        assert scores[0] > scores[1]
+
+    def test_missing_metrics_defaults_to_high_load(self):
+        """
+        Feature: unknown replica defaults to kv=1.0 → load=0.4 (not 1.0); no cache
+        Description: score a replica whose id is absent from the provider
+        Expectation: load=0.4·1.0=0.4 → s_load=0.6 → score=0.3·0.6=0.18
+        """
+        strat = _strat()
+        provider = FakeRouteDataProvider({})
+        scores = strat.score(PROMPT_IDS, provider, _replicas("ghost"))
+        assert scores == pytest.approx([0.18])
+
+
+# --------------------------------------------------------------------------- #
+# _cache_score: three-layer weighted hit (gpu + cpu + ssd)
+# --------------------------------------------------------------------------- #
+class TestKVCAwareCacheScore:
+    def test_three_layer_weighted_sum(self):
+        """
+        Feature: _cache_score = w_gpu·gpu + w_cpu·cpu + w_ssd·ssd
+        Description: gpu_hit_pct=80, cpu=0.6, ssd=0.2 with default weights
+        Expectation: 0.7*0.8 + 0.2*0.6 + 0.1*0.2 = 0.70
+        """
+        strat = _strat()
+        provider = FakeRouteDataProvider(
+            {"rep": {"gpu_hit_pct": 80, "tiers": {"cpu": 0.6, "ssd": 0.2}}}
+        )
+        gpu_hit_pct = provider.get_gpu_prefix_hit_rate(PROMPT_IDS)  # {"rep": 80}
+        assert strat._cache_score(provider, ReplicaInfo("rep"), PROMPT_IDS, gpu_hit_pct) == pytest.approx(0.70)
+
+    def test_gpu_only_when_tier_none(self):
+        """
+        Feature: None tier hit rate is treated as 0.0
+        Description: provider returns None for tiers (mooncake placeholder); gpu_hit_pct=80
+        Expectation: 0.7*0.8 + 0 + 0 = 0.56
+        """
+        class _NoneProvider(FakeRouteDataProvider):
+            def get_tier_prefix_hit_rate(self, replica_id, prompt_ids, tier):
+                return None
+
+        strat = _strat()
+        provider = _NoneProvider({"rep": {"gpu_hit_pct": 80, "tiers": {}}})
+        gpu_hit_pct = {"rep": 80}
+        assert strat._cache_score(provider, ReplicaInfo("rep"), PROMPT_IDS, gpu_hit_pct) == pytest.approx(0.56)
+
+    def test_no_hit_returns_zero(self):
+        """
+        Feature: no gpu hit and no tier hits → _cache_score = 0.0
+        Description: replica absent from gpu_hit_pct; tiers all 0
+        Expectation: 0.0
+        """
+        strat = _strat()
+        provider = FakeRouteDataProvider({"rep": {"tiers": {"cpu": 0.0, "ssd": 0.0}}})
+        assert strat._cache_score(provider, ReplicaInfo("rep"), PROMPT_IDS, {}) == pytest.approx(0.0)
+
+    def test_custom_weights_respected(self):
+        """
+        Feature: _cache_score honors custom layer_weights
+        Description: weights {gpu:0.5,cpu:0.3,ssd:0.2}; all hits = 1.0 (gpu_hit_pct=100)
+        Expectation: 0.5 + 0.3 + 0.2 = 1.0
+        """
+        strat = _strat(layer_weights={"gpu": 0.5, "cpu": 0.3, "ssd": 0.2})
+        provider = FakeRouteDataProvider(
+            {"rep": {"gpu_hit_pct": 100, "tiers": {"cpu": 1.0, "ssd": 1.0}}}
+        )
+        gpu_hit_pct = {"rep": 100}
+        assert strat._cache_score(provider, ReplicaInfo("rep"), PROMPT_IDS, gpu_hit_pct) == pytest.approx(1.0)
+
+
+# --------------------------------------------------------------------------- #
+# Tier weights in the cache term
+# --------------------------------------------------------------------------- #
+class TestKVCAwareTierWeights:
+    def test_cpu_weight_higher_than_ssd(self):
+        """
+        Feature: cpu tier weight (0.2) > ssd tier weight (0.1) in the cache term
+        Description: two light-load replicas; one has cpu hit, other ssd hit
+        Expectation: cpu-hit replica scores higher
+          cpu_hit: load=0.2→s_load=0.8; s_cache=0.2·0.6=0.12; score=0.7·0.12+0.3·0.8=0.324
+          ssd_hit: load=0.2→s_load=0.8; s_cache=0.1·0.8=0.08; score=0.7·0.08+0.3·0.8=0.296
+        """
+        strat = _strat()
+        provider = FakeRouteDataProvider(
+            {
+                "cpu_hit": {"kv_cache_usage_perc": 0.5, "num_requests_running": 0, "num_requests_waiting": 0,
+                            "gpu_hit_pct": 0, "tiers": {"cpu": 0.6, "ssd": 0.0}},
+                "ssd_hit": {"kv_cache_usage_perc": 0.5, "num_requests_running": 0, "num_requests_waiting": 0,
+                            "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.8}},
+            }
+        )
+        scores = strat.score(PROMPT_IDS, provider, _replicas("cpu_hit", "ssd_hit"))
+        assert scores == pytest.approx([0.324, 0.296])
+        assert scores[0] > scores[1]
+
+    def test_tier_none_treated_as_zero(self):
+        """
+        Feature: None return from get_tier_prefix_hit_rate is treated as 0.0
+        Description: provider returns None for tier hit rate
+        Expectation: score = (1-α)·s_load (S_cache=0), no TypeError
+          rep: load=0.2→s_load=0.8; s_cache=0; score=0.3·0.8=0.24
+        """
+        class _NoneProvider(FakeRouteDataProvider):
+            def get_tier_prefix_hit_rate(self, replica_id, prompt_ids, tier):
+                return None
+
+        strat = _strat()
+        provider = _NoneProvider(
+            {"rep": {"kv_cache_usage_perc": 0.5, "num_requests_running": 0, "num_requests_waiting": 0,
+                     "gpu_hit_pct": 0, "tiers": {}}}
+        )
+        scores = strat.score(PROMPT_IDS, provider, _replicas("rep"))
+        assert scores == pytest.approx([0.24])
+
+
+# --------------------------------------------------------------------------- #
+# Construction validation
+# --------------------------------------------------------------------------- #
+class TestKVCAwareConstruction:
+    @pytest.mark.parametrize("kwargs", [
+        {"alpha": 1.5},
+        {"alpha": -0.1},
+        {"load_threshold": 0},
+        {"load_threshold": 1.0},
+        {"layer_weights": {"gpu": 0.7, "cpu": 0.2, "ssd": -0.1}},   # negative weight
+        {"layer_weights": {"nvme": 1.0}},                            # illegal key
+        {"layer_weights": {"gpu": 1.0, "cpu": 0.2, "ssd": 0.1}},    # sum 1.3 != 1
+        {"layer_weights": {"gpu": 0.7, "cpu": 0.3}},                 # missing ssd
+        {"load_fn": "does-not-exist"},                               # unknown load fn
+        {"load_weights": (0.5, 0.3)},                                # len != 3
+        {"load_weights": (0.5, 0.5, 0.5)},                           # sum 1.5 != 1
+        {"load_weights": (-0.1, 0.6, 0.5)},                          # negative
+    ])
+    def test_invalid_construction_raises(self, kwargs):
+        """
+        Feature: invalid constructor arguments raise StrategyError
+        Description: construct KVCacheAwareStrategy with each invalid kwarg
+        Expectation: raises StrategyError for each case
+        """
+        with pytest.raises(StrategyError):
+            _strat(**kwargs)
+
+    def test_valid_three_key_weights_accepted(self):
+        """
+        Feature: three-key layer_weights summing to 1.0 construct successfully
+        """
+        strat = _strat(layer_weights={"gpu": 0.5, "cpu": 0.3, "ssd": 0.2})
+        assert strat.layer_weights == {"gpu": 0.5, "cpu": 0.3, "ssd": 0.2}
+
+    def test_default_load_fn_is_normalized(self):
+        """
+        Feature: default load_fn is "normalized"; load_weights default (0.4,0.3,0.3)
+        """
+        strat = _strat()
+        assert strat.load_fn == "normalized"
+        assert strat.load_weights == (0.4, 0.3, 0.3)
+
+    def test_load_fn_kv_over_pressure_selectable(self):
+        """
+        Feature: load_fn="kv_over_pressure" (legacy) is selectable
+        """
+        strat = _strat(load_fn="kv_over_pressure")
+        assert strat.load_fn == "kv_over_pressure"
+
+
+# --------------------------------------------------------------------------- #
+# Interface contract
+# --------------------------------------------------------------------------- #
+class TestStrategyContract:
+    def test_protocol_satisfied(self):
+        """
+        Feature: KVCacheAwareStrategy satisfies the RoutingStrategy Protocol
+        """
+        strat = _strat()
+        assert isinstance(strat, RoutingStrategy)
+
+    def test_output_length_matches_replicas(self):
+        """
+        Feature: score() returns a list with same length as replicas
+        """
+        strat = _strat()
+        provider = FakeRouteDataProvider(
+            {
+                "rep_a": {"kv_cache_usage_perc": 0.3, "num_requests_running": 1, "num_requests_waiting": 0,
+                          "gpu_hit_pct": 90, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "rep_b": {"kv_cache_usage_perc": 0.5, "num_requests_running": 2, "num_requests_waiting": 0,
+                          "gpu_hit_pct": 10, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+            }
+        )
+        replicas = _replicas("rep_a", "rep_b")
+        scores = strat.score(PROMPT_IDS, provider, replicas)
+        assert len(scores) == len(replicas)
+
+    def test_stateless_repeatable(self):
+        """
+        Feature: calling score() twice on the same inputs produces identical results
+        """
+        strat = _strat()
+        provider = FakeRouteDataProvider(
+            {
+                "rep_a": {"kv_cache_usage_perc": 0.3, "num_requests_running": 1, "num_requests_waiting": 0,
+                          "gpu_hit_pct": 80, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "rep_b": {"kv_cache_usage_perc": 0.5, "num_requests_running": 2, "num_requests_waiting": 0,
+                          "gpu_hit_pct": 0, "tiers": {"cpu": 0.5, "ssd": 0.0}},
+            }
+        )
+        replicas = _replicas("rep_a", "rep_b")
+        assert strat.score(PROMPT_IDS, provider, replicas) == pytest.approx(strat.score(PROMPT_IDS, provider, replicas))
+
+
+# --------------------------------------------------------------------------- #
+# route() composition
+# --------------------------------------------------------------------------- #
+
+class TestFromConfig:
+    def test_from_config_correct_fields(self):
+        """
+        Feature: from_config() transfers config fields to the strategy instance
+        Description: build a KVCAwareStrategyConfig with non-default values, then from_config()
+        Expectation: strategy alpha, load_threshold, layer_weights match the config;
+                     load_fn/weights come from code defaults (not config)
+        """
+        from uni_agent.llm_router.config.strategy import KVCAwareStrategyConfig
+
+        cfg = KVCAwareStrategyConfig(
+            alpha=0.6, load_threshold=0.85,
+            layer_weights={"gpu": 0.6, "cpu": 0.3, "ssd": 0.1},
+            weight=0.9, collector_names=["vllm_zmq"],
+        )
+        strat = KVCacheAwareStrategy.from_config(cfg)
+        assert strat.alpha == pytest.approx(0.6)
+        assert strat.load_threshold == pytest.approx(0.85)
+        assert strat.layer_weights == {"gpu": 0.6, "cpu": 0.3, "ssd": 0.1}
+        assert strat.load_fn == "normalized"          # code default
+        assert strat.load_weights == (0.4, 0.3, 0.3)   # code default
+
+    def test_from_config_scores_match_direct(self, monkeypatch):
+        """
+        Feature: a strategy built via from_config() produces the same scores as one built directly
+        Description: pin MAX_NUM_SEQS=64 so both resolve the same max_num_seqs
+        Expectation: both strategies return approx-equal score lists
+        """
+        from uni_agent.llm_router.config.strategy import KVCAwareStrategyConfig
+
+        monkeypatch.setenv("MAX_NUM_SEQS", "64")  # from_config resolves max_num_seqs from env
+        cfg = KVCAwareStrategyConfig(
+            alpha=0.7, load_threshold=0.9,
+            layer_weights={"gpu": 0.7, "cpu": 0.2, "ssd": 0.1},
+            weight=1.0, collector_names=["vllm_zmq"],
+        )
+        strat_from_cfg = KVCacheAwareStrategy.from_config(cfg)
+        strat_direct = _strat()  # max_num_seqs=64 pinned
+        provider = FakeRouteDataProvider(
+            {
+                "rep_a": {"kv_cache_usage_perc": 0.3, "num_requests_running": 1, "num_requests_waiting": 0,
+                          "gpu_hit_pct": 80, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "rep_b": {"kv_cache_usage_perc": 0.92, "num_requests_running": 0, "num_requests_waiting": 0,
+                          "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+            }
+        )
+        replicas = _replicas("rep_a", "rep_b")
+        assert strat_from_cfg.score(PROMPT_IDS, provider, replicas) == pytest.approx(
+            strat_direct.score(PROMPT_IDS, provider, replicas)
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Sticky-session short-circuit (is_overloaded uses load > load_threshold)
+# --------------------------------------------------------------------------- #
+class TestStickyShortCircuit:
+    """Sticky replica wins when bound + present + not overloaded; else fall through.
+
+    Overload now means ``load > load_threshold`` (default 0.9) — i.e. the bound
+    replica is genuinely saturated (kv≈1, running≈max_num_seqs, big backlog).
+    """
+
+    def _provider(self, **per_replica):
+        """Build a FakeRouteDataProvider from {rep_id: metrics_dict}."""
+        return FakeRouteDataProvider(per_replica)
+
+    # ── is_overloaded ──────────────────────────────────────────────────────
+    def test_is_overloaded_true_when_saturated(self):
+        """Feature: is_overloaded True when load > load_threshold (0.9).
+        Description: kv=1.0, running=64 (mns), waiting=1000 → load≈0.98 > 0.9
+        Expectation: overloaded
+        """
+        strat = _strat(load_threshold=0.9)
+        provider = self._provider(rep_a={"kv_cache_usage_perc": 1.0, "num_requests_running": 64, "num_requests_waiting": 1000})
+        assert strat.is_overloaded(provider, ReplicaInfo("rep_a")) is True
+
+    def test_is_overloaded_false_when_light(self):
+        """Feature: is_overloaded False when load <= load_threshold.
+        Description: kv=0.3, running=0, waiting=0 → load=0.12 < 0.9
+        Expectation: not overloaded
+        """
+        strat = _strat(load_threshold=0.9)
+        provider = self._provider(rep_a={"kv_cache_usage_perc": 0.3, "num_requests_running": 0})
+        assert strat.is_overloaded(provider, ReplicaInfo("rep_a")) is False
+
+    # ── score() sticky short-circuit ───────────────────────────────────────
+    def test_sticky_hit_not_overloaded_short_circuits(self):
+        """Feature: bound + present + not overloaded → sticky replica gets top score.
+        Description: sticky binds r1→rep_b; rep_b light (load=0.12); rep_a has better
+        combined score but must NOT win.
+        Expectation: scores = [0.0, STICKY_TOP_SCORE]; route() picks rep_b
+        """
+        strat = _strat(load_threshold=0.9)
+        provider = self._provider(
+            rep_a={"kv_cache_usage_perc": 0.2, "num_requests_running": 0, "gpu_hit_pct": 80},
+            rep_b={"kv_cache_usage_perc": 0.3, "num_requests_running": 0, "gpu_hit_pct": 0},
+        )
+        replicas = _replicas("rep_a", "rep_b")
+        sticky = StickySessionTable()
+        sticky.put("r1", "rep_b")
+        scores = strat.score(PROMPT_IDS, provider, replicas, "r1", sticky)
+        assert scores == [0.0, STICKY_TOP_SCORE]
+        ranking = route([(strat, 1.0)], PROMPT_IDS, provider, replicas, "r1", sticky)
+        assert ranking[0] == "rep_b"
+
+    def test_sticky_hit_overloaded_falls_back_to_combined(self):
+        """Feature: bound but saturated (load>0.9) → no short-circuit, combined scoring.
+        Description: sticky binds r1→rep_b; rep_b saturated (kv=1,r=64,w=1000);
+        rep_a light with gpu hit.
+        Expectation: rep_a wins (combined), not the saturated sticky rep_b
+        """
+        strat = _strat(load_threshold=0.9)
+        provider = self._provider(
+            rep_a={"kv_cache_usage_perc": 0.2, "num_requests_running": 0, "gpu_hit_pct": 80},
+            rep_b={"kv_cache_usage_perc": 1.0, "num_requests_running": 64, "num_requests_waiting": 1000, "gpu_hit_pct": 0},
+        )
+        replicas = _replicas("rep_a", "rep_b")
+        sticky = StickySessionTable()
+        sticky.put("r1", "rep_b")
+        ranking = route([(strat, 1.0)], PROMPT_IDS, provider, replicas, "r1", sticky)
+        assert ranking[0] == "rep_a"
+
+    def test_sticky_no_binding_cold_start_combined(self):
+        """Feature: no sticky binding → combined scoring (cold start).
+        Expectation: best combined replica wins (rep_a)
+        """
+        strat = _strat(load_threshold=0.9)
+        provider = self._provider(
+            rep_a={"kv_cache_usage_perc": 0.2, "num_requests_running": 0, "gpu_hit_pct": 80},
+            rep_b={"kv_cache_usage_perc": 0.3, "num_requests_running": 0, "gpu_hit_pct": 0},
+        )
+        replicas = _replicas("rep_a", "rep_b")
+        sticky = StickySessionTable()
+        ranking = route([(strat, 1.0)], PROMPT_IDS, provider, replicas, "r1", sticky)
+        assert ranking[0] == "rep_a"
+
+    def test_sticky_bound_replica_removed_falls_back(self):
+        """Feature: bound replica no longer in pool → fall back to combined.
+        Expectation: rep_a wins (combined), no KeyError/crash
+        """
+        strat = _strat(load_threshold=0.9)
+        provider = self._provider(
+            rep_a={"kv_cache_usage_perc": 0.2, "num_requests_running": 0, "gpu_hit_pct": 80},
+            rep_b={"kv_cache_usage_perc": 0.3, "num_requests_running": 0, "gpu_hit_pct": 0},
+        )
+        replicas = _replicas("rep_a", "rep_b")
+        sticky = StickySessionTable()
+        sticky.put("r1", "rep_gone")  # bound replica not in pool
+        ranking = route([(strat, 1.0)], PROMPT_IDS, provider, replicas, "r1", sticky)
+        assert ranking[0] == "rep_a"
+
+    def test_sticky_none_request_id_combined(self):
+        """Feature: request_id=None → combined scoring (no sticky lookup).
+        Expectation: combined scoring, rep_a wins
+        """
+        strat = _strat(load_threshold=0.9)
+        provider = self._provider(
+            rep_a={"kv_cache_usage_perc": 0.2, "num_requests_running": 0, "gpu_hit_pct": 80},
+            rep_b={"kv_cache_usage_perc": 0.3, "num_requests_running": 0, "gpu_hit_pct": 0},
+        )
+        replicas = _replicas("rep_a", "rep_b")
+        ranking = route([(strat, 1.0)], PROMPT_IDS, provider, replicas, None, None)
+        assert ranking[0] == "rep_a"

--- a/tests/uni_agent/llm_router/strategies/test_kvc_aware_strategy.py
+++ b/tests/uni_agent/llm_router/strategies/test_kvc_aware_strategy.py
@@ -16,24 +16,22 @@ from __future__ import annotations
 
 import pytest
 
+from uni_agent.llm_router.metric_spec import MetricKey
 from uni_agent.llm_router.strategies import (
     KVCacheAwareStrategy,
     RoutingStrategy,
-    StrategyError,
-    StrategyRegistry,
     StickySessionTable,
+    StrategyError,
     route,
 )
 from uni_agent.llm_router.strategies.base import ReplicaInfo
 from uni_agent.llm_router.strategies.kvc_aware import STICKY_TOP_SCORE
-from uni_agent.llm_router.metric_spec import MetricKey
-
-
 
 pytestmark = [pytest.mark.ut, pytest.mark.cpu]
 # --------------------------------------------------------------------------- #
 # Helpers
 # --------------------------------------------------------------------------- #
+
 
 def _strat(**kwargs) -> KVCacheAwareStrategy:
     """Build a KVCacheAwareStrategy with required boilerplate fields filled in.
@@ -140,6 +138,7 @@ class RaisingStrategy:
 
 pytestmark = [pytest.mark.ut, pytest.mark.cpu]
 
+
 class TestKVCAwareCombinedScore:
     def test_three_layer_cache_weighted_sum(self):
         """
@@ -152,10 +151,20 @@ class TestKVCAwareCombinedScore:
         strat = _strat()
         provider = FakeRouteDataProvider(
             {
-                "rep_a": {"kv_cache_usage_perc": 0.2, "num_requests_running": 0, "num_requests_waiting": 0,
-                          "gpu_hit_pct": 80, "tiers": {"cpu": 0.6, "ssd": 0.2}},
-                "rep_b": {"kv_cache_usage_perc": 0.4, "num_requests_running": 0, "num_requests_waiting": 0,
-                          "gpu_hit_pct": 0, "tiers": {"cpu": 0.3, "ssd": 0.4}},
+                "rep_a": {
+                    "kv_cache_usage_perc": 0.2,
+                    "num_requests_running": 0,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 80,
+                    "tiers": {"cpu": 0.6, "ssd": 0.2},
+                },
+                "rep_b": {
+                    "kv_cache_usage_perc": 0.4,
+                    "num_requests_running": 0,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 0,
+                    "tiers": {"cpu": 0.3, "ssd": 0.4},
+                },
             }
         )
         scores = strat.score(PROMPT_IDS, provider, _replicas("rep_a", "rep_b"))
@@ -173,10 +182,20 @@ class TestKVCAwareCombinedScore:
         strat = _strat()
         provider = FakeRouteDataProvider(
             {
-                "rep_a": {"kv_cache_usage_perc": 0.2, "num_requests_running": 0, "num_requests_waiting": 0,
-                          "gpu_hit_pct": 70, "tiers": {"cpu": 0.0, "ssd": 0.0}},
-                "rep_b": {"kv_cache_usage_perc": 0.4, "num_requests_running": 0, "num_requests_waiting": 0,
-                          "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "rep_a": {
+                    "kv_cache_usage_perc": 0.2,
+                    "num_requests_running": 0,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 70,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
+                "rep_b": {
+                    "kv_cache_usage_perc": 0.4,
+                    "num_requests_running": 0,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 0,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
             }
         )
         scores = strat.score(PROMPT_IDS, provider, _replicas("rep_a", "rep_b"))
@@ -195,10 +214,20 @@ class TestKVCAwareCombinedScore:
         strat = _strat()
         provider = FakeRouteDataProvider(
             {
-                "loaded": {"kv_cache_usage_perc": 1.0, "num_requests_running": 64, "num_requests_waiting": 1000,
-                           "gpu_hit_pct": 90, "tiers": {"cpu": 0.0, "ssd": 0.0}},
-                "light":  {"kv_cache_usage_perc": 0.2, "num_requests_running": 0, "num_requests_waiting": 0,
-                           "gpu_hit_pct": 50, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "loaded": {
+                    "kv_cache_usage_perc": 1.0,
+                    "num_requests_running": 64,
+                    "num_requests_waiting": 1000,
+                    "gpu_hit_pct": 90,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
+                "light": {
+                    "kv_cache_usage_perc": 0.2,
+                    "num_requests_running": 0,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 50,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
             }
         )
         scores = strat.score(PROMPT_IDS, provider, _replicas("loaded", "light"))
@@ -217,10 +246,20 @@ class TestKVCAwareCombinedScore:
         strat = _strat()
         provider = FakeRouteDataProvider(
             {
-                "idle": {"kv_cache_usage_perc": 0.0, "num_requests_running": 0, "num_requests_waiting": 0,
-                         "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
-                "full": {"kv_cache_usage_perc": 1.0, "num_requests_running": 0, "num_requests_waiting": 0,
-                         "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "idle": {
+                    "kv_cache_usage_perc": 0.0,
+                    "num_requests_running": 0,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 0,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
+                "full": {
+                    "kv_cache_usage_perc": 1.0,
+                    "num_requests_running": 0,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 0,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
             }
         )
         scores = strat.score(PROMPT_IDS, provider, _replicas("idle", "full"))
@@ -230,6 +269,7 @@ class TestKVCAwareCombinedScore:
 # --------------------------------------------------------------------------- #
 # StrategyRegistry
 # --------------------------------------------------------------------------- #
+
 
 class TestKVCAwareLoad:
     def test_load_formula_monotonic_in_kv(self):
@@ -244,12 +284,27 @@ class TestKVCAwareLoad:
         strat = _strat()
         provider = FakeRouteDataProvider(
             {
-                "idle":    {"kv_cache_usage_perc": 0.0, "num_requests_running": 0, "num_requests_waiting": 0,
-                            "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
-                "mid":     {"kv_cache_usage_perc": 0.5, "num_requests_running": 0, "num_requests_waiting": 0,
-                            "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
-                "loaded":  {"kv_cache_usage_perc": 1.0, "num_requests_running": 64, "num_requests_waiting": 0,
-                            "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "idle": {
+                    "kv_cache_usage_perc": 0.0,
+                    "num_requests_running": 0,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 0,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
+                "mid": {
+                    "kv_cache_usage_perc": 0.5,
+                    "num_requests_running": 0,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 0,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
+                "loaded": {
+                    "kv_cache_usage_perc": 1.0,
+                    "num_requests_running": 64,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 0,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
             }
         )
         scores = strat.score(PROMPT_IDS, provider, _replicas("idle", "mid", "loaded"))
@@ -268,12 +323,27 @@ class TestKVCAwareLoad:
         strat = _strat()
         provider = FakeRouteDataProvider(
             {
-                "r0":  {"kv_cache_usage_perc": 0.5, "num_requests_running": 0, "num_requests_waiting": 0,
-                        "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
-                "r32": {"kv_cache_usage_perc": 0.5, "num_requests_running": 32, "num_requests_waiting": 0,
-                        "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
-                "r64": {"kv_cache_usage_perc": 0.5, "num_requests_running": 64, "num_requests_waiting": 0,
-                        "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "r0": {
+                    "kv_cache_usage_perc": 0.5,
+                    "num_requests_running": 0,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 0,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
+                "r32": {
+                    "kv_cache_usage_perc": 0.5,
+                    "num_requests_running": 32,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 0,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
+                "r64": {
+                    "kv_cache_usage_perc": 0.5,
+                    "num_requests_running": 64,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 0,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
             }
         )
         scores = strat.score(PROMPT_IDS, provider, _replicas("r0", "r32", "r64"))
@@ -291,10 +361,20 @@ class TestKVCAwareLoad:
         strat = _strat()
         provider = FakeRouteDataProvider(
             {
-                "w0":  {"kv_cache_usage_perc": 0.0, "num_requests_running": 0, "num_requests_waiting": 0,
-                        "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
-                "w10": {"kv_cache_usage_perc": 0.0, "num_requests_running": 0, "num_requests_waiting": 10,
-                        "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "w0": {
+                    "kv_cache_usage_perc": 0.0,
+                    "num_requests_running": 0,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 0,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
+                "w10": {
+                    "kv_cache_usage_perc": 0.0,
+                    "num_requests_running": 0,
+                    "num_requests_waiting": 10,
+                    "gpu_hit_pct": 0,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
             }
         )
         scores = strat.score(PROMPT_IDS, provider, _replicas("w0", "w10"))
@@ -324,9 +404,7 @@ class TestKVCAwareCacheScore:
         Expectation: 0.7*0.8 + 0.2*0.6 + 0.1*0.2 = 0.70
         """
         strat = _strat()
-        provider = FakeRouteDataProvider(
-            {"rep": {"gpu_hit_pct": 80, "tiers": {"cpu": 0.6, "ssd": 0.2}}}
-        )
+        provider = FakeRouteDataProvider({"rep": {"gpu_hit_pct": 80, "tiers": {"cpu": 0.6, "ssd": 0.2}}})
         gpu_hit_pct = provider.get_gpu_prefix_hit_rate(PROMPT_IDS)  # {"rep": 80}
         assert strat._cache_score(provider, ReplicaInfo("rep"), PROMPT_IDS, gpu_hit_pct) == pytest.approx(0.70)
 
@@ -336,6 +414,7 @@ class TestKVCAwareCacheScore:
         Description: provider returns None for tiers (mooncake placeholder); gpu_hit_pct=80
         Expectation: 0.7*0.8 + 0 + 0 = 0.56
         """
+
         class _NoneProvider(FakeRouteDataProvider):
             def get_tier_prefix_hit_rate(self, replica_id, prompt_ids, tier):
                 return None
@@ -362,9 +441,7 @@ class TestKVCAwareCacheScore:
         Expectation: 0.5 + 0.3 + 0.2 = 1.0
         """
         strat = _strat(layer_weights={"gpu": 0.5, "cpu": 0.3, "ssd": 0.2})
-        provider = FakeRouteDataProvider(
-            {"rep": {"gpu_hit_pct": 100, "tiers": {"cpu": 1.0, "ssd": 1.0}}}
-        )
+        provider = FakeRouteDataProvider({"rep": {"gpu_hit_pct": 100, "tiers": {"cpu": 1.0, "ssd": 1.0}}})
         gpu_hit_pct = {"rep": 100}
         assert strat._cache_score(provider, ReplicaInfo("rep"), PROMPT_IDS, gpu_hit_pct) == pytest.approx(1.0)
 
@@ -384,10 +461,20 @@ class TestKVCAwareTierWeights:
         strat = _strat()
         provider = FakeRouteDataProvider(
             {
-                "cpu_hit": {"kv_cache_usage_perc": 0.5, "num_requests_running": 0, "num_requests_waiting": 0,
-                            "gpu_hit_pct": 0, "tiers": {"cpu": 0.6, "ssd": 0.0}},
-                "ssd_hit": {"kv_cache_usage_perc": 0.5, "num_requests_running": 0, "num_requests_waiting": 0,
-                            "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.8}},
+                "cpu_hit": {
+                    "kv_cache_usage_perc": 0.5,
+                    "num_requests_running": 0,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 0,
+                    "tiers": {"cpu": 0.6, "ssd": 0.0},
+                },
+                "ssd_hit": {
+                    "kv_cache_usage_perc": 0.5,
+                    "num_requests_running": 0,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 0,
+                    "tiers": {"cpu": 0.0, "ssd": 0.8},
+                },
             }
         )
         scores = strat.score(PROMPT_IDS, provider, _replicas("cpu_hit", "ssd_hit"))
@@ -401,14 +488,22 @@ class TestKVCAwareTierWeights:
         Expectation: score = (1-α)·s_load (S_cache=0), no TypeError
           rep: load=0.2→s_load=0.8; s_cache=0; score=0.3·0.8=0.24
         """
+
         class _NoneProvider(FakeRouteDataProvider):
             def get_tier_prefix_hit_rate(self, replica_id, prompt_ids, tier):
                 return None
 
         strat = _strat()
         provider = _NoneProvider(
-            {"rep": {"kv_cache_usage_perc": 0.5, "num_requests_running": 0, "num_requests_waiting": 0,
-                     "gpu_hit_pct": 0, "tiers": {}}}
+            {
+                "rep": {
+                    "kv_cache_usage_perc": 0.5,
+                    "num_requests_running": 0,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 0,
+                    "tiers": {},
+                }
+            }
         )
         scores = strat.score(PROMPT_IDS, provider, _replicas("rep"))
         assert scores == pytest.approx([0.24])
@@ -418,20 +513,23 @@ class TestKVCAwareTierWeights:
 # Construction validation
 # --------------------------------------------------------------------------- #
 class TestKVCAwareConstruction:
-    @pytest.mark.parametrize("kwargs", [
-        {"alpha": 1.5},
-        {"alpha": -0.1},
-        {"load_threshold": 0},
-        {"load_threshold": 1.0},
-        {"layer_weights": {"gpu": 0.7, "cpu": 0.2, "ssd": -0.1}},   # negative weight
-        {"layer_weights": {"nvme": 1.0}},                            # illegal key
-        {"layer_weights": {"gpu": 1.0, "cpu": 0.2, "ssd": 0.1}},    # sum 1.3 != 1
-        {"layer_weights": {"gpu": 0.7, "cpu": 0.3}},                 # missing ssd
-        {"load_fn": "does-not-exist"},                               # unknown load fn
-        {"load_weights": (0.5, 0.3)},                                # len != 3
-        {"load_weights": (0.5, 0.5, 0.5)},                           # sum 1.5 != 1
-        {"load_weights": (-0.1, 0.6, 0.5)},                          # negative
-    ])
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"alpha": 1.5},
+            {"alpha": -0.1},
+            {"load_threshold": 0},
+            {"load_threshold": 1.0},
+            {"layer_weights": {"gpu": 0.7, "cpu": 0.2, "ssd": -0.1}},  # negative weight
+            {"layer_weights": {"nvme": 1.0}},  # illegal key
+            {"layer_weights": {"gpu": 1.0, "cpu": 0.2, "ssd": 0.1}},  # sum 1.3 != 1
+            {"layer_weights": {"gpu": 0.7, "cpu": 0.3}},  # missing ssd
+            {"load_fn": "does-not-exist"},  # unknown load fn
+            {"load_weights": (0.5, 0.3)},  # len != 3
+            {"load_weights": (0.5, 0.5, 0.5)},  # sum 1.5 != 1
+            {"load_weights": (-0.1, 0.6, 0.5)},  # negative
+        ],
+    )
     def test_invalid_construction_raises(self, kwargs):
         """
         Feature: invalid constructor arguments raise StrategyError
@@ -482,10 +580,20 @@ class TestStrategyContract:
         strat = _strat()
         provider = FakeRouteDataProvider(
             {
-                "rep_a": {"kv_cache_usage_perc": 0.3, "num_requests_running": 1, "num_requests_waiting": 0,
-                          "gpu_hit_pct": 90, "tiers": {"cpu": 0.0, "ssd": 0.0}},
-                "rep_b": {"kv_cache_usage_perc": 0.5, "num_requests_running": 2, "num_requests_waiting": 0,
-                          "gpu_hit_pct": 10, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "rep_a": {
+                    "kv_cache_usage_perc": 0.3,
+                    "num_requests_running": 1,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 90,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
+                "rep_b": {
+                    "kv_cache_usage_perc": 0.5,
+                    "num_requests_running": 2,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 10,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
             }
         )
         replicas = _replicas("rep_a", "rep_b")
@@ -499,10 +607,20 @@ class TestStrategyContract:
         strat = _strat()
         provider = FakeRouteDataProvider(
             {
-                "rep_a": {"kv_cache_usage_perc": 0.3, "num_requests_running": 1, "num_requests_waiting": 0,
-                          "gpu_hit_pct": 80, "tiers": {"cpu": 0.0, "ssd": 0.0}},
-                "rep_b": {"kv_cache_usage_perc": 0.5, "num_requests_running": 2, "num_requests_waiting": 0,
-                          "gpu_hit_pct": 0, "tiers": {"cpu": 0.5, "ssd": 0.0}},
+                "rep_a": {
+                    "kv_cache_usage_perc": 0.3,
+                    "num_requests_running": 1,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 80,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
+                "rep_b": {
+                    "kv_cache_usage_perc": 0.5,
+                    "num_requests_running": 2,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 0,
+                    "tiers": {"cpu": 0.5, "ssd": 0.0},
+                },
             }
         )
         replicas = _replicas("rep_a", "rep_b")
@@ -512,6 +630,7 @@ class TestStrategyContract:
 # --------------------------------------------------------------------------- #
 # route() composition
 # --------------------------------------------------------------------------- #
+
 
 class TestFromConfig:
     def test_from_config_correct_fields(self):
@@ -524,16 +643,18 @@ class TestFromConfig:
         from uni_agent.llm_router.config.strategy import KVCAwareStrategyConfig
 
         cfg = KVCAwareStrategyConfig(
-            alpha=0.6, load_threshold=0.85,
+            alpha=0.6,
+            load_threshold=0.85,
             layer_weights={"gpu": 0.6, "cpu": 0.3, "ssd": 0.1},
-            weight=0.9, collector_names=["vllm_zmq"],
+            weight=0.9,
+            collector_names=["vllm_zmq"],
         )
         strat = KVCacheAwareStrategy.from_config(cfg)
         assert strat.alpha == pytest.approx(0.6)
         assert strat.load_threshold == pytest.approx(0.85)
         assert strat.layer_weights == {"gpu": 0.6, "cpu": 0.3, "ssd": 0.1}
-        assert strat.load_fn == "normalized"          # code default
-        assert strat.load_weights == (0.4, 0.3, 0.3)   # code default
+        assert strat.load_fn == "normalized"  # code default
+        assert strat.load_weights == (0.4, 0.3, 0.3)  # code default
 
     def test_from_config_scores_match_direct(self, monkeypatch):
         """
@@ -545,18 +666,30 @@ class TestFromConfig:
 
         monkeypatch.setenv("MAX_NUM_SEQS", "64")  # from_config resolves max_num_seqs from env
         cfg = KVCAwareStrategyConfig(
-            alpha=0.7, load_threshold=0.9,
+            alpha=0.7,
+            load_threshold=0.9,
             layer_weights={"gpu": 0.7, "cpu": 0.2, "ssd": 0.1},
-            weight=1.0, collector_names=["vllm_zmq"],
+            weight=1.0,
+            collector_names=["vllm_zmq"],
         )
         strat_from_cfg = KVCacheAwareStrategy.from_config(cfg)
         strat_direct = _strat()  # max_num_seqs=64 pinned
         provider = FakeRouteDataProvider(
             {
-                "rep_a": {"kv_cache_usage_perc": 0.3, "num_requests_running": 1, "num_requests_waiting": 0,
-                          "gpu_hit_pct": 80, "tiers": {"cpu": 0.0, "ssd": 0.0}},
-                "rep_b": {"kv_cache_usage_perc": 0.92, "num_requests_running": 0, "num_requests_waiting": 0,
-                          "gpu_hit_pct": 0, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "rep_a": {
+                    "kv_cache_usage_perc": 0.3,
+                    "num_requests_running": 1,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 80,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
+                "rep_b": {
+                    "kv_cache_usage_perc": 0.92,
+                    "num_requests_running": 0,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 0,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
             }
         )
         replicas = _replicas("rep_a", "rep_b")
@@ -586,7 +719,9 @@ class TestStickyShortCircuit:
         Expectation: overloaded
         """
         strat = _strat(load_threshold=0.9)
-        provider = self._provider(rep_a={"kv_cache_usage_perc": 1.0, "num_requests_running": 64, "num_requests_waiting": 1000})
+        provider = self._provider(
+            rep_a={"kv_cache_usage_perc": 1.0, "num_requests_running": 64, "num_requests_waiting": 1000}
+        )
         assert strat.is_overloaded(provider, ReplicaInfo("rep_a")) is True
 
     def test_is_overloaded_false_when_light(self):
@@ -627,7 +762,12 @@ class TestStickyShortCircuit:
         strat = _strat(load_threshold=0.9)
         provider = self._provider(
             rep_a={"kv_cache_usage_perc": 0.2, "num_requests_running": 0, "gpu_hit_pct": 80},
-            rep_b={"kv_cache_usage_perc": 1.0, "num_requests_running": 64, "num_requests_waiting": 1000, "gpu_hit_pct": 0},
+            rep_b={
+                "kv_cache_usage_perc": 1.0,
+                "num_requests_running": 64,
+                "num_requests_waiting": 1000,
+                "gpu_hit_pct": 0,
+            },
         )
         replicas = _replicas("rep_a", "rep_b")
         sticky = StickySessionTable()

--- a/tests/uni_agent/llm_router/strategies/test_load_score.py
+++ b/tests/uni_agent/llm_router/strategies/test_load_score.py
@@ -1,0 +1,146 @@
+"""Unit tests for the selectable load-score functions (strategies/load_score.py).
+
+All functions return ``load ∈ [0,1]`` with the convention **bigger = more loaded**
+(the inverse of the strategy's ``s_load``; the strategy converts via
+``s_load = 1 - load``).
+
+Normalized formula (default):
+    running_usage = min(1, running / max_num_seqs)
+    waiting_usage = min(1, waiting / max_num_seqs)
+    load = a·kv + b·running_usage + c·waiting_usage      (a+b+c=1)
+Default weights (a, b, c) = (0.4, 0.3, 0.3).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from uni_agent.llm_router.strategies.load_score import (
+    DEFAULT_LOAD_WEIGHTS,
+    DEFAULT_MAX_NUM_SEQS,
+    LOAD_FNS,
+    get_load_fn,
+    load_kv_over_pressure,
+    load_normalized,
+    resolve_max_num_seqs,
+)
+
+
+
+pytestmark = [pytest.mark.ut, pytest.mark.cpu]
+# --------------------------------------------------------------------------- #
+# load_normalized
+# --------------------------------------------------------------------------- #
+class TestLoadNormalized:
+    def test_idle_replica_is_zero(self):
+        """kv=0, running=0, waiting=0 → load=0 (all three terms vanish)."""
+        assert load_normalized(0.0, 0, 0, max_num_seqs=64) == pytest.approx(0.0)
+
+    def test_kv_only_contribution(self):
+        """kv=0.5, running/waiting=0 → load = a·kv = 0.4·0.5 = 0.2."""
+        assert load_normalized(0.5, 0, 0, max_num_seqs=64) == pytest.approx(0.2)
+
+    def test_running_and_kv(self):
+        """kv=0.5, running=32 (half of mns=64), waiting=0 → 0.4·0.5 + 0.3·0.5 = 0.35."""
+        assert load_normalized(0.5, 32, 0, max_num_seqs=64) == pytest.approx(0.35)
+
+    def test_running_clamped_to_one(self):
+        """running > max_num_seqs → running_usage clamped to 1.0 (load stays ≤1)."""
+        # kv=0.8, running=128 (>64) → run_usage=1.0; load = 0.4·0.8 + 0.3·1 = 0.62
+        assert load_normalized(0.8, 128, 0, max_num_seqs=64) == pytest.approx(0.62)
+
+    def test_waiting_term(self):
+        """kv=0, running=0, waiting=10 → wait_usage=10/64; load = 0.3·(10/64)=0.046875."""
+        assert load_normalized(0.0, 0, 10, max_num_seqs=64) == pytest.approx(0.3 * (10 / 64))
+
+    def test_custom_weights_change_load(self):
+        """weights (0.6,0.2,0.2) on kv=0.5,running=32 → 0.6·0.5 + 0.2·0.5 = 0.4."""
+        load = load_normalized(0.5, 32, 0, max_num_seqs=64, weights=(0.6, 0.2, 0.2))
+        assert load == pytest.approx(0.4)
+        # and differs from the default-weight result (0.35)
+        assert load != pytest.approx(0.35)
+
+    def test_near_saturated_exceeds_threshold(self):
+        """kv=1, running=mns, large waiting → load > 0.9 (overloaded regime)."""
+        load = load_normalized(1.0, 64, 1000, max_num_seqs=64)
+        assert load > 0.9
+        assert load <= 1.0
+
+    def test_max_num_seqs_zero_safe(self):
+        """max_num_seqs=0 → running_usage AND waiting_usage degrade to 1.0 (no div-by-zero)."""
+        # kv=0, running=5, waiting=0 → 0.4·0 + 0.3·1.0 + 0.3·1.0 = 0.6
+        load = load_normalized(0.0, 5, 0, max_num_seqs=0)
+        assert load == pytest.approx(0.6)  # 0.3·1.0 + 0.3·1.0
+
+
+# --------------------------------------------------------------------------- #
+# load_kv_over_pressure (legacy, = 1 - old s_load)
+# --------------------------------------------------------------------------- #
+class TestLoadKvOverPressure:
+    def test_idle_is_zero(self):
+        """kv=0,r=0,w=0 → old s_load=1.0 → load = 0.0 (consistent with normalized)."""
+        assert load_kv_over_pressure(0.0, 0, 0, max_num_seqs=64) == pytest.approx(0.0)
+
+    def test_inverts_old_formula(self):
+        """load = 1 - (1-kv)/(1+running+waiting). kv=0.5,r=1,w=0 → 1 - 0.25 = 0.75."""
+        assert load_kv_over_pressure(0.5, 1, 0, max_num_seqs=64) == pytest.approx(0.75)
+
+    def test_near_full(self):
+        """kv=0.9,r=5,w=0 → old s_load=0.1/6≈0.01667 → load≈0.98333."""
+        assert load_kv_over_pressure(0.9, 5, 0, max_num_seqs=64) == pytest.approx(1 - 0.1 / 6)
+
+    def test_ignores_max_num_seqs_and_weights(self):
+        """legacy formula does not use max_num_seqs/weights — same result regardless."""
+        a = load_kv_over_pressure(0.5, 1, 0, max_num_seqs=64)
+        b = load_kv_over_pressure(0.5, 1, 0, max_num_seqs=999)
+        c = load_kv_over_pressure(0.5, 1, 0, max_num_seqs=64, weights=(0.9, 0.05, 0.05))
+        assert a == pytest.approx(b) == pytest.approx(c)
+
+
+# --------------------------------------------------------------------------- #
+# Registry
+# --------------------------------------------------------------------------- #
+class TestLoadRegistry:
+    def test_default_weights_tuple(self):
+        """DEFAULT_LOAD_WEIGHTS == (0.4, 0.3, 0.3) and sums to 1."""
+        assert DEFAULT_LOAD_WEIGHTS == (0.4, 0.3, 0.3)
+        assert sum(DEFAULT_LOAD_WEIGHTS) == pytest.approx(1.0)
+
+    def test_default_max_num_seqs(self):
+        """DEFAULT_MAX_NUM_SEQS == 64 (matches infer_multi.sh / vLLM 24GB default)."""
+        assert DEFAULT_MAX_NUM_SEQS == 64
+
+    def test_registry_has_both_functions(self):
+        """LOAD_FNS exposes 'normalized' (default) and 'kv_over_pressure' (legacy)."""
+        assert LOAD_FNS["normalized"] is load_normalized
+        assert LOAD_FNS["kv_over_pressure"] is load_kv_over_pressure
+
+    def test_get_load_fn_returns_callable(self):
+        """get_load_fn(name) returns the registered function."""
+        assert get_load_fn("normalized") is load_normalized
+        assert get_load_fn("kv_over_pressure") is load_kv_over_pressure
+
+    def test_get_load_fn_unknown_raises(self):
+        """unknown name → KeyError."""
+        with pytest.raises(KeyError):
+            get_load_fn("does-not-exist")
+
+
+# --------------------------------------------------------------------------- #
+# resolve_max_num_seqs (env)
+# --------------------------------------------------------------------------- #
+class TestResolveMaxNumSeqs:
+    def test_default_when_env_unset(self, monkeypatch):
+        """MAX_NUM_SEQS unset → default 64."""
+        monkeypatch.delenv("MAX_NUM_SEQS", raising=False)
+        assert resolve_max_num_seqs() == 64
+
+    def test_env_override(self, monkeypatch):
+        """MAX_NUM_SEQS=128 → 128."""
+        monkeypatch.setenv("MAX_NUM_SEQS", "128")
+        assert resolve_max_num_seqs() == 128
+
+    def test_env_invalid_falls_back_to_default(self, monkeypatch):
+        """MAX_NUM_SEQS=garbage → fall back to default (no crash)."""
+        monkeypatch.setenv("MAX_NUM_SEQS", "not-a-number")
+        assert resolve_max_num_seqs() == 64

--- a/tests/uni_agent/llm_router/strategies/test_load_score.py
+++ b/tests/uni_agent/llm_router/strategies/test_load_score.py
@@ -25,9 +25,9 @@ from uni_agent.llm_router.strategies.load_score import (
     resolve_max_num_seqs,
 )
 
-
-
 pytestmark = [pytest.mark.ut, pytest.mark.cpu]
+
+
 # --------------------------------------------------------------------------- #
 # load_normalized
 # --------------------------------------------------------------------------- #

--- a/tests/uni_agent/llm_router/strategies/test_route.py
+++ b/tests/uni_agent/llm_router/strategies/test_route.py
@@ -1,0 +1,243 @@
+"""Tests for llm_router strategy seams (runtime strategy classes + registry).
+
+These are the minimal collaborator seams the Balancer constructs against
+(see detailed_balancer.md §2.3). Construction, registry dispatch, and routing
+are tested here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from uni_agent.llm_router import KVCAwareStrategyConfig
+from uni_agent.llm_router.strategies import (
+    KVCacheAwareStrategy,
+    ReplicaInfo,
+    StrategyRegistry,
+    route,
+)
+
+pytestmark = [pytest.mark.ut, pytest.mark.cpu]
+
+
+# ============================================================
+# StrategyRegistry
+# ============================================================
+
+
+
+class TestKVCacheAwareStrategy:
+    """R02-Rnn: KVCacheAwareStrategy construction seam."""
+
+    def test_r02_from_config_returns_instance_carrying_config(self):
+        """
+        Feature: from_config constructs a strategy instance from its config
+        Description: KVCacheAwareStrategy.from_config(KVCAwareStrategyConfig(weight=0.7))
+        Expectation: returns a KVCacheAwareStrategy carrying the config's strategy fields
+        """
+        cfg = KVCAwareStrategyConfig(
+            weight=0.7, alpha=0.7, load_threshold=0.1, collector_names=["vllm_zmq"]
+        )
+        strategy = KVCacheAwareStrategy.from_config(cfg)
+        assert isinstance(strategy, KVCacheAwareStrategy)
+        assert strategy.alpha == 0.7
+        assert strategy.load_threshold == 0.1
+
+
+# ============================================================
+# ReplicaInfo
+# ============================================================
+
+
+
+class TestReplicaInfo:
+    """R03: ReplicaInfo value type."""
+
+    def test_r03_carries_only_replica_id(self):
+        """
+        Feature: ReplicaInfo carries a replica_id and no actor handle
+        Description: construct ReplicaInfo(replica_id="s0")
+        Expectation: ri.replica_id == "s0" and has no handle attribute
+        """
+        ri = ReplicaInfo(replica_id="s0")
+        assert ri.replica_id == "s0"
+        assert not hasattr(ri, "handle")
+
+
+# ============================================================
+# route() — real ranking
+# ============================================================
+
+
+
+# ---- Strategy registry + route (comprehensive, from test_strategy.py) ----
+
+class TestStrategyRegistry:
+    def test_builtin_registered(self):
+        """
+        Feature: built-in KVCacheAwareStrategy is pre-registered for KVCAwareStrategyConfig
+        Description: look up KVCAwareStrategyConfig in the registry
+        Expectation: returns KVCacheAwareStrategy class
+        """
+        from uni_agent.llm_router.config.strategy import KVCAwareStrategyConfig
+        assert StrategyRegistry.get(KVCAwareStrategyConfig) is KVCacheAwareStrategy
+
+    def test_register_and_get(self):
+        """
+        Feature: custom strategy can be registered and retrieved by config type
+        Description: register a dummy config class, then call get() with it
+        Expectation: get() returns the registered strategy class
+        """
+        class _DummyConfig:
+            pass
+
+        class _DummyStrategy:
+            def score(self, prompt_ids, provider, replicas, request_id=None, sticky_table=None):
+                return [0.0] * len(replicas)
+
+        StrategyRegistry.register(_DummyConfig, _DummyStrategy)
+        try:
+            assert StrategyRegistry.get(_DummyConfig) is _DummyStrategy
+        finally:
+            StrategyRegistry._registry.pop(_DummyConfig, None)
+
+    def test_get_unknown_raises(self):
+        """
+        Feature: looking up an unregistered config type raises KeyError
+        Description: call get() with a class that was never registered
+        Expectation: raises KeyError
+        """
+        class _UnknownConfig:
+            pass
+
+        with pytest.raises(KeyError):
+            StrategyRegistry.get(_UnknownConfig)
+
+
+# --------------------------------------------------------------------------- #
+# Test doubles for route() composition tests
+# --------------------------------------------------------------------------- #
+
+class FakeRouteDataProvider:
+    def __init__(self, data=None):
+        self._data = data or {}
+    def get_metrics(self, replica_id): return {}
+    def get_metric(self, replica_id, key): return 0.0
+    def get_gpu_prefix_hit_rate(self, prompt_ids): return {}
+    def get_tier_prefix_hit_rate(self, replica_id, prompt_ids, tier): return 0.0
+
+class ConstantStrategy:
+    def __init__(self, scores): self._scores = scores
+    def score(self, prompt_ids, provider, replicas, request_id=None, sticky_table=None):
+        return list(self._scores)
+
+class BadLengthStrategy:
+    def score(self, prompt_ids, provider, replicas, request_id=None, sticky_table=None):
+        return [1.0]
+
+class RaisingStrategy:
+    def score(self, prompt_ids, provider, replicas, request_id=None, sticky_table=None):
+        raise KeyError("boom")
+
+def _replicas(*ids):
+    return [ReplicaInfo(replica_id=rid) for rid in ids]
+
+PROMPT_IDS = [1, 2, 3]
+
+def _strat(**kwargs):
+    defaults = dict(
+        alpha=0.7, load_threshold=0.9,
+        layer_weights={"gpu": 0.7, "cpu": 0.2, "ssd": 0.1},
+        collector_names=["vllm_zmq"], weight=1.0,
+        load_fn="normalized", load_weights=(0.4, 0.3, 0.3), max_num_seqs=64,
+    )
+    defaults.update(kwargs)
+    return KVCacheAwareStrategy(**defaults)
+
+
+# --------------------------------------------------------------------------- #
+# route() — real ranking
+# --------------------------------------------------------------------------- #
+
+class TestRoute:
+    def test_single_strategy_descending(self):
+        """
+        Feature: route() returns replica ids sorted by score descending
+        """
+        provider = FakeRouteDataProvider({})
+        ranking = route(
+            [(ConstantStrategy([0.2, 0.5, 0.1]), 1.0)],
+            PROMPT_IDS, provider, _replicas("rep_a", "rep_b", "rep_c"),
+        )
+        assert ranking == ["rep_b", "rep_a", "rep_c"]
+
+    def test_multi_strategy_weighted_sum(self):
+        """
+        Feature: multiple strategies are combined by weighted sum
+        """
+        provider = FakeRouteDataProvider({})
+        strategies = [
+            (ConstantStrategy([1.0, 2.0, 3.0]), 0.5),
+            (ConstantStrategy([3.0, 1.0, 0.0]), 0.5),
+        ]
+        ranking = route(strategies, PROMPT_IDS, provider, _replicas("rep_a", "rep_b", "rep_c"))
+        assert ranking[0] == "rep_a"
+
+    def test_overloaded_present_in_ranking(self):
+        """
+        Feature: all replicas remain present in the ranking
+        """
+        strat = _strat()
+        provider = FakeRouteDataProvider(
+            {
+                "rep_a":     {"kv_cache_usage_perc": 0.3, "num_requests_running": 1, "num_requests_waiting": 0,
+                              "gpu_hit_pct": 80, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "rep_b":     {"kv_cache_usage_perc": 0.5, "num_requests_running": 1, "num_requests_waiting": 0,
+                              "gpu_hit_pct": 30, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "overloaded": {"kv_cache_usage_perc": 0.92, "num_requests_running": 0, "num_requests_waiting": 0,
+                               "gpu_hit_pct": 90, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+            }
+        )
+        ranking = route([(strat, 1.0)], PROMPT_IDS, provider, _replicas("rep_a", "rep_b", "overloaded"))
+        assert set(ranking) == {"rep_a", "rep_b", "overloaded"}
+
+    def test_empty_pool_raises(self):
+        """
+        Feature: route() raises RuntimeError when the replica list is empty
+        """
+        with pytest.raises(RuntimeError):
+            route([(ConstantStrategy([]), 1.0)], PROMPT_IDS, FakeRouteDataProvider({}), [])
+
+    def test_length_mismatch_falls_back_to_random(self):
+        """
+        Feature: route() falls back to random order when score() returns wrong-length list
+        """
+        ranking = route(
+            [(BadLengthStrategy(), 1.0)],
+            PROMPT_IDS, FakeRouteDataProvider({}), _replicas("rep_a", "rep_b"),
+        )
+        assert set(ranking) == {"rep_a", "rep_b"}
+
+    def test_strategy_exception_falls_back_to_random(self):
+        """
+        Feature: exceptions from score() cause route() to fall back to random order
+        """
+        ranking = route([(RaisingStrategy(), 1.0)], PROMPT_IDS, FakeRouteDataProvider({}), _replicas("rep_a", "rep_b"))
+        assert set(ranking) == {"rep_a", "rep_b"}
+
+    def test_nan_score_ranked_last(self):
+        """
+        Feature: non-finite (NaN) scores are ranked last
+        """
+        provider = FakeRouteDataProvider({})
+        ranking = route(
+            [(ConstantStrategy([float("nan"), 0.1, 0.5]), 1.0)],
+            PROMPT_IDS, provider, _replicas("nan_rep", "low_rep", "high_rep"),
+        )
+        assert ranking[0] == "high_rep"
+        assert ranking[-1] == "nan_rep"
+
+
+# --------------------------------------------------------------------------- #
+# from_config() classmethod
+# --------------------------------------------------------------------------- #

--- a/tests/uni_agent/llm_router/strategies/test_route.py
+++ b/tests/uni_agent/llm_router/strategies/test_route.py
@@ -25,7 +25,6 @@ pytestmark = [pytest.mark.ut, pytest.mark.cpu]
 # ============================================================
 
 
-
 class TestKVCacheAwareStrategy:
     """R02-Rnn: KVCacheAwareStrategy construction seam."""
 
@@ -35,9 +34,7 @@ class TestKVCacheAwareStrategy:
         Description: KVCacheAwareStrategy.from_config(KVCAwareStrategyConfig(weight=0.7))
         Expectation: returns a KVCacheAwareStrategy carrying the config's strategy fields
         """
-        cfg = KVCAwareStrategyConfig(
-            weight=0.7, alpha=0.7, load_threshold=0.1, collector_names=["vllm_zmq"]
-        )
+        cfg = KVCAwareStrategyConfig(weight=0.7, alpha=0.7, load_threshold=0.1, collector_names=["vllm_zmq"])
         strategy = KVCacheAwareStrategy.from_config(cfg)
         assert isinstance(strategy, KVCacheAwareStrategy)
         assert strategy.alpha == 0.7
@@ -47,7 +44,6 @@ class TestKVCacheAwareStrategy:
 # ============================================================
 # ReplicaInfo
 # ============================================================
-
 
 
 class TestReplicaInfo:
@@ -69,8 +65,8 @@ class TestReplicaInfo:
 # ============================================================
 
 
-
 # ---- Strategy registry + route (comprehensive, from test_strategy.py) ----
+
 
 class TestStrategyRegistry:
     def test_builtin_registered(self):
@@ -80,6 +76,7 @@ class TestStrategyRegistry:
         Expectation: returns KVCacheAwareStrategy class
         """
         from uni_agent.llm_router.config.strategy import KVCAwareStrategyConfig
+
         assert StrategyRegistry.get(KVCAwareStrategyConfig) is KVCacheAwareStrategy
 
     def test_register_and_get(self):
@@ -88,6 +85,7 @@ class TestStrategyRegistry:
         Description: register a dummy config class, then call get() with it
         Expectation: get() returns the registered strategy class
         """
+
         class _DummyConfig:
             pass
 
@@ -107,6 +105,7 @@ class TestStrategyRegistry:
         Description: call get() with a class that was never registered
         Expectation: raises KeyError
         """
+
         class _UnknownConfig:
             pass
 
@@ -118,38 +117,59 @@ class TestStrategyRegistry:
 # Test doubles for route() composition tests
 # --------------------------------------------------------------------------- #
 
+
 class FakeRouteDataProvider:
     def __init__(self, data=None):
         self._data = data or {}
-    def get_metrics(self, replica_id): return {}
-    def get_metric(self, replica_id, key): return 0.0
-    def get_gpu_prefix_hit_rate(self, prompt_ids): return {}
-    def get_tier_prefix_hit_rate(self, replica_id, prompt_ids, tier): return 0.0
+
+    def get_metrics(self, replica_id):
+        return {}
+
+    def get_metric(self, replica_id, key):
+        return 0.0
+
+    def get_gpu_prefix_hit_rate(self, prompt_ids):
+        return {}
+
+    def get_tier_prefix_hit_rate(self, replica_id, prompt_ids, tier):
+        return 0.0
+
 
 class ConstantStrategy:
-    def __init__(self, scores): self._scores = scores
+    def __init__(self, scores):
+        self._scores = scores
+
     def score(self, prompt_ids, provider, replicas, request_id=None, sticky_table=None):
         return list(self._scores)
+
 
 class BadLengthStrategy:
     def score(self, prompt_ids, provider, replicas, request_id=None, sticky_table=None):
         return [1.0]
 
+
 class RaisingStrategy:
     def score(self, prompt_ids, provider, replicas, request_id=None, sticky_table=None):
         raise KeyError("boom")
 
+
 def _replicas(*ids):
     return [ReplicaInfo(replica_id=rid) for rid in ids]
 
+
 PROMPT_IDS = [1, 2, 3]
+
 
 def _strat(**kwargs):
     defaults = dict(
-        alpha=0.7, load_threshold=0.9,
+        alpha=0.7,
+        load_threshold=0.9,
         layer_weights={"gpu": 0.7, "cpu": 0.2, "ssd": 0.1},
-        collector_names=["vllm_zmq"], weight=1.0,
-        load_fn="normalized", load_weights=(0.4, 0.3, 0.3), max_num_seqs=64,
+        collector_names=["vllm_zmq"],
+        weight=1.0,
+        load_fn="normalized",
+        load_weights=(0.4, 0.3, 0.3),
+        max_num_seqs=64,
     )
     defaults.update(kwargs)
     return KVCacheAwareStrategy(**defaults)
@@ -159,6 +179,7 @@ def _strat(**kwargs):
 # route() — real ranking
 # --------------------------------------------------------------------------- #
 
+
 class TestRoute:
     def test_single_strategy_descending(self):
         """
@@ -167,7 +188,9 @@ class TestRoute:
         provider = FakeRouteDataProvider({})
         ranking = route(
             [(ConstantStrategy([0.2, 0.5, 0.1]), 1.0)],
-            PROMPT_IDS, provider, _replicas("rep_a", "rep_b", "rep_c"),
+            PROMPT_IDS,
+            provider,
+            _replicas("rep_a", "rep_b", "rep_c"),
         )
         assert ranking == ["rep_b", "rep_a", "rep_c"]
 
@@ -190,12 +213,27 @@ class TestRoute:
         strat = _strat()
         provider = FakeRouteDataProvider(
             {
-                "rep_a":     {"kv_cache_usage_perc": 0.3, "num_requests_running": 1, "num_requests_waiting": 0,
-                              "gpu_hit_pct": 80, "tiers": {"cpu": 0.0, "ssd": 0.0}},
-                "rep_b":     {"kv_cache_usage_perc": 0.5, "num_requests_running": 1, "num_requests_waiting": 0,
-                              "gpu_hit_pct": 30, "tiers": {"cpu": 0.0, "ssd": 0.0}},
-                "overloaded": {"kv_cache_usage_perc": 0.92, "num_requests_running": 0, "num_requests_waiting": 0,
-                               "gpu_hit_pct": 90, "tiers": {"cpu": 0.0, "ssd": 0.0}},
+                "rep_a": {
+                    "kv_cache_usage_perc": 0.3,
+                    "num_requests_running": 1,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 80,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
+                "rep_b": {
+                    "kv_cache_usage_perc": 0.5,
+                    "num_requests_running": 1,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 30,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
+                "overloaded": {
+                    "kv_cache_usage_perc": 0.92,
+                    "num_requests_running": 0,
+                    "num_requests_waiting": 0,
+                    "gpu_hit_pct": 90,
+                    "tiers": {"cpu": 0.0, "ssd": 0.0},
+                },
             }
         )
         ranking = route([(strat, 1.0)], PROMPT_IDS, provider, _replicas("rep_a", "rep_b", "overloaded"))
@@ -214,7 +252,9 @@ class TestRoute:
         """
         ranking = route(
             [(BadLengthStrategy(), 1.0)],
-            PROMPT_IDS, FakeRouteDataProvider({}), _replicas("rep_a", "rep_b"),
+            PROMPT_IDS,
+            FakeRouteDataProvider({}),
+            _replicas("rep_a", "rep_b"),
         )
         assert set(ranking) == {"rep_a", "rep_b"}
 
@@ -232,7 +272,9 @@ class TestRoute:
         provider = FakeRouteDataProvider({})
         ranking = route(
             [(ConstantStrategy([float("nan"), 0.1, 0.5]), 1.0)],
-            PROMPT_IDS, provider, _replicas("nan_rep", "low_rep", "high_rep"),
+            PROMPT_IDS,
+            provider,
+            _replicas("nan_rep", "low_rep", "high_rep"),
         )
         assert ranking[0] == "high_rep"
         assert ranking[-1] == "nan_rep"

--- a/tests/uni_agent/llm_router/strategies/test_sticky_session.py
+++ b/tests/uni_agent/llm_router/strategies/test_sticky_session.py
@@ -1,0 +1,153 @@
+"""Tests for StickySessionTable — request_id → replica_id LRU mapping.
+
+Covers the sticky-session affinity table the Balancer owns and threads into
+``route()`` → ``strategy.score()``. Mirrors verl ``GlobalRequestLoadBalancer``
+sticky semantics: access refreshes recency, LRU evicts cold entries, replica
+removal bulk-clears stale bindings.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from uni_agent.llm_router.strategies.sticky_session import (
+    DEFAULT_STICKY_MAX_SIZE,
+    StickySessionTable,
+)
+
+
+
+pytestmark = [pytest.mark.ut, pytest.mark.cpu]
+class TestStickySessionTable:
+    """S01-Snn: StickySessionTable construction + access semantics."""
+
+    def test_s01_get_missing_returns_none(self):
+        """Feature: cold-start get returns None (no binding yet).
+        Description: get() on an empty table for any request_id
+        Expectation: returns None
+        """
+        t = StickySessionTable()
+        assert t.get("r1") is None
+
+    def test_s02_put_then_get_returns_replica(self):
+        """Feature: put then get returns the bound replica_id.
+        Description: put("r1","s0"); get("r1")
+        Expectation: returns "s0"
+        """
+        t = StickySessionTable()
+        t.put("r1", "s0")
+        assert t.get("r1") == "s0"
+        assert len(t) == 1
+
+    def test_s03_put_refresh_updates_bound_replica(self):
+        """Feature: re-put for same request_id updates the bound replica.
+        Description: put("r1","s0"); put("r1","s1"); get("r1")
+        Expectation: returns "s1" (overload-fallback routed elsewhere)
+        """
+        t = StickySessionTable()
+        t.put("r1", "s0")
+        t.put("r1", "s1")
+        assert t.get("r1") == "s1"
+        assert len(t) == 1
+
+    def test_s04_get_refreshes_lru_recency(self):
+        """Feature: get() on a hot key prevents its LRU eviction.
+        Description: fill to max_size=2; touch r1; add r3; r1 still present, r2 evicted
+        Expectation: r1 bound, r2 None (r2 was coldest)
+        """
+        t = StickySessionTable(max_size=2)
+        t.put("r1", "s0")
+        t.put("r2", "s1")
+        # touch r1 so r2 becomes the coldest
+        assert t.get("r1") == "s0"
+        t.put("r3", "s2")  # evicts coldest (r2)
+        assert t.get("r1") == "s0"  # still bound
+        assert t.get("r2") is None  # evicted
+        assert t.get("r3") == "s2"
+
+    def test_s05_lru_evicts_coldest_when_full(self):
+        """Feature: inserting past max_size evicts the least-recently-used.
+        Description: max_size=2; put r1,r2,r3 in order
+        Expectation: r1 evicted (coldest), r2/r3 bound
+        """
+        t = StickySessionTable(max_size=2)
+        t.put("r1", "s0")
+        t.put("r2", "s1")
+        t.put("r3", "s2")  # evicts r1
+        assert t.get("r1") is None
+        assert t.get("r2") == "s1"
+        assert t.get("r3") == "s2"
+
+    def test_s06_invalidate_drops_single_binding(self):
+        """Feature: invalidate(request_id) drops one binding.
+        Description: put r1,s0; invalidate r1; get r1
+        Expectation: get returns None, len 0
+        """
+        t = StickySessionTable()
+        t.put("r1", "s0")
+        t.invalidate("r1")
+        assert t.get("r1") is None
+        assert len(t) == 0
+
+    def test_s07_invalidate_missing_is_noop(self):
+        """Feature: invalidate on a missing key is a no-op.
+        Description: invalidate("rX") on empty table
+        Expectation: no error, len 0
+        """
+        t = StickySessionTable()
+        t.invalidate("rX")  # must not raise
+        assert len(t) == 0
+
+    def test_s08_invalidate_replica_clears_all_bound(self):
+        """Feature: invalidate_replica clears every binding to that replica.
+        Description: r1→s0, r2→s1, r3→s0; invalidate_replica("s0")
+        Expectation: r1/r3 gone, r2 still bound
+        """
+        t = StickySessionTable()
+        t.put("r1", "s0")
+        t.put("r2", "s1")
+        t.put("r3", "s0")
+        t.invalidate_replica("s0")
+        assert t.get("r1") is None
+        assert t.get("r3") is None
+        assert t.get("r2") == "s1"
+
+    def test_s09_invalidate_replica_missing_is_noop(self):
+        """Feature: invalidate_replica on a replica with no bindings is a no-op.
+        Description: no bindings point to sX; invalidate_replica("sX")
+        Expectation: no error, table unchanged
+        """
+        t = StickySessionTable()
+        t.put("r1", "s0")
+        t.invalidate_replica("sX")
+        assert t.get("r1") == "s0"
+        assert len(t) == 1
+
+    def test_s10_status_reports_max_size_and_current_size(self):
+        """Feature: status() returns max_size and current size.
+        Description: max_size=5; put 2 entries; status()
+        Expectation: {"max_size": 5, "size": 2}
+        """
+        t = StickySessionTable(max_size=5)
+        t.put("r1", "s0")
+        t.put("r2", "s1")
+        s = t.status()
+        assert s == {"max_size": 5, "size": 2}
+
+    def test_s11_default_max_size_matches_verl(self):
+        """Feature: default max_size is 10000 (verl DEFAULT_ROUTING_CACHE_SIZE).
+        Description: StickySessionTable() with no args
+        Expectation: max_size == 10000
+        """
+        t = StickySessionTable()
+        assert t.max_size == DEFAULT_STICKY_MAX_SIZE == 10000
+
+    def test_s12_invalid_max_size_raises(self):
+        """Feature: max_size <= 0 raises ValueError.
+        Description: StickySessionTable(max_size=0) and (-1)
+        Expectation: both raise ValueError
+        """
+        with pytest.raises(ValueError):
+            StickySessionTable(max_size=0)
+        with pytest.raises(ValueError):
+            StickySessionTable(max_size=-1)

--- a/tests/uni_agent/llm_router/strategies/test_sticky_session.py
+++ b/tests/uni_agent/llm_router/strategies/test_sticky_session.py
@@ -15,9 +15,9 @@ from uni_agent.llm_router.strategies.sticky_session import (
     StickySessionTable,
 )
 
-
-
 pytestmark = [pytest.mark.ut, pytest.mark.cpu]
+
+
 class TestStickySessionTable:
     """S01-Snn: StickySessionTable construction + access semantics."""
 

--- a/tests/uni_agent/llm_router/test_config.py
+++ b/tests/uni_agent/llm_router/test_config.py
@@ -1,0 +1,1306 @@
+"""Tests for llm_router config dataclasses and parsing.
+
+Per §5 of detailed_config.md, each module has 5 test categories:
+① Input/output normal cases
+② Input/output abnormal cases
+③ Hydra parsing normal cases
+④ Hydra parsing abnormal cases
+⑤ Other cases
+"""
+
+from __future__ import annotations
+
+import pytest
+from hydra.errors import InstantiationException
+from omegaconf import OmegaConf
+
+
+# -- Public API via package __init__ --
+from uni_agent.llm_router import (
+    CacheStoreConfig,
+    CollectorConfig,
+    ConfigError,
+    KVCAwareConfig,
+    KVCAwareStrategyConfig,
+    StrategyConfig,
+)
+
+# Default collector_names for strategy construction (required field)
+_CN = ["vllm_zmq"]
+
+
+# ============================================================
+# 5.1 StrategyConfig / KVCAwareStrategyConfig
+# ============================================================
+
+# -- ① Input/output normal cases --
+
+
+
+pytestmark = [pytest.mark.ut, pytest.mark.cpu]
+class TestStrategyNormalInput:
+    """S01-S12: normal input/output cases"""
+
+    def test_s01_weight_1_0(self):
+        """
+        Feature: weight field parses normally
+        Description: construct KVCAwareStrategyConfig with weight=1.0
+        Expectation: cfg.weight == 1.0
+        """
+        cfg = KVCAwareStrategyConfig(weight=1.0, collector_names=_CN)
+        assert cfg.weight == 1.0
+
+    def test_s02_weight_0_7(self):
+        """
+        Feature: weight field accepts decimal values
+        Description: construct KVCAwareStrategyConfig with weight=0.7
+        Expectation: cfg.weight == 0.7
+        """
+        cfg = KVCAwareStrategyConfig(weight=0.7, collector_names=_CN)
+        assert cfg.weight == 0.7
+
+    def test_s03_alpha_0_7(self):
+        """
+        Feature: alpha field parses normally
+        Description: construct KVCAwareStrategyConfig with alpha=0.7
+        Expectation: cfg.alpha == 0.7
+        """
+        cfg = KVCAwareStrategyConfig(weight=1.0, alpha=0.7, collector_names=_CN)
+        assert cfg.alpha == 0.7
+
+    def test_s04_alpha_0_pure_load(self):
+        """
+        Feature: alpha=0.0 yields pure-load scoring
+        Description: construct KVCAwareStrategyConfig with alpha=0.0
+        Expectation: cfg.alpha == 0.0
+        """
+        cfg = KVCAwareStrategyConfig(weight=1.0, alpha=0.0, collector_names=_CN)
+        assert cfg.alpha == 0.0
+
+    def test_s05_alpha_1_pure_cache(self):
+        """
+        Feature: alpha=1.0 yields pure-cache scoring
+        Description: construct KVCAwareStrategyConfig with alpha=1.0
+        Expectation: cfg.alpha == 1.0
+        """
+        cfg = KVCAwareStrategyConfig(weight=1.0, alpha=1.0, collector_names=_CN)
+        assert cfg.alpha == 1.0
+
+    def test_s06_alpha_default_0_7(self):
+        """
+        Feature: alpha uses default when omitted
+        Description: construct KVCAwareStrategyConfig without alpha
+        Expectation: cfg.alpha == 0.7
+        """
+        cfg = KVCAwareStrategyConfig(weight=1.0, collector_names=_CN)
+        assert cfg.alpha == 0.7
+
+    def test_s07_load_threshold_0_5(self):
+        """
+        Feature: load_threshold field parses normally
+        Description: construct KVCAwareStrategyConfig with load_threshold=0.5
+        Expectation: cfg.load_threshold == 0.5
+        """
+        cfg = KVCAwareStrategyConfig(weight=1.0, load_threshold=0.5, collector_names=_CN)
+        assert cfg.load_threshold == 0.5
+
+    def test_s08_load_threshold_default_0_9(self):
+        """
+        Feature: load_threshold uses default when omitted
+        Description: construct KVCAwareStrategyConfig without load_threshold
+        Expectation: cfg.load_threshold == 0.9 (load ceiling; overload when load > threshold)
+        """
+        cfg = KVCAwareStrategyConfig(weight=1.0, collector_names=_CN)
+        assert cfg.load_threshold == 0.9
+
+    def test_s09_layer_weights_dict(self):
+        """
+        Feature: layer_weights custom dict parses normally (three tiers: gpu/cpu/ssd)
+        Description: construct strategy config with layer_weights={"gpu":0.7,"cpu":0.2,"ssd":0.1}
+        Expectation: cfg.layer_weights == {"gpu": 0.7, "cpu": 0.2, "ssd": 0.1}
+        """
+        cfg = KVCAwareStrategyConfig(
+            weight=1.0, layer_weights={"gpu": 0.7, "cpu": 0.2, "ssd": 0.1}, collector_names=_CN
+        )
+        assert cfg.layer_weights == {"gpu": 0.7, "cpu": 0.2, "ssd": 0.1}
+
+    def test_s10_layer_weights_default(self):
+        """
+        Feature: layer_weights uses default when omitted
+        Description: construct KVCAwareStrategyConfig without layer_weights
+        Expectation: cfg.layer_weights == {"gpu": 0.7, "cpu": 0.2, "ssd": 0.1}
+        """
+        cfg = KVCAwareStrategyConfig(weight=1.0, collector_names=_CN)
+        assert cfg.layer_weights == {"gpu": 0.7, "cpu": 0.2, "ssd": 0.1}
+
+    def test_s11_collector_names_bind(self):
+        """
+        Feature: collector_names binds multiple collectors
+        Description: construct strategy config with collector_names=["vllm_zmq","mooncake_prometheus"]
+        Expectation: cfg.collector_names has length 2 and matches
+        """
+        cfg = KVCAwareStrategyConfig(weight=1.0, collector_names=["vllm_zmq", "mooncake_prometheus"])
+        assert cfg.collector_names == ["vllm_zmq", "mooncake_prometheus"]
+        assert len(cfg.collector_names) == 2
+
+    def test_s12_multi_strategy_weights_sum_to_1(self):
+        """
+        Feature: sum of multi-strategy weights is ~1.0
+        Description: construct two strategies with weights 0.6 and 0.4
+        Expectation: sum of weights == pytest.approx(1.0)
+        """
+        s1 = KVCAwareStrategyConfig(weight=0.6, collector_names=["vllm_zmq"])
+        s2 = KVCAwareStrategyConfig(weight=0.4, collector_names=["mooncake_prometheus"])
+        assert s1.weight + s2.weight == pytest.approx(1.0)
+
+    def test_s12b_collector_names_missing_required(self):
+        """
+        Feature: construction fails when collector_names is missing
+        Description: construct strategy config without the required collector_names
+        Expectation: raises TypeError
+        """
+        with pytest.raises(TypeError):
+            KVCAwareStrategyConfig(weight=1.0)
+
+
+# -- ② Input/output abnormal cases --
+
+
+class TestStrategyAbnormalInput:
+    """S13-S23: abnormal input/output cases"""
+
+    def test_s13_weight_zero(self):
+        """
+        Feature: weight=0 triggers validation error
+        Description: construct strategy config with weight=0.0
+        Expectation: raises ConfigError matching "weight"
+        """
+        with pytest.raises(ConfigError, match="weight"):
+            KVCAwareStrategyConfig(weight=0.0, collector_names=_CN)
+
+    def test_s14_weight_above_1(self):
+        """
+        Feature: weight above upper bound triggers validation error
+        Description: construct strategy config with weight=1.5
+        Expectation: raises ConfigError matching "weight"
+        """
+        with pytest.raises(ConfigError, match="weight"):
+            KVCAwareStrategyConfig(weight=1.5, collector_names=_CN)
+
+    def test_s15_weight_negative(self):
+        """
+        Feature: negative weight triggers validation error
+        Description: construct strategy config with weight=-1.0
+        Expectation: raises ConfigError matching "weight"
+        """
+        with pytest.raises(ConfigError, match="weight"):
+            KVCAwareStrategyConfig(weight=-1.0, collector_names=_CN)
+
+    def test_s16_weight_string_type_error(self):
+        """
+        Feature: construction fails on wrong weight type
+        Description: construct strategy config with weight="0.7"
+        Expectation: raises TypeError
+        """
+        with pytest.raises(TypeError):
+            KVCAwareStrategyConfig(weight="0.7", collector_names=_CN)
+
+    def test_s17_weight_missing_required(self):
+        """
+        Feature: construction fails when weight is missing
+        Description: construct strategy config without the required weight
+        Expectation: raises TypeError
+        """
+        with pytest.raises(TypeError):
+            KVCAwareStrategyConfig(collector_names=_CN)
+
+    def test_s18_load_threshold_zero(self):
+        """
+        Feature: load_threshold=0 triggers validation error
+        Description: construct strategy config with load_threshold=0
+        Expectation: raises ConfigError matching "load_threshold"
+        """
+        with pytest.raises(ConfigError, match="load_threshold"):
+            KVCAwareStrategyConfig(weight=1.0, load_threshold=0, collector_names=_CN)
+
+    def test_s19_load_threshold_negative(self):
+        """
+        Feature: negative load_threshold triggers validation error
+        Description: construct strategy config with load_threshold=-1
+        Expectation: raises ConfigError matching "load_threshold"
+        """
+        with pytest.raises(ConfigError, match="load_threshold"):
+            KVCAwareStrategyConfig(weight=1.0, load_threshold=-1, collector_names=_CN)
+
+    def test_s19b_load_threshold_one_or_above(self):
+        """
+        Feature: load_threshold >= 1 triggers validation error
+        Description: construct strategy config with load_threshold=1.0 and load_threshold=80
+        Expectation: raises ConfigError matching "load_threshold"
+        """
+        with pytest.raises(ConfigError, match="load_threshold"):
+            KVCAwareStrategyConfig(weight=1.0, load_threshold=1.0, collector_names=_CN)
+        with pytest.raises(ConfigError, match="load_threshold"):
+            KVCAwareStrategyConfig(weight=1.0, load_threshold=80, collector_names=_CN)
+
+    def test_s20_layer_weights_non_gpu_cpu_ssd_key(self):
+        """
+        Feature: layer_weights with illegal key triggers validation error
+        Description: construct strategy config with a "disk" key in layer_weights
+        Expectation: raises ConfigError matching "layer_weights"
+        """
+        with pytest.raises(ConfigError, match="layer_weights"):
+            KVCAwareStrategyConfig(
+                weight=1.0, layer_weights={"gpu": 0.7, "cpu": 0.2, "disk": 0.1}, collector_names=_CN
+            )
+
+    def test_s21_layer_weights_missing_key(self):
+        """
+        Feature: layer_weights missing a required tier triggers validation error
+        Description: construct strategy config with layer_weights missing "ssd"
+        Expectation: raises ConfigError matching "layer_weights"
+        """
+        with pytest.raises(ConfigError, match="layer_weights"):
+            KVCAwareStrategyConfig(
+                weight=1.0, layer_weights={"gpu": 0.7, "cpu": 0.3}, collector_names=_CN
+            )
+
+    def test_s21b_layer_weights_sum_below_one(self):
+        """
+        Feature: layer_weights values summing below 1.0 trigger validation error
+        Description: construct strategy config with weights summing to 0.8
+        Expectation: raises ConfigError matching "layer_weights"
+        """
+        with pytest.raises(ConfigError, match="layer_weights"):
+            KVCAwareStrategyConfig(
+                weight=1.0, layer_weights={"gpu": 0.5, "cpu": 0.2, "ssd": 0.1}, collector_names=_CN
+            )
+
+    def test_s21c_layer_weights_sum_above_one(self):
+        """
+        Feature: layer_weights values summing above 1.0 trigger validation error
+        Description: construct strategy config with weights summing to 1.1
+        Expectation: raises ConfigError matching "layer_weights"
+        """
+        with pytest.raises(ConfigError, match="layer_weights"):
+            KVCAwareStrategyConfig(
+                weight=1.0, layer_weights={"gpu": 0.7, "cpu": 0.2, "ssd": 0.2}, collector_names=_CN
+            )
+
+    def test_s22_collector_names_not_list_type(self):
+        """
+        Feature: non-list collector_names triggers validation error
+        Description: construct strategy config with collector_names="vllm_zmq"
+        Expectation: raises ConfigError matching "collector_names must be a list"
+        """
+        with pytest.raises(ConfigError, match="collector_names must be a list"):
+            KVCAwareStrategyConfig(weight=1.0, collector_names="vllm_zmq")
+
+    def test_s23_multi_strategy_weights_not_sum_to_1(self):
+        """
+        Feature: multi-strategy weights not summing to 1.0 triggers validation error
+        Description: from_config with two strategies each weighted 0.4
+        Expectation: raises ConfigError matching "weight"
+        """
+        kwargs = OmegaConf.create({
+            "strategies": [
+                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                 "weight": 0.4, "collector_names": ["vllm_zmq"]},
+                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                 "weight": 0.4, "collector_names": ["mooncake_prometheus"]},
+            ],
+        })
+        with pytest.raises(ConfigError, match="weight"):
+            KVCAwareConfig.from_config(kwargs)
+
+    def test_s23b_strategies_empty_list(self):
+        """
+        Feature: empty strategies list triggers validation error
+        Description: from_config with strategies=[]
+        Expectation: raises ConfigError matching "strategies"
+        """
+        kwargs = OmegaConf.create({"strategies": []})
+        with pytest.raises(ConfigError, match="strategies"):
+            KVCAwareConfig.from_config(kwargs)
+
+    def test_s23c_strategies_not_list(self):
+        """
+        Feature: illegal strategies type triggers validation error
+        Description: from_config with strategies="kvc_aware"
+        Expectation: raises ConfigError matching "strategies"
+        """
+        kwargs = OmegaConf.create({"strategies": "kvc_aware"})
+        with pytest.raises(ConfigError, match="strategies"):
+            KVCAwareConfig.from_config(kwargs)
+
+    def test_s23d_strategy_item_not_dict(self):
+        """
+        Feature: non-dict strategy item triggers validation error
+        Description: from_config with strategies=["kvc_aware"]
+        Expectation: raises ConfigError matching "strategies"
+        """
+        kwargs = OmegaConf.create({"strategies": ["kvc_aware"]})
+        with pytest.raises(ConfigError, match="strategies"):
+            KVCAwareConfig.from_config(kwargs)
+
+
+# -- ③ Hydra parsing normal cases --
+
+
+class TestStrategyHydraNormal:
+    """S24-S26: Hydra parsing normal cases"""
+
+    def test_s24_strategy_instantiate(self):
+        """
+        Feature: strategy instantiates via _target_
+        Description: instantiate a strategy OmegaConf entry with _target_
+        Expectation: result is a KVCAwareStrategyConfig instance
+        """
+        entry = OmegaConf.create({
+            "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+            "weight": 1.0,
+            "collector_names": ["vllm_zmq"],
+        })
+        from hydra.utils import instantiate
+        result = instantiate(entry)
+        assert isinstance(result, KVCAwareStrategyConfig)
+
+    def test_s25_strategy_inherit_base(self):
+        """
+        Feature: strategy instance inherits StrategyConfig base
+        Description: instantiate a strategy entry then assert base type
+        Expectation: result is a StrategyConfig instance and weight==1.0
+        """
+        entry = OmegaConf.create({
+            "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+            "weight": 1.0,
+            "collector_names": ["vllm_zmq"],
+        })
+        from hydra.utils import instantiate
+        result = instantiate(entry)
+        assert isinstance(result, StrategyConfig)
+        assert result.weight == 1.0
+
+    def test_s26_strategy_defaults_filled(self):
+        """
+        Feature: defaults are filled after strategy instantiation
+        Description: instantiate a strategy entry with only weight/collector_names
+        Expectation: alpha/load_threshold/layer_weights equal defaults
+        """
+        entry = OmegaConf.create({
+            "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+            "weight": 1.0,
+            "collector_names": ["vllm_zmq"],
+        })
+        from hydra.utils import instantiate
+        result = instantiate(entry)
+        assert result.alpha == 0.7
+        assert result.load_threshold == 0.9
+        assert result.layer_weights == {"gpu": 0.7, "cpu": 0.2, "ssd": 0.1}
+        assert result.collector_names == ["vllm_zmq"]
+
+
+# -- ④ Hydra parsing abnormal cases --
+
+
+class TestStrategyHydraAbnormal:
+    """S27-S30: Hydra parsing abnormal cases"""
+
+    def test_s27_target_module_not_exist(self):
+        """
+        Feature: instantiation fails when _target_ module does not exist
+        Description: instantiate an entry whose _target_ points to nonexistent.Module.Class
+        Expectation: raises InstantiationException/ImportError/ConfigError
+        """
+        entry = OmegaConf.create({"_target_": "nonexistent.Module.Class"})
+        from hydra.utils import instantiate
+        with pytest.raises((InstantiationException, ImportError, ConfigError)):
+            instantiate(entry)
+
+    def test_s28_target_class_not_exist(self):
+        """
+        Feature: instantiation fails when _target_ class does not exist
+        Description: instantiate an entry whose _target_ points to config.NonExistClass
+        Expectation: raises InstantiationException/AttributeError/ConfigError
+        """
+        entry = OmegaConf.create({
+            "_target_": "uni_agent.llm_router.config.NonExistClass",
+        })
+        from hydra.utils import instantiate
+        with pytest.raises((InstantiationException, AttributeError, ConfigError)):
+            instantiate(entry)
+
+    def test_s29_target_missing(self):
+        """
+        Feature: strategy item missing _target_ triggers validation error
+        Description: from_config with a strategy item that has no _target_
+        Expectation: raises ConfigError matching "_target_"
+        """
+        kwargs = OmegaConf.create({"strategies": [{"weight": 1.0}]})
+        with pytest.raises(ConfigError, match="_target_"):
+            KVCAwareConfig.from_config(kwargs)
+
+    def test_s30_target_not_strategy_subclass(self):
+        """
+        Feature: _target_ pointing to a non-strategy subclass triggers validation error
+        Description: from_config with a strategy item whose _target_ is CacheStoreConfig
+        Expectation: raises ConfigError matching "StrategyConfig"
+        """
+        kwargs = OmegaConf.create({
+            "strategies": [
+                {"_target_": "uni_agent.llm_router.config.CacheStoreConfig",
+                 "kv_cache_store_type": "list", "ttl": 30},
+            ],
+        })
+        with pytest.raises(ConfigError, match="StrategyConfig"):
+            KVCAwareConfig.from_config(kwargs)
+
+
+# -- ⑤ Other cases --
+
+
+class TestStrategyOther:
+    """S31-S32: other cases"""
+
+    def test_s31_empty_config_no_strategy(self):
+        """
+        Feature: empty config triggers strategies-required error
+        Description: from_config with an empty OmegaConf dict
+        Expectation: raises ConfigError matching "strategies"
+        """
+        kwargs = OmegaConf.create({})
+        with pytest.raises(ConfigError, match="strategies"):
+            KVCAwareConfig.from_config(kwargs)
+
+    def test_s32_strategies_null_error(self):
+        """
+        Feature: null strategies triggers required error
+        Description: from_config with strategies=None
+        Expectation: raises ConfigError matching "strategies"
+        """
+        kwargs = OmegaConf.create({"strategies": None})
+        with pytest.raises(ConfigError, match="strategies"):
+            KVCAwareConfig.from_config(kwargs)
+
+
+# ============================================================
+# 5.2 CollectorConfig
+# ============================================================
+
+# -- ① Input/output normal cases --
+
+
+class TestMetricsNormalInput:
+    """M01-M09: normal input/output cases"""
+
+    # -- CollectorConfig: http_polling dict --
+
+    def test_m01_http_polling_default(self):
+        """
+        Feature: CollectorConfig default http_polling values
+        Description: construct CollectorConfig with no args
+        Expectation: http_polling == {"polling_interval": 5.0, "http_timeout": 10.0}
+        """
+        cfg = CollectorConfig()
+        assert cfg.http_polling == {"polling_interval": 5.0, "http_timeout": 10.0}
+
+    def test_m02_http_polling_custom(self):
+        """
+        Feature: http_polling accepts custom values
+        Description: construct CollectorConfig with custom http_polling
+        Expectation: http_polling equals custom values
+        """
+        cfg = CollectorConfig(http_polling={"polling_interval": 3.0, "http_timeout": 15.0})
+        assert cfg.http_polling == {"polling_interval": 3.0, "http_timeout": 15.0}
+
+    # -- CollectorConfig: long_connection dict --
+
+    def test_m03_long_connection_default(self):
+        """
+        Feature: CollectorConfig default long_connection values
+        Description: construct CollectorConfig with no args
+        Expectation: long_connection equals the four default params
+        """
+        cfg = CollectorConfig()
+        assert cfg.long_connection == {
+            "base_retry_delay": 1.0,
+            "max_retry_delay": 30.0,
+            "max_retry_attempts": 5,
+            "retry_backoff_factor": 2.0,
+        }
+
+    def test_m04_long_connection_custom(self):
+        """
+        Feature: long_connection accepts custom values
+        Description: construct CollectorConfig with custom long_connection
+        Expectation: base_retry_delay/max_retry_delay equal custom values
+        """
+        cfg = CollectorConfig(long_connection={
+            "base_retry_delay": 2.0, "max_retry_delay": 60.0,
+            "max_retry_attempts": 10, "retry_backoff_factor": 3.0,
+        })
+        assert cfg.long_connection["base_retry_delay"] == 2.0
+        assert cfg.long_connection["max_retry_delay"] == 60.0
+
+    # -- CollectorConfig base class is empty (placeholder) --
+
+    def test_m08_collector_config_fields(self):
+        """
+        Feature: CollectorConfig exposes connection-type fields
+        Description: inspect the dataclass field set of CollectorConfig
+        Expectation: field set is {http_polling, long_connection}
+        """
+        import dataclasses
+        field_names = {f.name for f in dataclasses.fields(CollectorConfig)}
+        assert field_names == {"http_polling", "long_connection"}
+
+    def test_m09_collector_config_is_dataclass(self):
+        """
+        Feature: CollectorConfig is a dataclass
+        Description: check the dataclass type of CollectorConfig
+        Expectation: is_dataclass returns True
+        """
+        import dataclasses
+        assert dataclasses.is_dataclass(CollectorConfig)
+
+
+# -- ② Input/output abnormal cases --
+
+
+class TestMetricsAbnormalInput:
+    """M10-M17: abnormal input/output cases"""
+
+    def test_m10_polling_interval_zero(self):
+        """
+        Feature: polling_interval=0 triggers validation error
+        Description: construct CollectorConfig with polling_interval=0
+        Expectation: raises ConfigError matching "polling_interval"
+        """
+        with pytest.raises(ConfigError, match="polling_interval"):
+            CollectorConfig(http_polling={"polling_interval": 0, "http_timeout": 10})
+
+    def test_m11_polling_interval_negative(self):
+        """
+        Feature: negative polling_interval triggers validation error
+        Description: construct CollectorConfig with polling_interval=-1
+        Expectation: raises ConfigError matching "polling_interval"
+        """
+        with pytest.raises(ConfigError, match="polling_interval"):
+            CollectorConfig(http_polling={"polling_interval": -1, "http_timeout": 10})
+
+    def test_m12_http_timeout_zero(self):
+        """
+        Feature: http_timeout=0 triggers validation error
+        Description: construct CollectorConfig with http_timeout=0
+        Expectation: raises ConfigError matching "http_timeout"
+        """
+        with pytest.raises(ConfigError, match="http_timeout"):
+            CollectorConfig(http_polling={"polling_interval": 5, "http_timeout": 0})
+
+    def test_m13_base_retry_delay_negative(self):
+        """
+        Feature: negative base_retry_delay triggers validation error
+        Description: construct CollectorConfig with base_retry_delay=-1
+        Expectation: raises ConfigError matching "base_retry_delay"
+        """
+        with pytest.raises(ConfigError, match="base_retry_delay"):
+            CollectorConfig(long_connection={"base_retry_delay": -1})
+
+    def test_m14_max_retry_delay_less_than_base(self):
+        """
+        Feature: max_retry_delay below base triggers validation error
+        Description: construct CollectorConfig with max_retry_delay=3 below base=5
+        Expectation: raises ConfigError matching "max_retry_delay"
+        """
+        with pytest.raises(ConfigError, match="max_retry_delay"):
+            CollectorConfig(long_connection={
+                "base_retry_delay": 5, "max_retry_delay": 3,
+            })
+
+    def test_m15_max_retry_attempts_zero(self):
+        """
+        Feature: max_retry_attempts=0 triggers validation error
+        Description: construct CollectorConfig with max_retry_attempts=0
+        Expectation: raises ConfigError matching "max_retry_attempts"
+        """
+        with pytest.raises(ConfigError, match="max_retry_attempts"):
+            CollectorConfig(long_connection={"max_retry_attempts": 0})
+
+    def test_m16_retry_backoff_factor_negative(self):
+        """
+        Feature: negative retry_backoff_factor triggers validation error
+        Description: construct CollectorConfig with retry_backoff_factor=-1
+        Expectation: raises ConfigError matching "retry_backoff_factor"
+        """
+        with pytest.raises(ConfigError, match="retry_backoff_factor"):
+            CollectorConfig(long_connection={"retry_backoff_factor": -1})
+
+
+# -- ③ Hydra parsing normal cases --
+# (No collector sub-config instantiate — concrete subclasses removed)
+
+
+# -- ⑤ Other cases --
+
+
+class TestMetricsOther:
+    """M18-M20: other cases"""
+
+    def test_m18_collector_defaults_with_strategy(self):
+        """
+        Feature: collector takes defaults when only strategies given
+        Description: from_config with a config containing only strategies
+        Expectation: http_polling/long_connection equal defaults
+        """
+        kwargs = OmegaConf.create({
+            "strategies": [
+                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
+            ],
+        })
+        result = KVCAwareConfig.from_config(kwargs)
+        assert result.collector.http_polling == {"polling_interval": 5.0, "http_timeout": 10.0}
+        assert result.collector.long_connection == {
+            "base_retry_delay": 1.0, "max_retry_delay": 30.0,
+            "max_retry_attempts": 5, "retry_backoff_factor": 2.0,
+        }
+
+    def test_m19_collector_null_default(self):
+        """
+        Feature: collector takes defaults when null
+        Description: from_config with collector=None
+        Expectation: result.collector is a CollectorConfig instance
+        """
+        kwargs = OmegaConf.create({
+            "strategies": [
+                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
+            ],
+            "collector": None,
+        })
+        result = KVCAwareConfig.from_config(kwargs)
+        assert isinstance(result.collector, CollectorConfig)
+
+    def test_m20_http_polling_override(self):
+        """
+        Feature: collector.http_polling overrides defaults
+        Description: from_config with config overriding polling_interval
+        Expectation: http_polling["polling_interval"] == 3.0
+        """
+        kwargs = OmegaConf.create({
+            "strategies": [
+                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
+            ],
+            "collector": {
+                "http_polling": {"polling_interval": 3},
+            },
+        })
+        result = KVCAwareConfig.from_config(kwargs)
+        assert result.collector.http_polling["polling_interval"] == 3.0
+
+
+# ============================================================
+# 5.3 CacheStoreConfig
+# ============================================================
+
+# -- ① Input/output normal cases --
+
+
+class TestCacheStoreNormalInput:
+    """C01-C05: normal input/output cases"""
+
+    def test_c01_kv_cache_store_type_list(self):
+        """
+        Feature: kv_cache_store_type=list parses normally
+        Description: construct CacheStoreConfig with kv_cache_store_type="list"
+        Expectation: cfg.kv_cache_store_type == "list"
+        """
+        cfg = CacheStoreConfig(kv_cache_store_type="list")
+        assert cfg.kv_cache_store_type == "list"
+
+    def test_c02_kv_cache_store_type_radix_tree(self):
+        """
+        Feature: kv_cache_store_type=radix_tree parses normally
+        Description: construct CacheStoreConfig with kv_cache_store_type="radix_tree"
+        Expectation: cfg.kv_cache_store_type == "radix_tree"
+        """
+        cfg = CacheStoreConfig(kv_cache_store_type="radix_tree")
+        assert cfg.kv_cache_store_type == "radix_tree"
+
+    def test_c03_kv_cache_store_type_default(self):
+        """
+        Feature: kv_cache_store_type uses default when omitted
+        Description: construct CacheStoreConfig with no args
+        Expectation: cfg.kv_cache_store_type == "list"
+        """
+        cfg = CacheStoreConfig()
+        assert cfg.kv_cache_store_type == "list"
+
+    def test_c04_ttl_30(self):
+        """
+        Feature: ttl field parses normally
+        Description: construct CacheStoreConfig with ttl=30.0
+        Expectation: cfg.ttl == 30.0
+        """
+        cfg = CacheStoreConfig(ttl=30.0)
+        assert cfg.ttl == 30.0
+
+    def test_c05_ttl_default(self):
+        """
+        Feature: ttl uses default when omitted
+        Description: construct CacheStoreConfig with no args
+        Expectation: cfg.ttl == 30.0
+        """
+        cfg = CacheStoreConfig()
+        assert cfg.ttl == 30.0
+
+
+# -- ② Input/output abnormal cases --
+
+
+class TestCacheStoreAbnormalInput:
+    """C06-C09: abnormal input/output cases"""
+
+    def test_c06_kv_cache_store_type_unknown(self):
+        """
+        Feature: illegal kv_cache_store_type triggers validation error
+        Description: construct CacheStoreConfig with kv_cache_store_type="unknown"
+        Expectation: raises ConfigError matching "kv_cache_store_type"
+        """
+        with pytest.raises(ConfigError, match="kv_cache_store_type"):
+            CacheStoreConfig(kv_cache_store_type="unknown")
+
+    def test_c07_ttl_zero(self):
+        """
+        Feature: ttl=0 triggers validation error
+        Description: construct CacheStoreConfig with ttl=0
+        Expectation: raises ConfigError matching "ttl"
+        """
+        with pytest.raises(ConfigError, match="ttl"):
+            CacheStoreConfig(ttl=0)
+
+    def test_c08_ttl_negative(self):
+        """
+        Feature: negative ttl triggers validation error
+        Description: construct CacheStoreConfig with ttl=-1
+        Expectation: raises ConfigError matching "ttl"
+        """
+        with pytest.raises(ConfigError, match="ttl"):
+            CacheStoreConfig(ttl=-1)
+
+    def test_c09_cache_store_not_dict(self):
+        """
+        Feature: non-dict cache_store triggers validation error
+        Description: from_config with cache_store="list"
+        Expectation: raises ConfigError matching "cache_store"
+        """
+        kwargs = OmegaConf.create({
+            "strategies": [
+                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
+            ],
+            "cache_store": "list",
+        })
+        with pytest.raises(ConfigError, match="cache_store"):
+            KVCAwareConfig.from_config(kwargs)
+
+
+# -- ⑤ Other cases --
+
+
+class TestCacheStoreOther:
+    """C10-C11: other cases"""
+
+    def test_c10_cache_store_defaults_with_strategy(self):
+        """
+        Feature: cache_store takes defaults when only strategies given
+        Description: from_config with a config containing only strategies
+        Expectation: kv_cache_store_type/ttl equal defaults
+        """
+        kwargs = OmegaConf.create({
+            "strategies": [
+                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
+            ],
+        })
+        result = KVCAwareConfig.from_config(kwargs)
+        assert result.cache_store.kv_cache_store_type == "list"
+        assert result.cache_store.ttl == 30.0
+
+    def test_c11_cache_store_null_default(self):
+        """
+        Feature: cache_store takes defaults when null
+        Description: from_config with cache_store=None
+        Expectation: result.cache_store is a CacheStoreConfig instance
+        """
+        kwargs = OmegaConf.create({
+            "strategies": [
+                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
+            ],
+            "cache_store": None,
+        })
+        result = KVCAwareConfig.from_config(kwargs)
+        assert isinstance(result.cache_store, CacheStoreConfig)
+
+
+# ============================================================
+# 5.4 KVCAwareConfig top-level
+# ============================================================
+
+# -- ① Input/output normal cases --
+
+
+class TestKVCAwareNormalInput:
+    """K01: normal input/output cases"""
+
+    def test_k01_full_config_normal_parse(self):
+        """
+        Feature: full config parses normally
+        Description: from_config with a full config of strategies/collector/cache_store
+        Expectation: result is a KVCAwareConfig and field types are correct
+        """
+        kwargs = OmegaConf.create({
+            "strategies": [
+                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                 "weight": 1.0, "alpha": 0.7, "collector_names": ["vllm_zmq", "mooncake_prometheus"]},
+            ],
+            "collector": {
+                "http_polling": {"polling_interval": 5, "http_timeout": 10},
+                "long_connection": {
+                    "base_retry_delay": 1.0, "max_retry_delay": 30.0,
+                    "max_retry_attempts": 5, "retry_backoff_factor": 2.0,
+                },
+
+            },
+            "cache_store": {"kv_cache_store_type": "list", "ttl": 30},
+        })
+        result = KVCAwareConfig.from_config(kwargs)
+        assert isinstance(result, KVCAwareConfig)
+        assert isinstance(result.strategies[0], KVCAwareStrategyConfig)
+        assert isinstance(result.collector, CollectorConfig)
+        assert isinstance(result.cache_store, CacheStoreConfig)
+
+
+# -- ② Input/output abnormal cases --
+
+
+class TestKVCAwareAbnormalInput:
+    """K02-K04: abnormal input/output cases"""
+
+    def test_k02_multi_error_aggregation(self):
+        """
+        Feature: from_config raises on multiple errors
+        Description: from_config with empty strategies/illegal collector/illegal cache_store
+        Expectation: raises ConfigError and message contains relevant field names
+        """
+        kwargs = OmegaConf.create({
+            "strategies": [],
+            "collector": {"http_polling": {"polling_interval": -1}},
+            "cache_store": {"ttl": 0},
+        })
+        with pytest.raises(ConfigError) as exc_info:
+            KVCAwareConfig.from_config(kwargs)
+        error_msg = str(exc_info.value)
+        assert "strategies" in error_msg or "polling_interval" in error_msg or "ttl" in error_msg
+
+    def test_k03_collector_not_dict(self):
+        """
+        Feature: non-dict collector triggers validation error
+        Description: from_config with collector="vllm"
+        Expectation: raises ConfigError matching "collector"
+        """
+        kwargs = OmegaConf.create({
+            "strategies": [
+                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
+            ],
+            "collector": "vllm",
+        })
+        with pytest.raises(ConfigError, match="collector"):
+            KVCAwareConfig.from_config(kwargs)
+
+
+# -- ③ Hydra parsing normal cases --
+
+
+class TestKVCAwareHydraNormal:
+    """K05-K08: Hydra parsing normal cases"""
+
+    def test_k05_omega_conf_merge_to_kvc_aware_config(self):
+        """
+        Feature: OmegaConf input parses into KVCAwareConfig normally
+        Description: from_config with an OmegaConf containing all three sections
+        Expectation: result is a KVCAwareConfig instance
+        """
+        kwargs = OmegaConf.create({
+            "strategies": [
+                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
+            ],
+            "collector": {
+                "http_polling": {"polling_interval": 5, "http_timeout": 10},
+            },
+            "cache_store": {"kv_cache_store_type": "list", "ttl": 30},
+        })
+        result = KVCAwareConfig.from_config(kwargs)
+        assert isinstance(result, KVCAwareConfig)
+
+    def test_k06_collector_auto_recursive_parse(self):
+        """
+        Feature: collector auto-recursive parsing
+        Description: from_config with config overriding http_polling
+        Expectation: result.collector is CollectorConfig and polling_interval==3.0
+        """
+        kwargs = OmegaConf.create({
+            "strategies": [
+                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
+            ],
+            "collector": {"http_polling": {"polling_interval": 3}},
+        })
+        result = KVCAwareConfig.from_config(kwargs)
+        assert isinstance(result.collector, CollectorConfig)
+        assert result.collector.http_polling["polling_interval"] == 3.0
+
+    def test_k07_cache_store_auto_recursive_parse(self):
+        """
+        Feature: cache_store auto-recursive parsing
+        Description: from_config with config overriding cache_store
+        Expectation: result.cache_store fields equal custom values
+        """
+        kwargs = OmegaConf.create({
+            "strategies": [
+                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
+            ],
+            "cache_store": {"kv_cache_store_type": "radix_tree", "ttl": 60},
+        })
+        result = KVCAwareConfig.from_config(kwargs)
+        assert isinstance(result.cache_store, CacheStoreConfig)
+        assert result.cache_store.kv_cache_store_type == "radix_tree"
+        assert result.cache_store.ttl == 60.0
+
+    def test_k08_strategies_dict_to_list_conversion(self):
+        """
+        Feature: strategies dict auto-converts to list
+        Description: from_config with strategies in dict form
+        Expectation: result.strategies is a list and element types/values are correct
+        """
+        kwargs = OmegaConf.create({
+            "strategies": {
+                "kvc_aware": {
+                    "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                    "weight": 1.0,
+                    "collector_names": ["vllm_zmq"],
+                },
+            },
+        })
+        result = KVCAwareConfig.from_config(kwargs)
+        assert isinstance(result.strategies, list)
+        assert len(result.strategies) == 1
+        assert isinstance(result.strategies[0], KVCAwareStrategyConfig)
+        assert result.strategies[0].weight == 1.0
+
+
+# -- ④ Hydra parsing abnormal cases --
+
+
+class TestKVCAwareHydraAbnormal:
+    """K09-K11: Hydra parsing abnormal cases"""
+
+    def test_k09_top_level_router_class_ignored(self):
+        """
+        Feature: from_config ignores VeRL-side router_class metadata
+        Description: from_config with a config containing router_class
+        Expectation: result is KVCAwareConfig and fields exclude router_class
+        """
+        kwargs = OmegaConf.create({
+            "router_class": "uni_agent.llm_router.balancer.KVCAwareBalancer",
+            "strategies": [
+                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
+            ],
+        })
+        result = KVCAwareConfig.from_config(kwargs)
+        assert isinstance(result, KVCAwareConfig)
+        import dataclasses
+        field_names = {f.name for f in dataclasses.fields(result)}
+        assert "router_class" not in field_names
+
+    def test_k10_metrics_unknown_key(self):
+        """
+        Feature: collector with undefined key triggers parse error
+        Description: from_config with collector containing unknown_key
+        Expectation: raises exception matching "unknown_key"
+        """
+        kwargs = OmegaConf.create({
+            "strategies": [
+                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
+            ],
+            "collector": {"unknown_key": 123, "http_polling": {"polling_interval": 5}},
+        })
+        with pytest.raises(Exception, match="unknown_key"):
+            KVCAwareConfig.from_config(kwargs)
+
+    def test_k11_compact_repr(self):
+        """
+        Feature: KVCAwareConfig multi-line indented repr
+        Description: from_config then call repr and inspect output
+        Expectation: repr contains newline and starts with KVCAwareConfig(
+        """
+        kwargs = OmegaConf.create({
+            "strategies": [
+                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                 "weight": 1.0, "collector_names": ["vllm_zmq", "mooncake_prometheus"]},
+            ],
+            "collector": {
+                "http_polling": {"polling_interval": 5, "http_timeout": 10},
+                "long_connection": {
+                    "base_retry_delay": 1.0, "max_retry_delay": 30.0,
+                    "max_retry_attempts": 5, "retry_backoff_factor": 2.0,
+                },
+            },
+            "cache_store": {"kv_cache_store_type": "list", "ttl": 30},
+        })
+        result = KVCAwareConfig.from_config(kwargs)
+        r = repr(result)
+        assert "\n" in r
+        assert r.startswith("KVCAwareConfig(")
+        assert "weight=1.0" in r
+        assert "collector_names" in r
+
+
+# -- ⑤ Other cases --
+
+
+class TestKVCAwareOther:
+    """K12-K14: other cases"""
+
+    def test_k12_only_strategies_defaults(self):
+        """
+        Feature: other fields take defaults when only strategies given
+        Description: from_config with a config containing only strategies
+        Expectation: collector/cache_store are their Config types
+        """
+        kwargs = OmegaConf.create({
+            "strategies": [
+                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
+            ],
+        })
+        result = KVCAwareConfig.from_config(kwargs)
+        assert isinstance(result.collector, CollectorConfig)
+        assert isinstance(result.cache_store, CacheStoreConfig)
+
+    def test_k13_manual_instantiate_all_dataclass(self):
+        """
+        Feature: multi-strategy instances are all StrategyConfig
+        Description: from_config with a config containing two strategies
+        Expectation: each strategy is a StrategyConfig instance
+        """
+        kwargs = OmegaConf.create({
+            "strategies": [
+                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                 "weight": 0.7, "collector_names": ["vllm_zmq"]},
+                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                 "weight": 0.3, "collector_names": ["vllm_prometheus"]},
+            ],
+        })
+        result = KVCAwareConfig.from_config(kwargs)
+        for s in result.strategies:
+            assert isinstance(s, StrategyConfig)
+
+    def test_k14_yaml_split_loading(self):
+        """
+        Feature: Hydra composition of real YAML parses end-to-end
+        Description: read kvc_aware_router via initialize_config_dir+compose then from_config
+        Expectation: all fields match the YAML config
+        """
+        from pathlib import Path
+        from hydra import initialize_config_dir, compose
+
+        config_dir = str((Path(__file__).parent.parent.parent.parent
+                          / "uni_agent" / "llm_router" / "configs").resolve())
+        with initialize_config_dir(config_dir=config_dir, version_base=None):
+            cfg = compose(config_name="kvc_aware_router")
+
+        assert cfg.router_class == "uni_agent.llm_router.balancer.KVCAwareBalancer"
+
+        result = KVCAwareConfig.from_config(cfg)
+
+        # ── strategies ──
+        assert isinstance(result.strategies, list)
+        assert len(result.strategies) == 1
+        strategy = result.strategies[0]
+        assert isinstance(strategy, KVCAwareStrategyConfig)
+        assert strategy.weight == 1.0
+        assert strategy.alpha == 0.7
+        assert strategy.load_threshold == 0.9
+        assert strategy.layer_weights == {"gpu": 0.7, "cpu": 0.2, "ssd": 0.1}
+        assert strategy.collector_names == ["vllm_zmq", "vllm_metrics"]
+        assert result.collector.http_polling == {"polling_interval": 5.0, "http_timeout": 10.0}
+        assert result.collector.long_connection == {
+            "base_retry_delay": 1.0, "max_retry_delay": 30.0,
+            "max_retry_attempts": 5, "retry_backoff_factor": 2.0,
+        }
+
+        # ── cache_store ──
+        assert isinstance(result.cache_store, CacheStoreConfig)
+        assert result.cache_store.kv_cache_store_type == "list"
+        assert result.cache_store.ttl == 30.0
+
+
+# ============================================================
+# 5.5 Drop-in flow integration tests
+# ============================================================
+
+
+class TestDropInIntegration:
+    """Drop-in flow integration tests (config side).
+
+    VeRL drop-in: hydra.compose → router_class → importlib → ray.remote → from_config.
+    This class tests the config-side behavior. VeRL-side pkg:// etc. live in
+    verl/tests/workers/rollout/test_router.py.
+    """
+
+    def _make_full_config(self) -> "OmegaConf":
+        """Helper: build a full config for drop-in tests."""
+        return OmegaConf.create({
+            "router_class": "uni_agent.llm_router.balancer.KVCAwareBalancer",
+            "strategies": [
+                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                 "weight": 1.0, "alpha": 0.7, "collector_names": ["vllm_zmq", "mooncake_prometheus"]},
+            ],
+            "collector": {
+                "http_polling": {"polling_interval": 5, "http_timeout": 10},
+                "long_connection": {
+                    "base_retry_delay": 1.0, "max_retry_delay": 30.0,
+                    "max_retry_attempts": 5, "retry_backoff_factor": 2.0,
+                },
+
+            },
+            "cache_store": {"kv_cache_store_type": "list", "ttl": 30},
+        })
+
+    def test_d05_compose_expands_defaults(self):
+        """
+        Feature: hydra.compose expands default config
+        Description: read kvc_aware_router via initialize_config_dir+compose
+        Expectation: strategies/collector/cache_store/router_class all present
+        """
+        from pathlib import Path
+        from hydra import initialize_config_dir, compose
+
+        config_dir = str((Path(__file__).parent.parent.parent.parent
+                          / "uni_agent" / "llm_router" / "configs").resolve())
+        with initialize_config_dir(config_dir=config_dir, version_base=None):
+            cfg = compose(config_name="kvc_aware_router")
+        assert "strategies" in cfg and "collector" in cfg and "cache_store" in cfg
+        assert cfg.router_class == "uni_agent.llm_router.balancer.KVCAwareBalancer"
+        assert "kvc_aware_strategy" in cfg.strategies
+        assert "http_polling" in cfg.collector
+        assert "long_connection" in cfg.collector
+
+    def test_d08_balancer_from_config(self):
+        """
+        Feature: from_config fully parses drop-in config
+        Description: from_config with config generated by _make_full_config
+        Expectation: result and field types are correct
+        """
+        cfg = self._make_full_config()
+        result = KVCAwareConfig.from_config(cfg)
+        assert isinstance(result, KVCAwareConfig)
+        assert isinstance(result.strategies[0], KVCAwareStrategyConfig)
+        assert isinstance(result.collector, CollectorConfig)
+        assert isinstance(result.cache_store, CacheStoreConfig)
+
+    def test_d09_strategy_subtarget_instantiate(self):
+        """
+        Feature: strategy sub-layer _target_ instantiates correctly
+        Description: take strategies[0] after from_config
+        Expectation: type is KVCAwareStrategyConfig and fields are correct
+        """
+        cfg = self._make_full_config()
+        result = KVCAwareConfig.from_config(cfg)
+        s = result.strategies[0]
+        assert type(s) == KVCAwareStrategyConfig
+        assert s.collector_names == ["vllm_zmq", "mooncake_prometheus"]
+        assert s.weight == 1.0
+
+    def test_d11_from_config_ignores_router_class(self):
+        """
+        Feature: from_config ignores router_class
+        Description: from_config with a config containing router_class
+        Expectation: result field set excludes router_class
+        """
+        cfg = self._make_full_config()
+        result = KVCAwareConfig.from_config(cfg)
+        import dataclasses
+        field_names = {f.name for f in dataclasses.fields(result)}
+        assert "router_class" not in field_names
+        assert not hasattr(result, "router_class")
+
+    def test_d12_omegaconf_dictconfig_input(self):
+        """
+        Feature: OmegaConf DictConfig input parses normally
+        Description: from_config with an OmegaConf-typed config
+        Expectation: strategies[0] is a KVCAwareStrategyConfig instance
+        """
+        cfg = self._make_full_config()
+        result = KVCAwareConfig.from_config(cfg)
+        assert isinstance(result.strategies[0], KVCAwareStrategyConfig)
+
+    def test_d13_plain_dict_input(self):
+        """
+        Feature: plain dict input parses normally
+        Description: to_container to plain dict then from_config
+        Expectation: strategies[0] type/weight are correct
+        """
+        cfg = OmegaConf.to_container(self._make_full_config(), resolve=True)
+        result = KVCAwareConfig.from_config(cfg)
+        assert isinstance(result.strategies[0], KVCAwareStrategyConfig)
+        assert result.strategies[0].weight == 1.0
+
+    def test_d14_yaml_file_e2e(self):
+        """
+        Feature: YAML file parses end-to-end
+        Description: simulate VeRL drop-in flow to read YAML then from_config
+        Expectation: all field types/values are correct and router_class is ignored
+        """
+        from pathlib import Path
+        from hydra import initialize_config_dir, compose
+        from hydra.core.global_hydra import GlobalHydra
+
+        config_dir = str((Path(__file__).parent.parent.parent.parent
+                          / "uni_agent" / "llm_router" / "configs").resolve())
+
+        GlobalHydra.instance().clear()
+        with initialize_config_dir(config_dir=config_dir, version_base=None):
+            cfg = compose(config_name="kvc_aware_router")
+
+        # Step 2: to_container → plain dict (VeRL input form)
+        cfg_dict = OmegaConf.to_container(cfg, resolve=True)
+        assert isinstance(cfg_dict, dict)
+        assert cfg_dict["router_class"] == "uni_agent.llm_router.balancer.KVCAwareBalancer"
+
+        # Step 3: from_config
+        result = KVCAwareConfig.from_config(cfg_dict)
+
+        # Step 4: validate
+        assert isinstance(result, KVCAwareConfig)
+        assert len(result.strategies) == 1
+        s = result.strategies[0]
+        assert isinstance(s, KVCAwareStrategyConfig)
+        assert s.weight == 1.0
+        assert s.alpha == 0.7
+        assert s.collector_names == ["vllm_zmq", "vllm_metrics"]
+        assert result.collector.http_polling["polling_interval"] == 5.0
+        assert result.collector.long_connection["max_retry_attempts"] == 5
+        assert result.cache_store.kv_cache_store_type == "list"
+        assert result.cache_store.ttl == 30.0
+        # router_class does not appear in KVCAwareConfig fields
+        import dataclasses
+        assert "router_class" not in {f.name for f in dataclasses.fields(result)}

--- a/tests/uni_agent/llm_router/test_config.py
+++ b/tests/uni_agent/llm_router/test_config.py
@@ -14,7 +14,6 @@ import pytest
 from hydra.errors import InstantiationException
 from omegaconf import OmegaConf
 
-
 # -- Public API via package __init__ --
 from uni_agent.llm_router import (
     CacheStoreConfig,
@@ -36,8 +35,9 @@ _CN = ["vllm_zmq"]
 # -- ① Input/output normal cases --
 
 
-
 pytestmark = [pytest.mark.ut, pytest.mark.cpu]
+
+
 class TestStrategyNormalInput:
     """S01-S12: normal input/output cases"""
 
@@ -250,9 +250,7 @@ class TestStrategyAbnormalInput:
         Expectation: raises ConfigError matching "layer_weights"
         """
         with pytest.raises(ConfigError, match="layer_weights"):
-            KVCAwareStrategyConfig(
-                weight=1.0, layer_weights={"gpu": 0.7, "cpu": 0.2, "disk": 0.1}, collector_names=_CN
-            )
+            KVCAwareStrategyConfig(weight=1.0, layer_weights={"gpu": 0.7, "cpu": 0.2, "disk": 0.1}, collector_names=_CN)
 
     def test_s21_layer_weights_missing_key(self):
         """
@@ -261,9 +259,7 @@ class TestStrategyAbnormalInput:
         Expectation: raises ConfigError matching "layer_weights"
         """
         with pytest.raises(ConfigError, match="layer_weights"):
-            KVCAwareStrategyConfig(
-                weight=1.0, layer_weights={"gpu": 0.7, "cpu": 0.3}, collector_names=_CN
-            )
+            KVCAwareStrategyConfig(weight=1.0, layer_weights={"gpu": 0.7, "cpu": 0.3}, collector_names=_CN)
 
     def test_s21b_layer_weights_sum_below_one(self):
         """
@@ -272,9 +268,7 @@ class TestStrategyAbnormalInput:
         Expectation: raises ConfigError matching "layer_weights"
         """
         with pytest.raises(ConfigError, match="layer_weights"):
-            KVCAwareStrategyConfig(
-                weight=1.0, layer_weights={"gpu": 0.5, "cpu": 0.2, "ssd": 0.1}, collector_names=_CN
-            )
+            KVCAwareStrategyConfig(weight=1.0, layer_weights={"gpu": 0.5, "cpu": 0.2, "ssd": 0.1}, collector_names=_CN)
 
     def test_s21c_layer_weights_sum_above_one(self):
         """
@@ -283,9 +277,7 @@ class TestStrategyAbnormalInput:
         Expectation: raises ConfigError matching "layer_weights"
         """
         with pytest.raises(ConfigError, match="layer_weights"):
-            KVCAwareStrategyConfig(
-                weight=1.0, layer_weights={"gpu": 0.7, "cpu": 0.2, "ssd": 0.2}, collector_names=_CN
-            )
+            KVCAwareStrategyConfig(weight=1.0, layer_weights={"gpu": 0.7, "cpu": 0.2, "ssd": 0.2}, collector_names=_CN)
 
     def test_s22_collector_names_not_list_type(self):
         """
@@ -302,14 +294,22 @@ class TestStrategyAbnormalInput:
         Description: from_config with two strategies each weighted 0.4
         Expectation: raises ConfigError matching "weight"
         """
-        kwargs = OmegaConf.create({
-            "strategies": [
-                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                 "weight": 0.4, "collector_names": ["vllm_zmq"]},
-                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                 "weight": 0.4, "collector_names": ["mooncake_prometheus"]},
-            ],
-        })
+        kwargs = OmegaConf.create(
+            {
+                "strategies": [
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 0.4,
+                        "collector_names": ["vllm_zmq"],
+                    },
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 0.4,
+                        "collector_names": ["mooncake_prometheus"],
+                    },
+                ],
+            }
+        )
         with pytest.raises(ConfigError, match="weight"):
             KVCAwareConfig.from_config(kwargs)
 
@@ -356,12 +356,15 @@ class TestStrategyHydraNormal:
         Description: instantiate a strategy OmegaConf entry with _target_
         Expectation: result is a KVCAwareStrategyConfig instance
         """
-        entry = OmegaConf.create({
-            "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-            "weight": 1.0,
-            "collector_names": ["vllm_zmq"],
-        })
+        entry = OmegaConf.create(
+            {
+                "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                "weight": 1.0,
+                "collector_names": ["vllm_zmq"],
+            }
+        )
         from hydra.utils import instantiate
+
         result = instantiate(entry)
         assert isinstance(result, KVCAwareStrategyConfig)
 
@@ -371,12 +374,15 @@ class TestStrategyHydraNormal:
         Description: instantiate a strategy entry then assert base type
         Expectation: result is a StrategyConfig instance and weight==1.0
         """
-        entry = OmegaConf.create({
-            "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-            "weight": 1.0,
-            "collector_names": ["vllm_zmq"],
-        })
+        entry = OmegaConf.create(
+            {
+                "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                "weight": 1.0,
+                "collector_names": ["vllm_zmq"],
+            }
+        )
         from hydra.utils import instantiate
+
         result = instantiate(entry)
         assert isinstance(result, StrategyConfig)
         assert result.weight == 1.0
@@ -387,12 +393,15 @@ class TestStrategyHydraNormal:
         Description: instantiate a strategy entry with only weight/collector_names
         Expectation: alpha/load_threshold/layer_weights equal defaults
         """
-        entry = OmegaConf.create({
-            "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-            "weight": 1.0,
-            "collector_names": ["vllm_zmq"],
-        })
+        entry = OmegaConf.create(
+            {
+                "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                "weight": 1.0,
+                "collector_names": ["vllm_zmq"],
+            }
+        )
         from hydra.utils import instantiate
+
         result = instantiate(entry)
         assert result.alpha == 0.7
         assert result.load_threshold == 0.9
@@ -414,6 +423,7 @@ class TestStrategyHydraAbnormal:
         """
         entry = OmegaConf.create({"_target_": "nonexistent.Module.Class"})
         from hydra.utils import instantiate
+
         with pytest.raises((InstantiationException, ImportError, ConfigError)):
             instantiate(entry)
 
@@ -423,10 +433,13 @@ class TestStrategyHydraAbnormal:
         Description: instantiate an entry whose _target_ points to config.NonExistClass
         Expectation: raises InstantiationException/AttributeError/ConfigError
         """
-        entry = OmegaConf.create({
-            "_target_": "uni_agent.llm_router.config.NonExistClass",
-        })
+        entry = OmegaConf.create(
+            {
+                "_target_": "uni_agent.llm_router.config.NonExistClass",
+            }
+        )
         from hydra.utils import instantiate
+
         with pytest.raises((InstantiationException, AttributeError, ConfigError)):
             instantiate(entry)
 
@@ -446,12 +459,17 @@ class TestStrategyHydraAbnormal:
         Description: from_config with a strategy item whose _target_ is CacheStoreConfig
         Expectation: raises ConfigError matching "StrategyConfig"
         """
-        kwargs = OmegaConf.create({
-            "strategies": [
-                {"_target_": "uni_agent.llm_router.config.CacheStoreConfig",
-                 "kv_cache_store_type": "list", "ttl": 30},
-            ],
-        })
+        kwargs = OmegaConf.create(
+            {
+                "strategies": [
+                    {
+                        "_target_": "uni_agent.llm_router.config.CacheStoreConfig",
+                        "kv_cache_store_type": "list",
+                        "ttl": 30,
+                    },
+                ],
+            }
+        )
         with pytest.raises(ConfigError, match="StrategyConfig"):
             KVCAwareConfig.from_config(kwargs)
 
@@ -535,10 +553,14 @@ class TestMetricsNormalInput:
         Description: construct CollectorConfig with custom long_connection
         Expectation: base_retry_delay/max_retry_delay equal custom values
         """
-        cfg = CollectorConfig(long_connection={
-            "base_retry_delay": 2.0, "max_retry_delay": 60.0,
-            "max_retry_attempts": 10, "retry_backoff_factor": 3.0,
-        })
+        cfg = CollectorConfig(
+            long_connection={
+                "base_retry_delay": 2.0,
+                "max_retry_delay": 60.0,
+                "max_retry_attempts": 10,
+                "retry_backoff_factor": 3.0,
+            }
+        )
         assert cfg.long_connection["base_retry_delay"] == 2.0
         assert cfg.long_connection["max_retry_delay"] == 60.0
 
@@ -551,6 +573,7 @@ class TestMetricsNormalInput:
         Expectation: field set is {http_polling, long_connection}
         """
         import dataclasses
+
         field_names = {f.name for f in dataclasses.fields(CollectorConfig)}
         assert field_names == {"http_polling", "long_connection"}
 
@@ -561,6 +584,7 @@ class TestMetricsNormalInput:
         Expectation: is_dataclass returns True
         """
         import dataclasses
+
         assert dataclasses.is_dataclass(CollectorConfig)
 
 
@@ -613,9 +637,12 @@ class TestMetricsAbnormalInput:
         Expectation: raises ConfigError matching "max_retry_delay"
         """
         with pytest.raises(ConfigError, match="max_retry_delay"):
-            CollectorConfig(long_connection={
-                "base_retry_delay": 5, "max_retry_delay": 3,
-            })
+            CollectorConfig(
+                long_connection={
+                    "base_retry_delay": 5,
+                    "max_retry_delay": 3,
+                }
+            )
 
     def test_m15_max_retry_attempts_zero(self):
         """
@@ -652,17 +679,24 @@ class TestMetricsOther:
         Description: from_config with a config containing only strategies
         Expectation: http_polling/long_connection equal defaults
         """
-        kwargs = OmegaConf.create({
-            "strategies": [
-                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
-            ],
-        })
+        kwargs = OmegaConf.create(
+            {
+                "strategies": [
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 1.0,
+                        "collector_names": ["vllm_zmq"],
+                    },
+                ],
+            }
+        )
         result = KVCAwareConfig.from_config(kwargs)
         assert result.collector.http_polling == {"polling_interval": 5.0, "http_timeout": 10.0}
         assert result.collector.long_connection == {
-            "base_retry_delay": 1.0, "max_retry_delay": 30.0,
-            "max_retry_attempts": 5, "retry_backoff_factor": 2.0,
+            "base_retry_delay": 1.0,
+            "max_retry_delay": 30.0,
+            "max_retry_attempts": 5,
+            "retry_backoff_factor": 2.0,
         }
 
     def test_m19_collector_null_default(self):
@@ -671,13 +705,18 @@ class TestMetricsOther:
         Description: from_config with collector=None
         Expectation: result.collector is a CollectorConfig instance
         """
-        kwargs = OmegaConf.create({
-            "strategies": [
-                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
-            ],
-            "collector": None,
-        })
+        kwargs = OmegaConf.create(
+            {
+                "strategies": [
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 1.0,
+                        "collector_names": ["vllm_zmq"],
+                    },
+                ],
+                "collector": None,
+            }
+        )
         result = KVCAwareConfig.from_config(kwargs)
         assert isinstance(result.collector, CollectorConfig)
 
@@ -687,15 +726,20 @@ class TestMetricsOther:
         Description: from_config with config overriding polling_interval
         Expectation: http_polling["polling_interval"] == 3.0
         """
-        kwargs = OmegaConf.create({
-            "strategies": [
-                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
-            ],
-            "collector": {
-                "http_polling": {"polling_interval": 3},
-            },
-        })
+        kwargs = OmegaConf.create(
+            {
+                "strategies": [
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 1.0,
+                        "collector_names": ["vllm_zmq"],
+                    },
+                ],
+                "collector": {
+                    "http_polling": {"polling_interval": 3},
+                },
+            }
+        )
         result = KVCAwareConfig.from_config(kwargs)
         assert result.collector.http_polling["polling_interval"] == 3.0
 
@@ -795,13 +839,18 @@ class TestCacheStoreAbnormalInput:
         Description: from_config with cache_store="list"
         Expectation: raises ConfigError matching "cache_store"
         """
-        kwargs = OmegaConf.create({
-            "strategies": [
-                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
-            ],
-            "cache_store": "list",
-        })
+        kwargs = OmegaConf.create(
+            {
+                "strategies": [
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 1.0,
+                        "collector_names": ["vllm_zmq"],
+                    },
+                ],
+                "cache_store": "list",
+            }
+        )
         with pytest.raises(ConfigError, match="cache_store"):
             KVCAwareConfig.from_config(kwargs)
 
@@ -818,12 +867,17 @@ class TestCacheStoreOther:
         Description: from_config with a config containing only strategies
         Expectation: kv_cache_store_type/ttl equal defaults
         """
-        kwargs = OmegaConf.create({
-            "strategies": [
-                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
-            ],
-        })
+        kwargs = OmegaConf.create(
+            {
+                "strategies": [
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 1.0,
+                        "collector_names": ["vllm_zmq"],
+                    },
+                ],
+            }
+        )
         result = KVCAwareConfig.from_config(kwargs)
         assert result.cache_store.kv_cache_store_type == "list"
         assert result.cache_store.ttl == 30.0
@@ -834,13 +888,18 @@ class TestCacheStoreOther:
         Description: from_config with cache_store=None
         Expectation: result.cache_store is a CacheStoreConfig instance
         """
-        kwargs = OmegaConf.create({
-            "strategies": [
-                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
-            ],
-            "cache_store": None,
-        })
+        kwargs = OmegaConf.create(
+            {
+                "strategies": [
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 1.0,
+                        "collector_names": ["vllm_zmq"],
+                    },
+                ],
+                "cache_store": None,
+            }
+        )
         result = KVCAwareConfig.from_config(kwargs)
         assert isinstance(result.cache_store, CacheStoreConfig)
 
@@ -861,21 +920,28 @@ class TestKVCAwareNormalInput:
         Description: from_config with a full config of strategies/collector/cache_store
         Expectation: result is a KVCAwareConfig and field types are correct
         """
-        kwargs = OmegaConf.create({
-            "strategies": [
-                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                 "weight": 1.0, "alpha": 0.7, "collector_names": ["vllm_zmq", "mooncake_prometheus"]},
-            ],
-            "collector": {
-                "http_polling": {"polling_interval": 5, "http_timeout": 10},
-                "long_connection": {
-                    "base_retry_delay": 1.0, "max_retry_delay": 30.0,
-                    "max_retry_attempts": 5, "retry_backoff_factor": 2.0,
+        kwargs = OmegaConf.create(
+            {
+                "strategies": [
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 1.0,
+                        "alpha": 0.7,
+                        "collector_names": ["vllm_zmq", "mooncake_prometheus"],
+                    },
+                ],
+                "collector": {
+                    "http_polling": {"polling_interval": 5, "http_timeout": 10},
+                    "long_connection": {
+                        "base_retry_delay": 1.0,
+                        "max_retry_delay": 30.0,
+                        "max_retry_attempts": 5,
+                        "retry_backoff_factor": 2.0,
+                    },
                 },
-
-            },
-            "cache_store": {"kv_cache_store_type": "list", "ttl": 30},
-        })
+                "cache_store": {"kv_cache_store_type": "list", "ttl": 30},
+            }
+        )
         result = KVCAwareConfig.from_config(kwargs)
         assert isinstance(result, KVCAwareConfig)
         assert isinstance(result.strategies[0], KVCAwareStrategyConfig)
@@ -895,11 +961,13 @@ class TestKVCAwareAbnormalInput:
         Description: from_config with empty strategies/illegal collector/illegal cache_store
         Expectation: raises ConfigError and message contains relevant field names
         """
-        kwargs = OmegaConf.create({
-            "strategies": [],
-            "collector": {"http_polling": {"polling_interval": -1}},
-            "cache_store": {"ttl": 0},
-        })
+        kwargs = OmegaConf.create(
+            {
+                "strategies": [],
+                "collector": {"http_polling": {"polling_interval": -1}},
+                "cache_store": {"ttl": 0},
+            }
+        )
         with pytest.raises(ConfigError) as exc_info:
             KVCAwareConfig.from_config(kwargs)
         error_msg = str(exc_info.value)
@@ -911,13 +979,18 @@ class TestKVCAwareAbnormalInput:
         Description: from_config with collector="vllm"
         Expectation: raises ConfigError matching "collector"
         """
-        kwargs = OmegaConf.create({
-            "strategies": [
-                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
-            ],
-            "collector": "vllm",
-        })
+        kwargs = OmegaConf.create(
+            {
+                "strategies": [
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 1.0,
+                        "collector_names": ["vllm_zmq"],
+                    },
+                ],
+                "collector": "vllm",
+            }
+        )
         with pytest.raises(ConfigError, match="collector"):
             KVCAwareConfig.from_config(kwargs)
 
@@ -934,16 +1007,21 @@ class TestKVCAwareHydraNormal:
         Description: from_config with an OmegaConf containing all three sections
         Expectation: result is a KVCAwareConfig instance
         """
-        kwargs = OmegaConf.create({
-            "strategies": [
-                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
-            ],
-            "collector": {
-                "http_polling": {"polling_interval": 5, "http_timeout": 10},
-            },
-            "cache_store": {"kv_cache_store_type": "list", "ttl": 30},
-        })
+        kwargs = OmegaConf.create(
+            {
+                "strategies": [
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 1.0,
+                        "collector_names": ["vllm_zmq"],
+                    },
+                ],
+                "collector": {
+                    "http_polling": {"polling_interval": 5, "http_timeout": 10},
+                },
+                "cache_store": {"kv_cache_store_type": "list", "ttl": 30},
+            }
+        )
         result = KVCAwareConfig.from_config(kwargs)
         assert isinstance(result, KVCAwareConfig)
 
@@ -953,13 +1031,18 @@ class TestKVCAwareHydraNormal:
         Description: from_config with config overriding http_polling
         Expectation: result.collector is CollectorConfig and polling_interval==3.0
         """
-        kwargs = OmegaConf.create({
-            "strategies": [
-                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
-            ],
-            "collector": {"http_polling": {"polling_interval": 3}},
-        })
+        kwargs = OmegaConf.create(
+            {
+                "strategies": [
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 1.0,
+                        "collector_names": ["vllm_zmq"],
+                    },
+                ],
+                "collector": {"http_polling": {"polling_interval": 3}},
+            }
+        )
         result = KVCAwareConfig.from_config(kwargs)
         assert isinstance(result.collector, CollectorConfig)
         assert result.collector.http_polling["polling_interval"] == 3.0
@@ -970,13 +1053,18 @@ class TestKVCAwareHydraNormal:
         Description: from_config with config overriding cache_store
         Expectation: result.cache_store fields equal custom values
         """
-        kwargs = OmegaConf.create({
-            "strategies": [
-                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
-            ],
-            "cache_store": {"kv_cache_store_type": "radix_tree", "ttl": 60},
-        })
+        kwargs = OmegaConf.create(
+            {
+                "strategies": [
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 1.0,
+                        "collector_names": ["vllm_zmq"],
+                    },
+                ],
+                "cache_store": {"kv_cache_store_type": "radix_tree", "ttl": 60},
+            }
+        )
         result = KVCAwareConfig.from_config(kwargs)
         assert isinstance(result.cache_store, CacheStoreConfig)
         assert result.cache_store.kv_cache_store_type == "radix_tree"
@@ -988,15 +1076,17 @@ class TestKVCAwareHydraNormal:
         Description: from_config with strategies in dict form
         Expectation: result.strategies is a list and element types/values are correct
         """
-        kwargs = OmegaConf.create({
-            "strategies": {
-                "kvc_aware": {
-                    "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                    "weight": 1.0,
-                    "collector_names": ["vllm_zmq"],
+        kwargs = OmegaConf.create(
+            {
+                "strategies": {
+                    "kvc_aware": {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 1.0,
+                        "collector_names": ["vllm_zmq"],
+                    },
                 },
-            },
-        })
+            }
+        )
         result = KVCAwareConfig.from_config(kwargs)
         assert isinstance(result.strategies, list)
         assert len(result.strategies) == 1
@@ -1016,16 +1106,22 @@ class TestKVCAwareHydraAbnormal:
         Description: from_config with a config containing router_class
         Expectation: result is KVCAwareConfig and fields exclude router_class
         """
-        kwargs = OmegaConf.create({
-            "router_class": "uni_agent.llm_router.balancer.KVCAwareBalancer",
-            "strategies": [
-                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
-            ],
-        })
+        kwargs = OmegaConf.create(
+            {
+                "router_class": "uni_agent.llm_router.balancer.KVCAwareBalancer",
+                "strategies": [
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 1.0,
+                        "collector_names": ["vllm_zmq"],
+                    },
+                ],
+            }
+        )
         result = KVCAwareConfig.from_config(kwargs)
         assert isinstance(result, KVCAwareConfig)
         import dataclasses
+
         field_names = {f.name for f in dataclasses.fields(result)}
         assert "router_class" not in field_names
 
@@ -1035,13 +1131,18 @@ class TestKVCAwareHydraAbnormal:
         Description: from_config with collector containing unknown_key
         Expectation: raises exception matching "unknown_key"
         """
-        kwargs = OmegaConf.create({
-            "strategies": [
-                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
-            ],
-            "collector": {"unknown_key": 123, "http_polling": {"polling_interval": 5}},
-        })
+        kwargs = OmegaConf.create(
+            {
+                "strategies": [
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 1.0,
+                        "collector_names": ["vllm_zmq"],
+                    },
+                ],
+                "collector": {"unknown_key": 123, "http_polling": {"polling_interval": 5}},
+            }
+        )
         with pytest.raises(Exception, match="unknown_key"):
             KVCAwareConfig.from_config(kwargs)
 
@@ -1051,20 +1152,27 @@ class TestKVCAwareHydraAbnormal:
         Description: from_config then call repr and inspect output
         Expectation: repr contains newline and starts with KVCAwareConfig(
         """
-        kwargs = OmegaConf.create({
-            "strategies": [
-                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                 "weight": 1.0, "collector_names": ["vllm_zmq", "mooncake_prometheus"]},
-            ],
-            "collector": {
-                "http_polling": {"polling_interval": 5, "http_timeout": 10},
-                "long_connection": {
-                    "base_retry_delay": 1.0, "max_retry_delay": 30.0,
-                    "max_retry_attempts": 5, "retry_backoff_factor": 2.0,
+        kwargs = OmegaConf.create(
+            {
+                "strategies": [
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 1.0,
+                        "collector_names": ["vllm_zmq", "mooncake_prometheus"],
+                    },
+                ],
+                "collector": {
+                    "http_polling": {"polling_interval": 5, "http_timeout": 10},
+                    "long_connection": {
+                        "base_retry_delay": 1.0,
+                        "max_retry_delay": 30.0,
+                        "max_retry_attempts": 5,
+                        "retry_backoff_factor": 2.0,
+                    },
                 },
-            },
-            "cache_store": {"kv_cache_store_type": "list", "ttl": 30},
-        })
+                "cache_store": {"kv_cache_store_type": "list", "ttl": 30},
+            }
+        )
         result = KVCAwareConfig.from_config(kwargs)
         r = repr(result)
         assert "\n" in r
@@ -1085,12 +1193,17 @@ class TestKVCAwareOther:
         Description: from_config with a config containing only strategies
         Expectation: collector/cache_store are their Config types
         """
-        kwargs = OmegaConf.create({
-            "strategies": [
-                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                 "weight": 1.0, "collector_names": ["vllm_zmq"]},
-            ],
-        })
+        kwargs = OmegaConf.create(
+            {
+                "strategies": [
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 1.0,
+                        "collector_names": ["vllm_zmq"],
+                    },
+                ],
+            }
+        )
         result = KVCAwareConfig.from_config(kwargs)
         assert isinstance(result.collector, CollectorConfig)
         assert isinstance(result.cache_store, CacheStoreConfig)
@@ -1101,14 +1214,22 @@ class TestKVCAwareOther:
         Description: from_config with a config containing two strategies
         Expectation: each strategy is a StrategyConfig instance
         """
-        kwargs = OmegaConf.create({
-            "strategies": [
-                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                 "weight": 0.7, "collector_names": ["vllm_zmq"]},
-                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                 "weight": 0.3, "collector_names": ["vllm_prometheus"]},
-            ],
-        })
+        kwargs = OmegaConf.create(
+            {
+                "strategies": [
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 0.7,
+                        "collector_names": ["vllm_zmq"],
+                    },
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 0.3,
+                        "collector_names": ["vllm_prometheus"],
+                    },
+                ],
+            }
+        )
         result = KVCAwareConfig.from_config(kwargs)
         for s in result.strategies:
             assert isinstance(s, StrategyConfig)
@@ -1120,10 +1241,12 @@ class TestKVCAwareOther:
         Expectation: all fields match the YAML config
         """
         from pathlib import Path
-        from hydra import initialize_config_dir, compose
 
-        config_dir = str((Path(__file__).parent.parent.parent.parent
-                          / "uni_agent" / "llm_router" / "configs").resolve())
+        from hydra import compose, initialize_config_dir
+
+        config_dir = str(
+            (Path(__file__).parent.parent.parent.parent / "uni_agent" / "llm_router" / "configs").resolve()
+        )
         with initialize_config_dir(config_dir=config_dir, version_base=None):
             cfg = compose(config_name="kvc_aware_router")
 
@@ -1143,8 +1266,10 @@ class TestKVCAwareOther:
         assert strategy.collector_names == ["vllm_zmq", "vllm_metrics"]
         assert result.collector.http_polling == {"polling_interval": 5.0, "http_timeout": 10.0}
         assert result.collector.long_connection == {
-            "base_retry_delay": 1.0, "max_retry_delay": 30.0,
-            "max_retry_attempts": 5, "retry_backoff_factor": 2.0,
+            "base_retry_delay": 1.0,
+            "max_retry_delay": 30.0,
+            "max_retry_attempts": 5,
+            "retry_backoff_factor": 2.0,
         }
 
         # ── cache_store ──
@@ -1166,24 +1291,31 @@ class TestDropInIntegration:
     verl/tests/workers/rollout/test_router.py.
     """
 
-    def _make_full_config(self) -> "OmegaConf":
+    def _make_full_config(self) -> OmegaConf:
         """Helper: build a full config for drop-in tests."""
-        return OmegaConf.create({
-            "router_class": "uni_agent.llm_router.balancer.KVCAwareBalancer",
-            "strategies": [
-                {"_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
-                 "weight": 1.0, "alpha": 0.7, "collector_names": ["vllm_zmq", "mooncake_prometheus"]},
-            ],
-            "collector": {
-                "http_polling": {"polling_interval": 5, "http_timeout": 10},
-                "long_connection": {
-                    "base_retry_delay": 1.0, "max_retry_delay": 30.0,
-                    "max_retry_attempts": 5, "retry_backoff_factor": 2.0,
+        return OmegaConf.create(
+            {
+                "router_class": "uni_agent.llm_router.balancer.KVCAwareBalancer",
+                "strategies": [
+                    {
+                        "_target_": "uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig",
+                        "weight": 1.0,
+                        "alpha": 0.7,
+                        "collector_names": ["vllm_zmq", "mooncake_prometheus"],
+                    },
+                ],
+                "collector": {
+                    "http_polling": {"polling_interval": 5, "http_timeout": 10},
+                    "long_connection": {
+                        "base_retry_delay": 1.0,
+                        "max_retry_delay": 30.0,
+                        "max_retry_attempts": 5,
+                        "retry_backoff_factor": 2.0,
+                    },
                 },
-
-            },
-            "cache_store": {"kv_cache_store_type": "list", "ttl": 30},
-        })
+                "cache_store": {"kv_cache_store_type": "list", "ttl": 30},
+            }
+        )
 
     def test_d05_compose_expands_defaults(self):
         """
@@ -1192,10 +1324,12 @@ class TestDropInIntegration:
         Expectation: strategies/collector/cache_store/router_class all present
         """
         from pathlib import Path
-        from hydra import initialize_config_dir, compose
 
-        config_dir = str((Path(__file__).parent.parent.parent.parent
-                          / "uni_agent" / "llm_router" / "configs").resolve())
+        from hydra import compose, initialize_config_dir
+
+        config_dir = str(
+            (Path(__file__).parent.parent.parent.parent / "uni_agent" / "llm_router" / "configs").resolve()
+        )
         with initialize_config_dir(config_dir=config_dir, version_base=None):
             cfg = compose(config_name="kvc_aware_router")
         assert "strategies" in cfg and "collector" in cfg and "cache_store" in cfg
@@ -1226,7 +1360,7 @@ class TestDropInIntegration:
         cfg = self._make_full_config()
         result = KVCAwareConfig.from_config(cfg)
         s = result.strategies[0]
-        assert type(s) == KVCAwareStrategyConfig
+        assert type(s) is KVCAwareStrategyConfig
         assert s.collector_names == ["vllm_zmq", "mooncake_prometheus"]
         assert s.weight == 1.0
 
@@ -1239,6 +1373,7 @@ class TestDropInIntegration:
         cfg = self._make_full_config()
         result = KVCAwareConfig.from_config(cfg)
         import dataclasses
+
         field_names = {f.name for f in dataclasses.fields(result)}
         assert "router_class" not in field_names
         assert not hasattr(result, "router_class")
@@ -1271,11 +1406,13 @@ class TestDropInIntegration:
         Expectation: all field types/values are correct and router_class is ignored
         """
         from pathlib import Path
-        from hydra import initialize_config_dir, compose
+
+        from hydra import compose, initialize_config_dir
         from hydra.core.global_hydra import GlobalHydra
 
-        config_dir = str((Path(__file__).parent.parent.parent.parent
-                          / "uni_agent" / "llm_router" / "configs").resolve())
+        config_dir = str(
+            (Path(__file__).parent.parent.parent.parent / "uni_agent" / "llm_router" / "configs").resolve()
+        )
 
         GlobalHydra.instance().clear()
         with initialize_config_dir(config_dir=config_dir, version_base=None):
@@ -1303,4 +1440,5 @@ class TestDropInIntegration:
         assert result.cache_store.ttl == 30.0
         # router_class does not appear in KVCAwareConfig fields
         import dataclasses
+
         assert "router_class" not in {f.name for f in dataclasses.fields(result)}

--- a/uni_agent/deployment/__init__.py
+++ b/uni_agent/deployment/__init__.py
@@ -6,6 +6,7 @@ from .config import (
     LocalAttachDeploymentConfig,
     LocalDeploymentConfig,
     LocalNativeDeploymentConfig,
+    SimulatedDeploymentConfig,
     ModalDeploymentConfig,
     VefaasDeploymentConfig,
 )
@@ -15,6 +16,7 @@ _LAZY_EXPORTS = {
     "LocalAttachDeployment": ".local_attach.deployment",
     "LocalDeployment": ".local.deployment",
     "LocalNativeDeployment": ".local_native.deployment",
+    "SimulatedDeployment": ".simulated.deployment",
     "ModalDeployment": ".modal.deployment",
     "VefaasDeployment": ".vefaas.deployment",
 }
@@ -25,12 +27,14 @@ __all__ = [
     "LocalAttachDeploymentConfig",
     "LocalDeploymentConfig",
     "LocalNativeDeploymentConfig",
+    "SimulatedDeploymentConfig",
     "ModalDeploymentConfig",
     "VefaasDeploymentConfig",
     "HostDeployment",
     "LocalAttachDeployment",
     "LocalDeployment",
     "LocalNativeDeployment",
+    "SimulatedDeployment",
     "ModalDeployment",
     "VefaasDeployment",
 ]

--- a/uni_agent/deployment/config.py
+++ b/uni_agent/deployment/config.py
@@ -3,6 +3,8 @@ from typing import Annotated, Any, Literal, TypeAlias
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from .simulated.config import SimulatedDeploymentConfig
+
 
 class HostDeploymentConfig(BaseModel):
     """Configuration for host-local execution (no container)."""
@@ -187,6 +189,7 @@ DeployConfig: TypeAlias = Annotated[
     | LocalAttachDeploymentConfig
     | HostDeploymentConfig
     | LocalNativeDeploymentConfig
-    | ModalDeploymentConfig,
+    | ModalDeploymentConfig
+    | SimulatedDeploymentConfig,
     Field(discriminator="type"),
 ]

--- a/uni_agent/deployment/simulated/config.py
+++ b/uni_agent/deployment/simulated/config.py
@@ -1,0 +1,68 @@
+"""Config for the simulated sandbox deployment.
+
+``SimulatedDeploymentConfig`` is the ``type: simulated`` member of the ``DeployConfig``
+discriminated union -- selectable from ``agent_config`` exactly like
+host/local/modal. It carries the tunables that control SimulatedRuntime's
+observation sampling (seed/scale), plus the failure-simulation knobs.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TimeoutSimConfig(BaseModel):
+    """Command-timeout simulation. When enabled, a run_in_session call may
+    sleep ``delay_seconds`` then raise swerex's ``CommandTimeoutError`` so
+    ``AgentEnv`` exercises its real timeout/interrupt/timeout_budget path."""
+
+    enabled: bool = False
+    probability: float = Field(default=0.05, ge=0.0, le=1.0)
+    delay_seconds: float = Field(default=0.5, ge=0.0)
+
+
+class TerminalDeadConfig(BaseModel):
+    """Terminal-death simulation. When enabled, a run_in_session call may
+    raise swerex's ``TerminalNotAliveError`` so the episode exits via the
+    real ``terminal_dead`` path."""
+
+    enabled: bool = False
+    probability: float = Field(default=0.01, ge=0.0, le=1.0)
+
+
+class SimulatedDeploymentConfig(BaseModel):
+    """Configuration for the simulated (CPU-only, canned-observation) deployment.
+
+    Used for performance testing: the LLM runs for real, the sandbox is
+    stubbed. Observation sizes/structure follow hand-tuned representative
+    templates (see ``simulated/deployment.py``).
+    """
+
+    type: Literal["simulated"] = "simulated"
+    """Discriminator for (de)serialization. Do not change."""
+
+    seed: int | None = None
+    """Sampling seed. ``None`` (default) = random sampling each run; an int =
+    reproducible sampling (same command sequence -> identical outputs)."""
+
+    observation_scale: float = Field(default=1.0, ge=0.0)
+    """Multiplier applied to every template's length. 1.0 = as-authored;
+    use >1 to stress KV/prefill load."""
+
+    timeout: TimeoutSimConfig = Field(default_factory=TimeoutSimConfig)
+    terminal_dead: TerminalDeadConfig = Field(default_factory=TerminalDeadConfig)
+
+    # ``extra="ignore"`` (NOT "forbid"): swebench datasets carry per-sample
+    # ``extra_info.tools_kwargs`` overrides for the docker path (image, command,
+    # container_runtime, ...). The agent loop deep-merges these onto the YAML
+    # deployment block, so SimulatedDeploymentConfig receives docker-only keys it
+    # doesn't model. Ignoring them lets the same dataset drive both local and
+    # simulated deployments without a per-sample schema fork.
+    model_config = ConfigDict(extra="ignore")
+
+    def get_deployment(self, run_id: str):
+        from .deployment import SimulatedDeployment
+
+        return SimulatedDeployment.from_config(self, run_id)

--- a/uni_agent/deployment/simulated/deployment.py
+++ b/uni_agent/deployment/simulated/deployment.py
@@ -1,0 +1,427 @@
+"""Simulated sandbox deployment for performance testing.
+
+The LLM (vLLM replicas + router) runs for real; only the sandbox
+(docker/swe-rex bash execution) is stubbed. ``SimulatedRuntime`` implements
+swerex's ``AbstractRuntime`` so the entire production code path
+(``AgentEnv`` -> tools install -> ``run_action``) runs unmodified -- only
+the leaf bash execution returns a representative canned observation.
+
+Built test-first. Two responsibilities so far: the command router
+(``_route``) and observation rendering with reproducible seeding.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import random
+import re
+
+from swerex.runtime.abstract import (
+    AbstractRuntime,
+    BashAction,
+    BashInterruptAction,
+    Observation,
+)
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+# Patterns checked in order; first match wins. The command string is the bash
+# that ``tools_manager.get_tool_bash_command`` emits (see findings.md).
+#
+# Install-phase commands (which/export/chmod/mkdir/pip) must route to
+# ``install`` so they no-op successfully and ``AgentEnv.install_tools`` passes.
+_ROUTE_RULES: list[tuple[str, re.Pattern[str]]] = [
+    ("finish", re.compile(r"""echo\s+['"]<<<Finished>>>['"]""")),
+    ("install", re.compile(r"^(which|export|chmod|mkdir|pip|pip3)\b")),
+    ("install", re.compile(r"\bpip3?\s+install\b")),
+    ("install", re.compile(r"\bpython\d?\s+-m\s+pip\b")),
+    ("editor:view", re.compile(r"^str_replace_editor\b.*--command\s+view\b")),
+    ("editor:create", re.compile(r"^str_replace_editor\b.*--command\s+create\b")),
+    ("editor:str_replace", re.compile(r"^str_replace_editor\b.*--command\s+str_replace\b")),
+    ("editor:insert", re.compile(r"^str_replace_editor\b.*--command\s+insert\b")),
+    ("editor:undo_edit", re.compile(r"^str_replace_editor\b.*--command\s+undo_edit\b")),
+    ("test_output", re.compile(r"^(\S*python\S*\s+-m\s+pytest\b|^pytest\b)")),
+    ("python_script", re.compile(r"^python\d?\s")),
+    ("listing", re.compile(r"^(find|ls)\b")),
+    ("search", re.compile(r"^grep\b")),
+    ("file_view", re.compile(r"^(cat|head|tail)\b")),
+]
+
+
+# ---------------------------------------------------------------------------
+# Template pool
+# ---------------------------------------------------------------------------
+# Each route key -> list of (weight, text). Weights are hand-tuned to a
+# realistic success:failure ratio (~8:2) and length spread -- NOT copied from
+# the run logs, whose frequency is polluted by an unrelated KV-memory bug
+# (see findings.md). Text structure follows real SWE-bench samples.
+#
+# finish / install are fixed single outputs (not sampled).
+
+_FINISH_OUTPUT = "<<<Finished>>>"
+
+_TEMPLATES: dict[str, list[tuple[int, str]]] = {
+    "editor:view": [
+        (3, "Here's the result of running `cat -n` on /testbed/x.py:\n"
+            "     1\timport os\n"
+            "     2\t\n"
+            "     3\tclass Filter:\n"
+            "     4\t    def __init__(self, model):\n"
+            "     5\t        self.model = model\n"),
+        (2, "Here's the result of running `cat -n` on /testbed/models.py:\n"
+            "     1\tclass Model:\n"
+            "     2\t    objects = Manager()\n"),
+    ],
+    "editor:create": [
+        (5, "File created successfully at: /testbed/reproduce_issue.py"),
+        (1, "ERROR: file already exists at /testbed/x.py. Use str_replace to edit it."),
+    ],
+    "editor:str_replace": [
+        (4, "The file /testbed/x.py has been edited. Here's the result of running `cat -n` on a snippet:\n"
+            "    10\t    def filter(self, qs):\n"
+            "    11\t        return qs\n"),
+        (1, "ERROR: old_str was not found in /testbed/x.py. Make sure it matches exactly."),
+    ],
+    "editor:insert": [
+        (5, "The file /testbed/x.py has been edited. Inserted text after line 11."),
+    ],
+    "editor:undo_edit": [
+        (5, "Last edit to /testbed/x.py has been reverted."),
+    ],
+    "test_output": [
+        (4, "============================= test session starts ==============================\n"
+            "platform linux -- Python 3.9.20, pytest-7.4.0\n"
+            "rootdir: /testbed\n"
+            "collected 5 items\n\n"
+            "tests/test_x.py .....                                                 [100%]\n\n"
+            "============================== 5 passed in 2.13s ===============================\n"),
+        (3, "============================= test session starts ==============================\n"
+            "collected 5 items\n\n"
+            "tests/test_x.py ..F..                                                [100%]\n\n"
+            "=================================== FAILURES ===================================\n"
+            "_____________________________ test_third ______________________________________\n"
+            "    assert result == expected\n"
+            "E   AssertionError: assert 3 == 5\n"
+            "=========================== short test summary info ===========================\n"
+            "FAILED tests/test_x.py::test_third - AssertionError: assert 3 == 5\n"
+            "========================= 1 failed, 4 passed in 2.10s ==========================\n"),
+    ],
+    "python_script": [
+        (5, "ok\n"),
+        (2, "Traceback (most recent call last):\n"
+            "  File \"/testbed/reproduce_issue.py\", line 5, in <module>\n"
+            "    obj = load(path)\n"
+            "  File \"/testbed/pkg/loader.py\", line 21, in load\n"
+            "    return _read(path)\n"
+            "FileNotFoundError: [Errno 2] No such file or directory: '/testbed/data.bin'\n"),
+        (1, "/bin/bash: line 1: python: command not found\n"),
+    ],
+    "listing": [
+        (3, "/testbed/setup.py\n/testbed/pkg/__init__.py\n/testbed/pkg/models.py\n/testbed/pkg/views.py\n"),
+        (1, "/testbed\n"),
+    ],
+    "search": [
+        (3, "/testbed/x.py:12:    def filter(self, qs):\n/testbed/y.py:40:    qs = filter(qs)\n"),
+        (2, "Your command ran successfully and did not produce any output.\n"),
+    ],
+    "file_view": [
+        (3, "import os\n\n\nclass Model:\n    pass\n"),
+        (1, "cat: /testbed/x.py: No such file or directory\n"),
+    ],
+    "default": [
+        (4, "Your command ran successfully and did not produce any output.\n"),
+        (1, "done\n"),
+    ],
+}
+
+
+# Bundled YAML (real-sample structure, hand-tuned weights). Resolved relative
+# to this file so it works regardless of CWD.
+_DEFAULT_TEMPLATES_PATH = os.path.join(os.path.dirname(__file__), "observations.yaml")
+
+
+def load_templates(path: str | None = None) -> dict[str, list[tuple[int, str]]]:
+    """Load the observation template pool from YAML.
+
+    Schema: ``route_key -> [{weight: int, text: str}, ...]``. ``path=None`` loads
+    the bundled default. Falls back to the in-source ``_TEMPLATES`` only if the
+    YAML is unreadable, so a missing/corrupt file never crashes a perf run.
+    """
+    import yaml
+
+    target = path or _DEFAULT_TEMPLATES_PATH
+    try:
+        raw = yaml.safe_load(_read_text(target))
+    except (OSError, yaml.YAMLError):
+        return {k: list(v) for k, v in _TEMPLATES.items()}
+    pool: dict[str, list[tuple[int, str]]] = {}
+    for key, entries in (raw or {}).items():
+        out: list[tuple[int, str]] = []
+        for entry in entries:
+            out.append((int(entry["weight"]), str(entry["text"])))
+        pool[key] = out
+    return pool
+
+
+def _read_text(path: str) -> str:
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def _scale_text(text: str, scale: float) -> str:
+    """Stretch (or shrink) ``text`` toward ``len(text) * scale`` chars.
+
+    Grown by repeating a clean newline-terminated block; shrunk by truncating
+    on a line boundary. A no-op at scale == 1.0.
+    """
+    if scale <= 0:
+        return ""
+    target = int(len(text) * scale)
+    if target <= len(text):
+        return text[:target].rsplit("\n", 1)[0]
+    if not text:
+        return text
+    block = text if text.endswith("\n") else text + "\n"
+    reps = max(1, target // max(1, len(block)) + 1)
+    grown = (block * reps)[:target]
+    if not grown.endswith("\n"):
+        grown = grown.rsplit("\n", 1)[0]
+    return grown
+
+
+class SimulatedRuntime(AbstractRuntime):
+    """CPU-only runtime that returns canned observations by routing the
+    command string. Subclassed from ``AbstractRuntime`` for protocol
+    compatibility; no real session is created."""
+
+    def __init__(
+        self,
+        run_id: str = "simulated",
+        *,
+        seed: int | None = None,
+        observation_scale: float = 1.0,
+        templates: dict[str, list[tuple[int, str]]] | None = None,
+        templates_path: str | None = None,
+        timeout: "TimeoutSimConfig | None" = None,
+        terminal_dead: "TerminalDeadConfig | None" = None,
+    ) -> None:
+        from .config import TerminalDeadConfig, TimeoutSimConfig
+
+        self.run_id = run_id
+        self._seed = seed
+        self.observation_scale = observation_scale
+        # Precedence: explicit dict > explicit yaml path > bundled default yaml.
+        if templates is not None:
+            self._templates = templates
+        elif templates_path is not None:
+            self._templates = load_templates(templates_path)
+        else:
+            self._templates = load_templates()
+        self._timeout_cfg = timeout or TimeoutSimConfig()
+        self._terminal_dead_cfg = terminal_dead or TerminalDeadConfig()
+        # Failure state: once the terminal "dies" it stays dead -- every later
+        # run_in_session (including env.py's liveness probe) returns no marker,
+        # which is what makes env.py raise TerminalNotAliveError.
+        self._dead = False
+        # One independent RNG stream per route key, derived from
+        # (global_seed, route_key). Same seed -> same per-key streams ->
+        # reproducible sampling, without one command type's draws perturbing
+        # another's. Failure modes get their own dedicated streams so timeout
+        # and terminal_dead patterns are mutually reproducible/independent.
+        self._rngs: dict[str, random.Random] = {}
+        for key in self._templates:
+            self._rngs[key] = random.Random(self._derive_seed(key))
+        self._timeout_rng = random.Random(self._derive_seed("__timeout__"))
+        self._dead_rng = random.Random(self._derive_seed("__terminal_dead__"))
+
+    def _derive_seed(self, key: str) -> int | None:
+        if self._seed is None:
+            return None
+        digest = hashlib.sha256(f"{self._seed}:{key}".encode()).digest()
+        return int.from_bytes(digest[:8], "big")
+
+    def _route(self, command: str) -> str:
+        """Map a bash command string to a route key (a template group).
+
+        Pure function of ``command``: same command always yields the same
+        key. Order matters -- ``python -m pip install`` must hit ``install``
+        before ``python_script``; ``str_replace_editor --command`` variants
+        are split by subcommand.
+        """
+        stripped = command.strip()
+        for key, pattern in _ROUTE_RULES:
+            if pattern.search(stripped):
+                return key
+        return "default"
+
+    def _render(self, route_key: str) -> str:
+        """Sample a representative observation for ``route_key``.
+
+        Fixed keys (finish/install) return constants; others sample by weight
+        from the template pool, then apply ``observation_scale``.
+        """
+        if route_key == "finish":
+            return _FINISH_OUTPUT
+        if route_key == "install":
+            return ""
+        pool = self._templates.get(route_key)
+        if not pool:
+            # Unknown route key (e.g. an editor subcommand we didn't model):
+            # fall back to the default pool rather than crash.
+            pool = self._templates.get("default", [(1, "")])
+        weights = [w for w, _ in pool]
+        texts = [t for _, t in pool]
+        rng = self._rngs.get(route_key)
+        if rng is None:
+            # A route key with no prebuilt stream (templates overridden to add
+            # a new key): build an ephemeral one so sampling still works.
+            rng = random.Random(self._derive_seed(route_key))
+        text = rng.choices(texts, weights=weights, k=1)[0]
+        return _scale_text(text, self.observation_scale)
+
+    async def run_in_session(self, action) -> Observation:
+        import asyncio
+
+        from swerex.exceptions import CommandTimeoutError
+
+        if isinstance(action, BashInterruptAction):
+            # A dead terminal cannot accept an interrupt either -- this is what
+            # pushes env.py out of its interrupt_session() happy path and into
+            # the liveness-probe branch that raises TerminalNotAliveError.
+            if self._dead:
+                from swerex.exceptions import CommandTimeoutError
+
+                raise CommandTimeoutError("simulated: terminal dead, interrupt unresponsive")
+            return Observation(output="", exit_code=130)
+        if not isinstance(action, BashAction):
+            raise TypeError(f"Unsupported action type: {type(action)}")
+        route_key = self._route(action.command)
+
+        # Once the terminal is dead, every call (including env.py's liveness
+        # probe ``echo 'terminal still alive'``) returns no marker -> env.py
+        # concludes the terminal is dead and raises TerminalNotAliveError.
+        if self._dead:
+            return Observation(output="", exit_code=1)
+
+        # Failure simulation only applies to real tool commands, not the
+        # install/finish phase (which must stay reliable so install_tools
+        # passes and submit terminates cleanly).
+        if route_key not in ("install", "finish"):
+            # terminal_dead: model it as a hung command. Time out (which makes
+            # env.py probe liveness), then stay dead so the probe fails.
+            if self._terminal_dead_cfg.enabled and self._dead_rng.random() < self._terminal_dead_cfg.probability:
+                self._dead = True
+                raise CommandTimeoutError("simulated: terminal died (command hung)")
+            # timeout: recoverable. Sleep to mimic real bash wall-clock, then
+            # raise so env.py decrements timeout_budget.
+            if self._timeout_cfg.enabled and self._timeout_rng.random() < self._timeout_cfg.probability:
+                if self._timeout_cfg.delay_seconds > 0:
+                    await asyncio.sleep(self._timeout_cfg.delay_seconds)
+                raise CommandTimeoutError("simulated: simulated command timeout")
+
+        output = self._render(route_key)
+        return Observation(output=output, exit_code=0)
+
+    # --- AbstractRuntime protocol stubs (filled by later TDD cycles) ---------
+    async def create_session(self, request):  # pragma: no cover - stub
+        return None
+
+    async def execute(self, command):  # pragma: no cover - stub
+        from swerex.runtime.abstract import CommandResponse
+
+        return CommandResponse(stdout="", stderr="", exit_code=0)
+
+    async def upload(self, request):  # pragma: no cover - stub
+        from swerex.runtime.abstract import UploadResponse
+
+        return UploadResponse()
+
+    async def read_file(self, request):  # pragma: no cover - stub
+        from swerex.runtime.abstract import ReadFileResponse
+
+        return ReadFileResponse(content="")
+
+    async def write_file(self, request):  # pragma: no cover - stub
+        from swerex.runtime.abstract import WriteFileResponse
+
+        return WriteFileResponse()
+
+    async def is_alive(self, *, timeout=None):  # pragma: no cover - stub
+        from swerex.runtime.abstract import IsAliveResponse
+
+        return IsAliveResponse(is_alive=True)
+
+    async def close_session(self, request):  # pragma: no cover - stub
+        from swerex.runtime.abstract import CloseSessionResponse
+
+        return CloseSessionResponse()
+
+    async def close(self):  # pragma: no cover - stub
+        from swerex.runtime.abstract import CloseResponse
+
+        return CloseResponse()
+
+
+class SimulatedDeployment:
+    """Deployment wrapper around :class:`SimulatedRuntime`.
+
+    Implements swerex's ``AbstractDeployment`` protocol (structurally) so
+    ``AgentEnv`` drives it exactly like docker/modal/etc. ``start()`` does
+    nothing real -- no process, no docker, no swe-rex -- it just marks the
+    runtime ready. The configured seed/scale flow into the SimulatedRuntime so
+    sampling is reproducible before any command runs.
+    """
+
+    def __init__(
+        self,
+        run_id: str,
+        *,
+        seed: int | None = None,
+        observation_scale: float = 1.0,
+        timeout=None,
+        terminal_dead=None,
+    ) -> None:
+        self.run_id = run_id
+        self._runtime = SimulatedRuntime(
+            run_id=run_id,
+            seed=seed,
+            observation_scale=observation_scale,
+            timeout=timeout,
+            terminal_dead=terminal_dead,
+        )
+        self._started = False
+
+    @classmethod
+    def from_config(cls, config, run_id: str | None = None) -> "SimulatedDeployment":
+        return cls(
+            run_id=run_id or "simulated",
+            seed=config.seed,
+            observation_scale=config.observation_scale,
+            timeout=config.timeout,
+            terminal_dead=config.terminal_dead,
+        )
+
+    def add_hook(self, hook):  # pragma: no cover - protocol no-op
+        pass
+
+    async def start(self, max_retries: int = 5) -> None:
+        self._started = True
+
+    async def stop(self) -> None:
+        self._started = False
+
+    async def is_alive(self, *, timeout=None):
+        from swerex.runtime.abstract import IsAliveResponse
+
+        return IsAliveResponse(is_alive=self._started)
+
+    @property
+    def runtime(self) -> SimulatedRuntime:
+        if not self._started:
+            from swerex.exceptions import DeploymentNotStartedError
+
+            raise DeploymentNotStartedError()
+        return self._runtime
+

--- a/uni_agent/deployment/simulated/observations.yaml
+++ b/uni_agent/deployment/simulated/observations.yaml
@@ -1,0 +1,409 @@
+# Simulated sandbox observation templates.
+#
+# Structure: route_key -> list of {weight, text}. Sampling is weighted; weights
+# are HAND-TUNED. Text STRUCTURE follows real SWE-bench samples (pytest banner,
+# python traceback, find listing, editor cat -n).
+#
+# Design notes:
+# - pytest (test_output) is weighted HEAVILY toward success (~8:2). Real agent
+#   loops that see tests pass tend to submit (finished) rather than spin to the
+#   max_turns limit, so a high pass rate yields a more realistic trajectory
+#   length distribution for perf testing.
+# - Each key has MANY diverse entries (varied file names / paths / function
+#   names) to reduce token-block repetition across trajectories, so prefix-cache
+#   hit doesn't read artificially high. Long-tail (very large) entries are kept
+#   at low weight to model real accidental dumps.
+# - Tunable at perf time: raise a weight, add entries. observation_scale
+#   (in SimulatedRuntime) multiplies every entry's length globally.
+
+# ---------------------------------------------------------------------------
+# pytest / test runs -- ~80% success so models reach `submit` (finished).
+# ---------------------------------------------------------------------------
+test_output:
+  - weight: 6
+    text: |-
+      ============================= test session starts ==============================
+      platform linux -- Python 3.9.20, pytest-7.4.0, pluggy-1.3.0
+      rootdir: /testbed
+      collecting ... collected 5 items
+
+      tests/test_filters.py .....                                            [100%]
+
+      =============================== 5 passed in 2.13s ===============================
+  - weight: 5
+    text: |-
+      ============================= test session starts ==============================
+      platform linux -- Python 3.9.20, pytest-7.4.0
+      rootdir: /testbed
+      collecting ... collected 12 items
+
+      tests/test_models.py ............                                      [100%]
+
+      ============================== 12 passed in 3.41s ==============================
+  - weight: 4
+    text: |-
+      ============================= test session starts ==============================
+      collecting ... collected 8 items
+
+      tests/test_views.py ........                                           [100%]
+
+      =============================== 8 passed in 1.87s ===============================
+  - weight: 4
+    text: |-
+      ============================= test session starts ==============================
+      collecting ... collected 3 items
+
+      tests/test_admin.py ...                                                [100%]
+
+      =============================== 3 passed in 0.92s ===============================
+  - weight: 3
+    text: |-
+      ============================= test session starts ==============================
+      collecting ... collected 10 items
+
+      tests/test_utils.py ..........                                         [100%]
+
+      -------- coverage: platform linux, python 3.9.20 --------
+      ============================== 10 passed in 2.55s ==============================
+  - weight: 3
+    text: |-
+      ============================= test session starts ==============================
+      collecting ... collected 6 items
+
+      tests/test_forms.py ....s.                                             [100%]
+      ========================= 5 passed, 1 skipped in 1.44s ========================
+  - weight: 3
+    text: "PASSED tests/test_query.py::test_ordering\nPASSED tests/test_query.py::test_filtering\nPASSED tests/test_query.py::test_distinct\n3 passed"
+  - weight: 2
+    text: |-
+      ============================= test session starts ==============================
+      collecting ... collected 9 items
+
+      tests/test_serializers.py ........F                                    [100%]
+      =================================== FAILURES ===================================
+      ______________________________ test_to_representation __________________________
+          def test_to_representation(self):
+              data = Serializer(instance).data
+      >       assert data['name'] == 'expected'
+      E       AssertionError: assert 'got' == 'expected'
+      =========================== short test summary info ===========================
+      FAILED tests/test_serializers.py::test_to_representation - AssertionError
+      ========================= 1 failed, 8 passed in 2.20s ==========================
+  - weight: 1
+    text: |-
+      ============================= test session starts ==============================
+      collecting ... collected 0 items
+      ============================ no tests ran in 0.02s =============================
+      ERROR: file or directory not found: tests/test_missing.py
+  - weight: 1
+    text: |-
+      ============================= test session starts ==============================
+      collecting ... collected 15 items
+
+      tests/test_pipeline.py FFFFFFFFFFFFFFFF.                               [100%]
+      ImportError: cannot import name 'RelatedFieldListFilter'
+
+# ---------------------------------------------------------------------------
+# editor view -- many distinct file contents to cut block repetition.
+# ---------------------------------------------------------------------------
+editor:view:
+  - weight: 3
+    text: |-
+      Here's the result of running `cat -n` on /testbed/views.py:
+           1	from django.shortcuts import render
+           2	from .models import Article
+           3
+           4
+           5	def list_view(request):
+           6	    qs = Article.objects.all().order_by('-published')
+           7	    return render(request, 'list.html', {'articles': qs})
+  - weight: 3
+    text: |-
+      Here's the result of running `cat -n` on /testbed/models.py:
+           1	from django.db import models
+           2
+           3
+           4	class Author(models.Model):
+           5	    name = models.CharField(max_length=100)
+           6	    email = models.EmailField(unique=True)
+           7
+           8	    def __str__(self):
+           9	        return self.name
+  - weight: 3
+    text: |-
+      Here's the result of running `cat -n` on /testbed/filters.py:
+           1	from django.contrib.admin import ListFilter
+           2
+           3
+           4	class RelatedFieldListFilter(ListFilter):
+           5	    def __init__(self, field, request, params, model, model_admin, field_path):
+           6	        self.ordering = model_admin.ordering or ()
+           7	        super().__init__(field, request, params, model, model_admin, field_path)
+           8
+           9	    def field_choices(self, field, request, model_admin):
+          10	        ordering = self.field_admin_ordering(field, request, model_admin)
+          11	        return field.get_choices(include_blank=False, ordering=ordering)
+  - weight: 3
+    text: |-
+      Here's the result of running `cat -n` on /testbed/admin.py:
+           1	from django.contrib import admin
+           2	from .models import Author, Article
+           3
+           4
+           5	@admin.register(Article)
+           6	class ArticleAdmin(admin.ModelAdmin):
+           7	    list_display = ('title', 'author', 'published')
+           8	    ordering = ('-published',)
+  - weight: 3
+    text: |-
+      Here's the result of running `cat -n` on /testbed/utils.py:
+           1	import hashlib
+           2	import re
+           3
+           4
+           5	def slugify(value):
+           6	    value = re.sub(r'[^\w\s-]', '', value).strip().lower()
+           7	    return re.sub(r'[-\s]+', '-', value)
+           8
+           9
+          10	def checksum(data):
+          11	    return hashlib.sha256(data.encode()).hexdigest()
+  - weight: 2
+    text: |-
+      Here's the result of running `cat -n` on /testbed/forms.py:
+           1	from django import forms
+           2	from .models import Comment
+           3
+           4
+           5	class CommentForm(forms.ModelForm):
+           6	    class Meta:
+           7	        model = Comment
+           8	        fields = ('body',)
+  - weight: 2
+    text: |-
+      Here's the result of running `cat -n` on /testbed/serializers.py:
+           1	from rest_framework import serializers
+           2	from .models import Article
+           3
+           4
+           5	class ArticleSerializer(serializers.ModelSerializer):
+           6	    author_name = serializers.ReadOnlyField(source='author.name')
+           7
+           8	    class Meta:
+           9	        model = Article
+          10	        fields = '__all__'
+  - weight: 2
+    text: |-
+      Here's the result of running `cat -n` on /testbed/urls.py:
+           1	from django.urls import path
+           2	from . import views
+           3
+           4
+           5	urlpatterns = [
+           6	    path('articles/', views.list_view, name='article-list'),
+           7	    path('articles/<int:pk>/', views.detail_view, name='article-detail'),
+           8	]
+  - weight: 2
+    text: |-
+      Here's the result of running `cat -n` on /testbed/settings.py:
+           1	DEBUG = True
+           2	INSTALLED_APPS = [
+           3	    'django.contrib.admin',
+           4	    'django.contrib.auth',
+           5	    'blog',
+           6	]
+           7	DATABASES = {'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': 'db.sqlite3'}}
+  - weight: 2
+    text: |-
+      Here's the result of running `cat -n` on /testbed/middleware.py:
+           1	import time
+           2
+           3
+           4	class TimingMiddleware:
+           5	    def __init__(self, get_response):
+           6	        self.get_response = get_response
+           7
+           8	    def __call__(self, request):
+           9	        start = time.perf_counter()
+          10	        response = self.get_response(request)
+          11	        response['X-Duration'] = f'{time.perf_counter() - start:.4f}'
+          12	        return response
+  - weight: 1
+    text: "ERROR: No such file or directory: /testbed/missing.py"
+
+# ---------------------------------------------------------------------------
+# editor create -- mostly success.
+# ---------------------------------------------------------------------------
+editor:create:
+  - weight: 8
+    text: "File created successfully at: /testbed/reproduce_issue.py"
+  - weight: 4
+    text: "File created successfully at: /testbed/fix_patch.py"
+  - weight: 2
+    text: "ERROR: file already exists at /testbed/x.py. Use str_replace to edit it instead."
+
+# ---------------------------------------------------------------------------
+# editor edits -- mostly success with varied confirmations.
+# ---------------------------------------------------------------------------
+editor:str_replace:
+  - weight: 5
+    text: |-
+      The file /testbed/filters.py has been edited. Here's the result of running `cat -n` on a snippet:
+          10	    def field_choices(self, field, request, model_admin):
+          11	        ordering = self.field_admin_ordering(field, request, model_admin)
+          12	        return field.get_choices(include_blank=False, ordering=ordering)
+  - weight: 5
+    text: |-
+      The file /testbed/views.py has been edited. Here's the result of running `cat -n` on a snippet:
+           5	def list_view(request):
+           6	    qs = Article.objects.filter(published=True).order_by('-published')
+           7	    return render(request, 'list.html', {'articles': qs})
+  - weight: 4
+    text: "The file /testbed/models.py has been edited. Here's the result of running `cat -n` on a snippet:\n    10\t    ordering = ('name',)"
+  - weight: 4
+    text: |-
+      The file /testbed/utils.py has been edited. Here's the result of running `cat -n` on a snippet:
+           5	def slugify(value):
+           6	    value = value.strip().lower()
+           7	    return value
+  - weight: 1
+    text: "ERROR: old_str was not found in /testbed/x.py. Make sure it matches exactly and is unique."
+
+editor:insert:
+  - weight: 8
+    text: "The file /testbed/views.py has been edited. Inserted text after line 11."
+  - weight: 4
+    text: "The file /testbed/models.py has been edited. Inserted text after line 7."
+  - weight: 1
+    text: "ERROR: insert_line out of range for /testbed/x.py."
+
+editor:undo_edit:
+  - weight: 9
+    text: "Last edit to /testbed/views.py has been reverted."
+  - weight: 1
+    text: "ERROR: nothing to undo for /testbed/x.py."
+
+# ---------------------------------------------------------------------------
+# python script -- mostly small successful output.
+# ---------------------------------------------------------------------------
+python_script:
+  - weight: 6
+    text: |-
+      ok
+      {'count': 3, 'ordering': ('name',)}
+  - weight: 5
+    text: "All checks passed.\n"
+  - weight: 4
+    text: "instance: <Author: Jane Doe>\nrelated count: 5\nordering applied: True\n"
+  - weight: 4
+    text: "slug: hello-world\nchecksum: 9b74c9...\n"
+  - weight: 3
+    text: "migrated 7 operations\nok\n"
+  - weight: 2
+    text: |-
+      Traceback (most recent call last):
+        File "/testbed/reproduce_issue.py", line 12, in <module>
+          main()
+        File "/testbed/reproduce_issue.py", line 8, in main
+          qs = Author.objects.filter(name='x')
+      AttributeError: 'NoneType' object has no attribute 'objects'
+  - weight: 1
+    text: "/bin/bash: line 1: python: command not found"
+
+# ---------------------------------------------------------------------------
+# listing -- varied file sets.
+# ---------------------------------------------------------------------------
+listing:
+  - weight: 4
+    text: |-
+      /testbed/setup.py
+      /testbed/manage.py
+      /testbed/blog/__init__.py
+      /testbed/blog/models.py
+      /testbed/blog/views.py
+      /testbed/blog/admin.py
+      /testbed/blog/urls.py
+  - weight: 3
+    text: |-
+      /testbed/blog/migrations/0001_initial.py
+      /testbed/blog/migrations/0002_author_email.py
+      /testbed/blog/migrations/0003_article_published.py
+  - weight: 3
+    text: |-
+      /testbed/tests/__init__.py
+      /testbed/tests/test_models.py
+      /testbed/tests/test_views.py
+      /testbed/tests/test_filters.py
+      /testbed/tests/test_forms.py
+  - weight: 2
+    text: "/testbed"
+  - weight: 1
+    text: |-
+      /testbed/.git/objects/01/2345...
+      /testbed/.git/objects/02/3456...
+      /testbed/node_modules/react/index.js
+      # (long-tail: an accidental `ls`/`find` dumping the whole tree)
+
+# ---------------------------------------------------------------------------
+# search -- varied grep hits, including no-match.
+# ---------------------------------------------------------------------------
+search:
+  - weight: 4
+    text: |-
+      /testbed/blog/filters.py:196:        ordering = ()
+      /testbed/blog/filters.py:422:        return field.get_choices(include_blank=False)
+      /testbed/blog/admin.py:88:    ordering = None
+  - weight: 3
+    text: |-
+      /testbed/blog/models.py:14:    ordering = ('-published',)
+      /testbed/blog/views.py:6:    qs = Article.objects.all().order_by('-published')
+  - weight: 3
+    text: |-
+      /testbed/blog/utils.py:6:    value = re.sub(r'[^\w\s-]', '', value)
+      /testbed/blog/serializers.py:9:        fields = '__all__'
+  - weight: 3
+    text: "Your command ran successfully and did not produce any output."
+  - weight: 1
+    text: |-
+      /testbed/blog/db/models/query.py:42:    def filter(self):
+      /testbed/blog/db/models/query.py:88:    def exclude(self):
+      /testbed/blog/db/models/query.py:120:   def order_by(self):
+      # (long-tail: many matches across a large codebase)
+
+# ---------------------------------------------------------------------------
+# file view -- varied small contents.
+# ---------------------------------------------------------------------------
+file_view:
+  - weight: 5
+    text: |-
+      import os
+
+
+      class Model:
+          pass
+  - weight: 4
+    text: |-
+      DEBUG = True
+      SECRET_KEY = 'dev-key'
+      ALLOWED_HOSTS = ['*']
+  - weight: 3
+    text: "django\npytest\nrest_framework\n"
+  - weight: 3
+    text: "Your command ran successfully and did not produce any output."
+  - weight: 1
+    text: "cat: /testbed/x.py: No such file or directory"
+
+# ---------------------------------------------------------------------------
+# default -- generic bash output.
+# ---------------------------------------------------------------------------
+default:
+  - weight: 6
+    text: "Your command ran successfully and did not produce any output."
+  - weight: 3
+    text: |-
+      done
+      exit status: 0
+  - weight: 2
+    text: "Switched to branch 'fix-ordering'\n"
+  - weight: 1
+    text: "command returned non-zero exit status 1"

--- a/uni_agent/llm_router/__init__.py
+++ b/uni_agent/llm_router/__init__.py
@@ -1,0 +1,36 @@
+"""KV-cache-aware LLM Router configuration and routing primitives."""
+
+from uni_agent.llm_router.config import (
+    CacheStoreConfig,
+    CollectorConfig,
+    ConfigError,
+    KVCAwareConfig,
+    KVCAwareStrategyConfig,
+    StrategyConfig,
+)
+from uni_agent.llm_router.strategies import (
+    KVCacheAwareStrategy,
+    RoutingStrategy,
+    StrategyError,
+    StrategyRegistry,
+    route,
+)
+from uni_agent.llm_router.collectors import MetricKey, RouteDataProvider
+from uni_agent.llm_router.strategies import ReplicaInfo
+
+__all__ = [
+    "CacheStoreConfig",
+    "CollectorConfig",
+    "ConfigError",
+    "KVCAwareConfig",
+    "KVCAwareStrategyConfig",
+    "StrategyConfig",
+    "KVCacheAwareStrategy",
+    "RoutingStrategy",
+    "StrategyError",
+    "StrategyRegistry",
+    "route",
+    "MetricKey",
+    "ReplicaInfo",
+    "RouteDataProvider",
+]

--- a/uni_agent/llm_router/__init__.py
+++ b/uni_agent/llm_router/__init__.py
@@ -1,5 +1,6 @@
 """KV-cache-aware LLM Router configuration and routing primitives."""
 
+from uni_agent.llm_router.collectors import MetricKey, RouteDataProvider
 from uni_agent.llm_router.config import (
     CacheStoreConfig,
     CollectorConfig,
@@ -10,13 +11,12 @@ from uni_agent.llm_router.config import (
 )
 from uni_agent.llm_router.strategies import (
     KVCacheAwareStrategy,
+    ReplicaInfo,
     RoutingStrategy,
     StrategyError,
     StrategyRegistry,
     route,
 )
-from uni_agent.llm_router.collectors import MetricKey, RouteDataProvider
-from uni_agent.llm_router.strategies import ReplicaInfo
 
 __all__ = [
     "CacheStoreConfig",

--- a/uni_agent/llm_router/balancer.py
+++ b/uni_agent/llm_router/balancer.py
@@ -1,0 +1,169 @@
+"""KVCAwareBalancer — top-level orchestration shell for the KVCAware router.
+
+A **pure framework shell** (detailed_balancer.md §1): it wires Config /
+Strategy / collectors, manages their lifecycle, and delegates each request to
+``route()``. It contains no routing algorithm.
+
+VeRL imports this class by FQN (``router_class``) and wraps it with
+``ray.remote(...)`` at runtime, so this is a plain class — directly
+constructible and unit-testable. It satisfies the ``RequestLoadBalancer``
+Protocol (6 methods) via structural subtyping.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Import RouteDataProvider from its definition module (collectors.provider),
+# not the ``collectors`` package attribute. Unit tests in test_balancer.py
+# monkeypatch ``collectors.RouteDataProvider`` to a fake; if we imported via the
+# package, Ray worker processes that fork from the patched pytest process would
+# bind the fake and report "_FakeProvider" in get_status(). Sourcing the class
+# from its definition site is immune to that package-attribute patch.
+from uni_agent.llm_router.collectors.provider import RouteDataProvider
+from uni_agent.llm_router.config import KVCAwareConfig
+from uni_agent.llm_router.logging import get_router_logger
+from uni_agent.llm_router.strategies import (
+    ReplicaInfo,
+    StrategyRegistry,
+    StickySessionTable,
+    route,
+)
+
+logger = get_router_logger("balancer")
+
+
+class KVCAwareBalancer:
+    """Pure-framework router shell. See module docstring."""
+
+    def __init__(self, servers: dict[str, Any], router_config: Any) -> None:
+        if not servers:
+            raise ValueError("servers must be non-empty")
+        self._config = KVCAwareConfig.from_config(router_config)
+        self._strategies: list[tuple[Any, float]] = [
+            (StrategyRegistry.get(type(cfg)).from_config(cfg), cfg.weight)
+            for cfg in self._config.strategies
+        ]
+        self._servers: dict[str, Any] = dict(servers)
+        self._route_calls = 0
+        # Sticky-session LRU table: request_id → replica_id. Owned by the
+        # Balancer (single Ray actor, serial acquire_server → no locking
+        # needed) and threaded into route()→strategy.score() so a strategy can
+        # short-circuit to a bound, non-overloaded replica.
+        self._sticky = StickySessionTable(max_size=self._config.sticky_max_size)
+        self._init_provider()
+
+    def _init_provider(self) -> None:
+        """Resolve per-server endpoints from Ray actor handles and init the provider.
+
+        Iterates ``self._servers``, calling ``get_server_address.remote()`` and
+        ``get_kv_events_endpoints.remote()`` on each handle to dynamically
+        discover the Prometheus polling addresses and ZMQ kv-event endpoints.
+        The resolved addresses are then passed to ``RouteDataProvider``, which
+        routes them to the appropriate collector type at creation time.
+
+        Handles that are not real Ray actors (e.g. plain strings passed by
+        unit tests or bring-up stubs) have no ``get_server_address`` remote;
+        for those, dynamic discovery is skipped and collectors fall back to
+        their configured/default endpoints.
+        """
+        import ray
+
+        collection_names = sorted(
+            {name for cfg in self._config.strategies for name in cfg.collector_names}
+        )
+        server_addresses: dict[str, str] = {}
+        kv_event_endpoints: dict[str, list[str]] = {}
+        for replica_id, handle in self._servers.items():
+            if not hasattr(handle, "get_server_address"):
+                logger.warning(
+                    f"server '{replica_id}' handle has no get_server_address remote "
+                    f"(type={type(handle).__name__}); skipping dynamic endpoint discovery",
+                )
+                continue
+            ip, port = ray.get(handle.get_server_address.remote())
+            server_addresses[replica_id] = f"{ip}:{port}"
+            endpoints = ray.get(handle.get_kv_events_endpoints.remote())
+            if endpoints is not None:
+                kv_event_endpoints[replica_id] = endpoints
+        self._provider = RouteDataProvider(
+            self._config.collector, collection_names,
+            server_addresses=server_addresses,
+            kv_event_endpoints=kv_event_endpoints,
+        )
+        self._provider.start()
+
+    def get_all_servers(self) -> list[str]:
+        """List all active server ids."""
+        return list(self._servers.keys())
+
+    def get_status(self) -> dict:
+        """Return construction + routing state for debugging.
+
+        Reports what the balancer was wired with (pool, provider type,
+        materialized strategies) and how many routing decisions it has made —
+        enough to verify the construction flow over the remote boundary.
+        """
+        return {
+            "servers": list(self._servers.keys()),
+            "provider": type(self._provider).__name__,
+            "strategies": [{"type": type(s).__name__, "weight": w} for s, w in self._strategies],
+            "route_calls": self._route_calls,
+            "sticky_size": len(self._sticky),
+        }
+
+    def release_server(self, server_id: str) -> None:
+        """Release a server after a request completes. No-op in v1 (no inflight)."""
+
+    def acquire_server(
+        self, request_id: str, prompt_ids: list[int] | None = None
+    ) -> tuple[str, Any]:
+        """Acquire the best server for a request: delegate to ``route()``, map back.
+
+        Builds ``ReplicaInfo`` candidates from the pool, asks ``route()`` for a
+        best-first ranking, and returns ``(ranking[0], handle)``. Raises
+        ``RuntimeError`` if no replica is available (empty pool or all blacklisted).
+
+        The ``request_id`` and the sticky-session table are forwarded to
+        ``route()`` so strategies can short-circuit to a bound, non-overloaded
+        replica. After a ranking is chosen, the binding is refreshed so the
+        next turn of the same ``request_id`` stays affinity-bound (or, when a
+        sticky replica was overloaded and routing fell back, rebinds to the
+        new choice).
+        """
+        replicas = [ReplicaInfo(replica_id=sid) for sid in self._servers]
+        self._route_calls += 1
+        ranking = route(
+            self._strategies, prompt_ids, self._provider, replicas,
+            request_id, self._sticky,
+        )
+        if not ranking:
+            raise RuntimeError("no available replica to route to")
+        server_id = ranking[0]
+        self._sticky.put(request_id, server_id)
+        logger.info(
+            f"request={request_id} routed to server={server_id} (ranking={ranking}, pool={list(self._servers)})",
+        )
+        return server_id, self._servers[server_id]
+
+    def add_servers(self, servers: dict[str, Any]) -> None:
+        """Bulk-add servers to the pool.
+
+        Note: the provider is keyed by the endpoint addresses resolved at
+        init time, not by this pool, so it is not touched here.
+        """
+        for sid, handle in servers.items():
+            self._servers[sid] = handle
+
+    def remove_servers(self, server_ids: list[str]) -> None:
+        """Bulk-remove servers from the pool (provider is not keyed by the pool).
+
+        Also invalidates every sticky binding pointing at a removed server so a
+        subsequent ``acquire_server`` for a bound conversation doesn't try to
+        short-circuit to a dead replica (the strategy would reject it and fall
+        back to combined scoring anyway, but clearing early keeps the table
+        clean and the logs honest).
+        """
+        for sid in server_ids:
+            self._servers.pop(sid, None)
+            self._sticky.invalidate_replica(sid)

--- a/uni_agent/llm_router/balancer.py
+++ b/uni_agent/llm_router/balancer.py
@@ -25,8 +25,8 @@ from uni_agent.llm_router.config import KVCAwareConfig
 from uni_agent.llm_router.logging import get_router_logger
 from uni_agent.llm_router.strategies import (
     ReplicaInfo,
-    StrategyRegistry,
     StickySessionTable,
+    StrategyRegistry,
     route,
 )
 
@@ -41,8 +41,7 @@ class KVCAwareBalancer:
             raise ValueError("servers must be non-empty")
         self._config = KVCAwareConfig.from_config(router_config)
         self._strategies: list[tuple[Any, float]] = [
-            (StrategyRegistry.get(type(cfg)).from_config(cfg), cfg.weight)
-            for cfg in self._config.strategies
+            (StrategyRegistry.get(type(cfg)).from_config(cfg), cfg.weight) for cfg in self._config.strategies
         ]
         self._servers: dict[str, Any] = dict(servers)
         self._route_calls = 0
@@ -69,9 +68,7 @@ class KVCAwareBalancer:
         """
         import ray
 
-        collection_names = sorted(
-            {name for cfg in self._config.strategies for name in cfg.collector_names}
-        )
+        collection_names = sorted({name for cfg in self._config.strategies for name in cfg.collector_names})
         server_addresses: dict[str, str] = {}
         kv_event_endpoints: dict[str, list[str]] = {}
         for replica_id, handle in self._servers.items():
@@ -87,7 +84,8 @@ class KVCAwareBalancer:
             if endpoints is not None:
                 kv_event_endpoints[replica_id] = endpoints
         self._provider = RouteDataProvider(
-            self._config.collector, collection_names,
+            self._config.collector,
+            collection_names,
             server_addresses=server_addresses,
             kv_event_endpoints=kv_event_endpoints,
         )
@@ -115,9 +113,7 @@ class KVCAwareBalancer:
     def release_server(self, server_id: str) -> None:
         """Release a server after a request completes. No-op in v1 (no inflight)."""
 
-    def acquire_server(
-        self, request_id: str, prompt_ids: list[int] | None = None
-    ) -> tuple[str, Any]:
+    def acquire_server(self, request_id: str, prompt_ids: list[int] | None = None) -> tuple[str, Any]:
         """Acquire the best server for a request: delegate to ``route()``, map back.
 
         Builds ``ReplicaInfo`` candidates from the pool, asks ``route()`` for a
@@ -134,8 +130,12 @@ class KVCAwareBalancer:
         replicas = [ReplicaInfo(replica_id=sid) for sid in self._servers]
         self._route_calls += 1
         ranking = route(
-            self._strategies, prompt_ids, self._provider, replicas,
-            request_id, self._sticky,
+            self._strategies,
+            prompt_ids,
+            self._provider,
+            replicas,
+            request_id,
+            self._sticky,
         )
         if not ranking:
             raise RuntimeError("no available replica to route to")

--- a/uni_agent/llm_router/collectors/__init__.py
+++ b/uni_agent/llm_router/collectors/__init__.py
@@ -1,0 +1,9 @@
+"""Provide ``RouteDataProvider`` for the balancer strategy layer to query routing data."""
+
+from uni_agent.llm_router.metric_spec import MetricKey
+from uni_agent.llm_router.collectors.provider import RouteDataProvider
+
+__all__ = [
+    "MetricKey",
+    "RouteDataProvider",
+]

--- a/uni_agent/llm_router/collectors/__init__.py
+++ b/uni_agent/llm_router/collectors/__init__.py
@@ -1,7 +1,7 @@
 """Provide ``RouteDataProvider`` for the balancer strategy layer to query routing data."""
 
-from uni_agent.llm_router.metric_spec import MetricKey
 from uni_agent.llm_router.collectors.provider import RouteDataProvider
+from uni_agent.llm_router.metric_spec import MetricKey
 
 __all__ = [
     "MetricKey",

--- a/uni_agent/llm_router/collectors/collector.py
+++ b/uni_agent/llm_router/collectors/collector.py
@@ -1,0 +1,92 @@
+"""Collector — unified collector interface combining Transport + Decoder.
+
+Composes a ``Transport`` (data acquisition) and a ``Decoder`` (data
+interpretation and store writing).  Both ``start()`` and ``stop()``
+are synchronous — async logic is encapsulated internally so the
+upper layer (e.g. Ray actor) can call them without ``await``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+
+from concurrent.futures import Future
+
+from uni_agent.llm_router.collectors.transport.base import Transport
+from uni_agent.llm_router.collectors.decoder.base import Decoder
+
+logger = logging.getLogger(__name__)
+
+
+class Collector:
+    """Unified collector — composes Transport + Decoder.
+
+    The Collector owns the lifecycle: it starts the Transport on a
+    dedicated event-loop thread, passing the Decoder's ``decode``
+    method as the handler.  ``store_cls`` is derived from the Decoder
+    so the registry can look it up.
+
+    Args:
+        transport: Transport instance (ZMQ, HTTP, etc.)
+        decoder: Decoder instance (vLLM KV, vLLM Metrics, etc.)
+    """
+
+    def __init__(self, transport: Transport, decoder: Decoder) -> None:
+        self._transport = transport
+        self._decoder = decoder
+        self._future: Future | None = None
+        self._loop: asyncio.AbstractEventLoop = asyncio.new_event_loop()
+        self._loop_thread: threading.Thread | None = None
+
+    # ── Derived attributes ─────────────────────────────────────────────
+
+    @property
+    def store_cls(self) -> type:
+        """Store class — derived from the Decoder."""
+        return self._decoder.store_cls
+
+    # ── Lifecycle ───────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        """Start the collector — launch event-loop thread and subscribe.
+
+        Spawns a dedicated event-loop thread, starts the Transport's
+        subscribe loop on it, passing the Decoder's decode method
+        as the handler.  Synchronous — no ``await`` needed.
+        """
+        self._loop_thread = threading.Thread(
+            target=self._loop.run_forever,
+            daemon=True,
+        )
+        self._loop_thread.start()
+
+        self._future = asyncio.run_coroutine_threadsafe(
+            self._transport.subscribe(self._decoder.decode),
+            self._loop,
+        )
+
+    def stop(self) -> None:
+        """Stop the collector — stop transport, then stop event-loop thread.
+
+        Synchronous — blocks until all cleanup is complete.
+        """
+        # First stop the transport (it cancels its own tasks and closes sockets)
+        self._transport.stop()
+
+        # Cancel and await the main subscribe future
+        if self._future is not None:
+            self._future.cancel()
+            try:
+                self._future.result()
+            except (asyncio.CancelledError, Exception) as exc:
+                logger.debug("Error waiting for collector task to finish: %s", exc)
+            self._future = None
+
+        # Stop the event loop and join the thread
+        if self._loop.is_running():
+            self._loop.call_soon_threadsafe(self._loop.stop)
+        if self._loop_thread is not None:
+            self._loop_thread.join(timeout=10)
+            self._loop_thread = None

--- a/uni_agent/llm_router/collectors/collector.py
+++ b/uni_agent/llm_router/collectors/collector.py
@@ -11,11 +11,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
-
 from concurrent.futures import Future
 
-from uni_agent.llm_router.collectors.transport.base import Transport
 from uni_agent.llm_router.collectors.decoder.base import Decoder
+from uni_agent.llm_router.collectors.transport.base import Transport
 
 logger = logging.getLogger(__name__)
 

--- a/uni_agent/llm_router/collectors/decoder/__init__.py
+++ b/uni_agent/llm_router/collectors/decoder/__init__.py
@@ -1,0 +1,5 @@
+"""Decoders — backend-specific data decoding and store writing."""
+
+from uni_agent.llm_router.collectors.decoder.base import Decoder
+
+__all__ = ["Decoder"]

--- a/uni_agent/llm_router/collectors/decoder/base.py
+++ b/uni_agent/llm_router/collectors/decoder/base.py
@@ -1,0 +1,31 @@
+"""Decoder — abstract base for data decoding and store writing.
+
+A Decoder receives raw data from a Transport and decodes it into
+structured updates, writing results to its associated Store.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class Decoder(ABC):
+    """Abstract base for data decoders.
+
+    Subclasses implement ``decode()`` with their backend-specific
+    parsing logic and declare ``store_cls`` as a class attribute
+    to indicate which Store they write to.
+    """
+
+    store_cls: type  # Store class this decoder writes to
+
+    @abstractmethod
+    def decode(self, raw_data: bytes | str, node_id: str) -> None:
+        """Decode raw data and write results to the store.
+
+        Args:
+            raw_data: Raw payload — ``bytes`` (from ZMQ) or ``str``
+                (from HTTP response text).
+            node_id: Source replica/node identifier.
+        """

--- a/uni_agent/llm_router/collectors/decoder/base.py
+++ b/uni_agent/llm_router/collectors/decoder/base.py
@@ -7,7 +7,6 @@ structured updates, writing results to its associated Store.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any
 
 
 class Decoder(ABC):

--- a/uni_agent/llm_router/collectors/decoder/vllm/__init__.py
+++ b/uni_agent/llm_router/collectors/decoder/vllm/__init__.py
@@ -1,0 +1,6 @@
+"""vLLM backend decoders."""
+
+from uni_agent.llm_router.collectors.decoder.vllm.kv import VLLMKVDecoder
+from uni_agent.llm_router.collectors.decoder.vllm.metrics import VLLMMetricsDecoder
+
+__all__ = ["VLLMKVDecoder", "VLLMMetricsDecoder"]

--- a/uni_agent/llm_router/collectors/decoder/vllm/kv.py
+++ b/uni_agent/llm_router/collectors/decoder/vllm/kv.py
@@ -1,0 +1,131 @@
+"""VLLMKVDecoder — vLLM KV-cache event decoder.
+
+Decodes msgpack payloads from ZMQ, applies KV cache events to
+KVCacheStore via dispatch table.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import msgpack
+
+from uni_agent.llm_router.collectors.decoder.base import Decoder
+from uni_agent.llm_router.collectors.decoder.vllm.kv_event import KVCacheEvent
+from uni_agent.llm_router.hash import compute_hash
+from uni_agent.llm_router.store.kv_cache_store import KVCacheStore
+
+logger = logging.getLogger(__name__)
+
+
+class VLLMKVDecoder(Decoder):
+    """vLLM KV-cache decoder — msgpack payload → KVCacheStore updates.
+
+    Event dispatch uses a ``_DISPATCH`` table mapping ``event_type``
+    to handler methods — no if/else chain needed.
+
+    Attributes:
+        remote_to_local_block_hash: Mapping from vLLM remote block_hash
+            to locally-computed prefix hash (str).  Used in
+            _handle_stored for chained hash computation.
+    """
+
+    store_cls = KVCacheStore
+
+    # event_type → handler method name
+    _DISPATCH: dict[str, str] = {
+        "stored": "_handle_stored",
+        "removed": "_handle_removed",
+        "clear": "_handle_clear",
+    }
+
+    def __init__(self) -> None:
+        self._store = self.store_cls.default()
+        self.remote_to_local_block_hash: dict[str, str] = {}
+
+    def decode(self, raw_data: bytes | str, node_id: str) -> None:
+        """Decode msgpack payload, apply events to store.
+
+        Args:
+            raw_data: ZMQ payload bytes (msgpack-encoded).
+            node_id: The replica that sent this payload.
+        """
+        # ZMQ delivers bytes; ignore string data (shouldn't happen for this decoder)
+        if isinstance(raw_data, str):
+            logger.debug("VLLMKVDecoder received string data, expected bytes — skipping")
+            return
+
+        try:
+            raw = msgpack.unpackb(raw_data, raw=False)
+            events = KVCacheEvent.from_raw(raw, default_replica_id=node_id)
+            for event in events:
+                self._apply_event(event, default_replica_id=node_id)
+        except (msgpack.UnpackException, ValueError, TypeError) as exc:
+            logger.warning(
+                "Failed to decode msgpack payload from node %s: %s",
+                node_id, exc,
+            )
+
+    def _apply_event(
+        self,
+        event: KVCacheEvent,
+        default_replica_id: str | None = None,
+    ) -> None:
+        """Dispatch a KVCacheEvent to the appropriate handler."""
+        handler_name = self._DISPATCH.get(event.event_type)
+        if handler_name is None:
+            logger.debug("Unhandled event type: %s", event.event_type)
+            return
+        handler = getattr(self, handler_name)
+        replica_id = event.replica_id or default_replica_id or ""
+        handler(event, replica_id)
+
+    # ── Event handlers ──────────────────────────────────────────────────
+
+    def _handle_stored(self, event: KVCacheEvent, replica_id: str) -> None:
+        """Handle BlockStored: learn block_size, compute local hashes, update store."""
+        store = self._store
+        seed = 0
+
+        if store.block_size is None and event.block_size is not None:
+            store.block_size = event.block_size
+
+        if event.token_ids is not None:
+            local_parent_hash = seed
+            if event.parent_block_hash is not None:
+                local_parent_str = self.remote_to_local_block_hash.get(
+                    event.parent_block_hash
+                )
+                if local_parent_str is not None:
+                    local_parent_hash = int(local_parent_str)
+
+            local_hashes: list[str] = []
+            for i, block_bytes in enumerate(event.token_ids):
+                if i >= len(event.block_hashes):
+                    break
+                local_hash_int = compute_hash(
+                    local_parent_hash, block_bytes, seed=seed,
+                )
+                local_hash_str = str(local_hash_int)
+                bh = event.block_hashes[i]
+                self.remote_to_local_block_hash[bh] = local_hash_str
+                local_hashes.append(local_hash_str)
+                local_parent_hash = local_hash_int  # chain
+
+            store.add_blocks(replica_id, local_hashes)
+
+    def _handle_removed(self, event: KVCacheEvent, replica_id: str) -> None:
+        """Handle BlockRemoved: convert remote hashes to local, remove from store."""
+        store = self._store
+        local_hashes = [
+            self.remote_to_local_block_hash[bh]
+            for bh in event.block_hashes
+            if bh in self.remote_to_local_block_hash
+        ]
+        store.remove_blocks(replica_id, local_hashes)
+        for bh in event.block_hashes:
+            self.remote_to_local_block_hash.pop(bh, None)
+
+    def _handle_clear(self, event: KVCacheEvent, replica_id: str) -> None:
+        """Handle AllBlocksCleared: clear all blocks for the replica."""
+        self._store.clear_replica(replica_id)

--- a/uni_agent/llm_router/collectors/decoder/vllm/kv.py
+++ b/uni_agent/llm_router/collectors/decoder/vllm/kv.py
@@ -63,7 +63,8 @@ class VLLMKVDecoder(Decoder):
         except (msgpack.UnpackException, ValueError, TypeError) as exc:
             logger.warning(
                 "Failed to decode msgpack payload from node %s: %s",
-                node_id, exc,
+                node_id,
+                exc,
             )
 
     def _apply_event(
@@ -93,9 +94,7 @@ class VLLMKVDecoder(Decoder):
         if event.token_ids is not None:
             local_parent_hash = seed
             if event.parent_block_hash is not None:
-                local_parent_str = self.remote_to_local_block_hash.get(
-                    event.parent_block_hash
-                )
+                local_parent_str = self.remote_to_local_block_hash.get(event.parent_block_hash)
                 if local_parent_str is not None:
                     local_parent_hash = int(local_parent_str)
 
@@ -104,7 +103,9 @@ class VLLMKVDecoder(Decoder):
                 if i >= len(event.block_hashes):
                     break
                 local_hash_int = compute_hash(
-                    local_parent_hash, block_bytes, seed=seed,
+                    local_parent_hash,
+                    block_bytes,
+                    seed=seed,
                 )
                 local_hash_str = str(local_hash_int)
                 bh = event.block_hashes[i]
@@ -118,9 +119,7 @@ class VLLMKVDecoder(Decoder):
         """Handle BlockRemoved: convert remote hashes to local, remove from store."""
         store = self._store
         local_hashes = [
-            self.remote_to_local_block_hash[bh]
-            for bh in event.block_hashes
-            if bh in self.remote_to_local_block_hash
+            self.remote_to_local_block_hash[bh] for bh in event.block_hashes if bh in self.remote_to_local_block_hash
         ]
         store.remove_blocks(replica_id, local_hashes)
         for bh in event.block_hashes:

--- a/uni_agent/llm_router/collectors/decoder/vllm/kv_event.py
+++ b/uni_agent/llm_router/collectors/decoder/vllm/kv_event.py
@@ -1,0 +1,245 @@
+"""
+KVCacheEvent — standardized KV cache event data structure.
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class KVCacheEvent:
+    """Standardized KV cache event — normalized from backend-specific ZMQ payloads.
+
+    Attributes:
+        event_type: ``"stored"`` / ``"removed"`` / ``"clear"``.
+        replica_id: Source replica (from ZMQ connection or group_idx).
+        block_hashes: Block hashes involved in the event (list from msgpack).
+        parent_block_hash: Parent block hash — single value shared by all
+                           block_hashes in a BlockStored event.
+        token_ids: Pre-chopped block token bytes (``list[bytes]``, only present
+                   in BlockStored events).  Each element is one full block
+                   encoded as uint32 big-endian (4 bytes per token).
+        block_size: Block size (only present in BlockStored events).
+    """
+
+    event_type: str
+    replica_id: str
+    block_hashes: list[str]
+    parent_block_hash: str | None
+    token_ids: list[bytes] | None
+    block_size: int | None
+
+    # ── Factory ──────────────────────────────────────────────────────────
+
+    @classmethod
+    def from_raw(cls, raw_data: Any, default_replica_id: str | None = None) -> list[KVCacheEvent]:
+        """Parse msgpack-decoded raw data into a list of KVCacheEvent instances.
+
+        Parsing pattern::
+
+            timestamp    = raw_data[0]               # ignored for routing
+            event_list   = raw_data[1]               # list of events
+            event_tag    = raw_data[1][i][0]          # tag for event i
+            event_fields = raw_data[1][i][1:]         # fields for event i
+
+        Args:
+            raw_data: Msgpack-decoded list ``[timestamp, [[tag, fields...], ...]]``.
+            default_replica_id: Fallback replica_id when raw data lacks it.
+
+        Returns:
+            A list of KVCacheEvent instances.  Malformed events are skipped.
+
+        Raises:
+            ValueError: If the top-level format is invalid.
+        """
+        if not isinstance(raw_data, (list, tuple)) or len(raw_data) < 2:
+            raise ValueError(f"Expected list with >= 2 elements, got {type(raw_data)}")
+
+        event_list = raw_data[1]
+        if not isinstance(event_list, (list, tuple)):
+            raise ValueError(f"Expected raw_data[1] as event list, got {type(event_list)}")
+
+        results: list[KVCacheEvent] = []
+        for event_entry in event_list:
+            if not isinstance(event_entry, (list, tuple)) or len(event_entry) < 1:
+                continue
+
+            tag = event_entry[0]
+            fields = event_entry[1:]
+            event_type = cls._resolve_event_type(tag)
+            if event_type.startswith("unknown"):
+                continue
+
+            replica_id = default_replica_id or ""
+            try:
+                event = cls._build_event(event_type, fields, replica_id)
+                if event is not None:
+                    results.append(event)
+            except (ValueError, TypeError, IndexError):
+                continue
+
+        return results
+
+    # ── Build helpers ────────────────────────────────────────────────────
+
+    @classmethod
+    def _build_event(
+        cls, event_type: str, fields: list | tuple, replica_id: str,
+    ) -> KVCacheEvent | None:
+        """Dispatch to the appropriate builder by event_type."""
+        if event_type == "stored":
+            return cls._build_block_stored(fields, replica_id)
+        elif event_type == "removed":
+            return cls._build_block_removed(fields, replica_id)
+        elif event_type == "clear":
+            return cls._build_all_blocks_cleared(replica_id)
+        return None
+
+    @classmethod
+    def _build_block_stored(cls, fields: list | tuple, replica_id: str) -> KVCacheEvent:
+        """Build a BlockStored event from its field list.
+
+        Field order (after tag):
+            0: block_hashes         — list of block hash values
+            1: parent_block_hash    — single value or None
+            2: token_ids            — list of int or None
+            3: block_size           — int
+
+        Raw ``token_ids`` (``list[int]``) are chopped into full blocks
+        and encoded as uint32 big-endian bytes via ``_convert_token_ids``.
+        """
+        if len(fields) < 4:
+            raise ValueError(f"BlockStored needs >= 4 fields, got {len(fields)}")
+
+        block_hashes = [str(bh) for bh in fields[0]]
+        parent_block_hash = str(fields[1]) if fields[1] is not None else None
+        raw_token_ids = list(fields[2]) if fields[2] is not None else None
+        block_size = int(fields[3])
+
+        # Chop and encode token IDs into block-sized uint32 big-endian bytes
+        token_ids = (
+            _convert_token_ids(raw_token_ids, block_size)
+            if raw_token_ids is not None
+            else None
+        )
+
+        return cls(
+            event_type="stored",
+            replica_id=replica_id,
+            block_hashes=block_hashes,
+            parent_block_hash=parent_block_hash,
+            token_ids=token_ids,
+            block_size=block_size
+        )
+
+    @classmethod
+    def _build_block_removed(cls, fields: list | tuple, replica_id: str) -> KVCacheEvent:
+        """Build a BlockRemoved event from its field list.
+
+        Field order (after tag):
+            0: block_hashes — list of block hash values
+            1: medium       — str or None
+            2: group_idx    — int or None
+        """
+        block_hashes = [str(bh) for bh in fields[0]]
+
+        return cls(
+            event_type="removed",
+            replica_id=replica_id,
+            block_hashes=block_hashes,
+            parent_block_hash=None,
+            token_ids=None,
+            block_size=None
+        )
+
+    @classmethod
+    def _build_all_blocks_cleared(cls, replica_id: str) -> KVCacheEvent:
+        """Build an AllBlocksCleared event — no fields after tag."""
+        return cls(
+            event_type="clear",
+            replica_id=replica_id,
+            block_hashes=[],
+            parent_block_hash=None,
+            token_ids=None,
+            block_size=None
+        )
+
+    # ── Tag resolution ───────────────────────────────────────────────────
+
+    @staticmethod
+    def _resolve_event_type(tag: Any) -> str:
+        """Map msgspec struct tag to canonical event type string.
+
+        vLLM msgspec uses numeric tags:
+          - 0 → BlockStored
+          - 1 → BlockRemoved
+          - 2 → AllBlocksCleared
+
+        String tags are also supported.
+        """
+        if isinstance(tag, int):
+            return {0: "stored", 1: "removed", 2: "clear"}.get(tag, f"unknown_{tag}")
+
+        tag_str = str(tag).lower()
+        if "stored" in tag_str:
+            return "stored"
+        elif "removed" in tag_str or "evicted" in tag_str:
+            return "removed"
+        elif "clear" in tag_str:
+            return "clear"
+        return f"unknown_{tag}"
+
+    # ── Convenience properties ──────────────────────────────────────────
+
+    @property
+    def is_store(self) -> bool:
+        """True if this is a block-stored event."""
+        return "stored" in self.event_type.lower()
+
+    @property
+    def is_remove(self) -> bool:
+        """True if this is a block-removed event."""
+        return any(k in self.event_type.lower() for k in ("removed", "evicted"))
+
+    @property
+    def is_clear(self) -> bool:
+        """True if this is an all-blocks-cleared event."""
+        return "clear" in self.event_type.lower()
+
+
+# ── Token ID conversion ────────────────────────────────────────────────────
+
+
+def _convert_token_ids(raw_ids: list[int], block_size: int) -> list[bytes]:
+    """Convert raw token IDs to list of block-sized uint32 big-endian byte chunks.
+
+    Each block of token IDs is encoded as uint32 big-endian (4 bytes per token),
+    matching aibrix's ``convertTokenIDs`` / ``tokenIDsToBytes``.
+
+    Args:
+        raw_ids: Raw token IDs as ``list[int]``.
+        block_size: Number of tokens per block (must be > 0).
+
+    Returns:
+        List of bytes objects, one per full block.
+
+    Raises:
+        ValueError: If ``block_size <= 0`` or ``len(raw_ids)`` is not
+            divisible by ``block_size``.
+    """
+    if block_size <= 0:
+        raise ValueError(f"block_size must be > 0, got {block_size}")
+    if len(raw_ids) % block_size != 0:
+        raise ValueError(
+            f"token_ids len={len(raw_ids)} not divisible by block_size={block_size}"
+        )
+    num_blocks = len(raw_ids) // block_size
+    result: list[bytes] = []
+    for i in range(num_blocks):
+        start = i * block_size
+        end = start + block_size
+        result.append(struct.pack(f">{block_size}I", *raw_ids[start:end]))
+    return result

--- a/uni_agent/llm_router/collectors/decoder/vllm/kv_event.py
+++ b/uni_agent/llm_router/collectors/decoder/vllm/kv_event.py
@@ -55,16 +55,16 @@ class KVCacheEvent:
         Raises:
             ValueError: If the top-level format is invalid.
         """
-        if not isinstance(raw_data, (list, tuple)) or len(raw_data) < 2:
+        if not isinstance(raw_data, list | tuple) or len(raw_data) < 2:
             raise ValueError(f"Expected list with >= 2 elements, got {type(raw_data)}")
 
         event_list = raw_data[1]
-        if not isinstance(event_list, (list, tuple)):
+        if not isinstance(event_list, list | tuple):
             raise ValueError(f"Expected raw_data[1] as event list, got {type(event_list)}")
 
         results: list[KVCacheEvent] = []
         for event_entry in event_list:
-            if not isinstance(event_entry, (list, tuple)) or len(event_entry) < 1:
+            if not isinstance(event_entry, list | tuple) or len(event_entry) < 1:
                 continue
 
             tag = event_entry[0]
@@ -87,7 +87,10 @@ class KVCacheEvent:
 
     @classmethod
     def _build_event(
-        cls, event_type: str, fields: list | tuple, replica_id: str,
+        cls,
+        event_type: str,
+        fields: list | tuple,
+        replica_id: str,
     ) -> KVCacheEvent | None:
         """Dispatch to the appropriate builder by event_type."""
         if event_type == "stored":
@@ -120,11 +123,7 @@ class KVCacheEvent:
         block_size = int(fields[3])
 
         # Chop and encode token IDs into block-sized uint32 big-endian bytes
-        token_ids = (
-            _convert_token_ids(raw_token_ids, block_size)
-            if raw_token_ids is not None
-            else None
-        )
+        token_ids = _convert_token_ids(raw_token_ids, block_size) if raw_token_ids is not None else None
 
         return cls(
             event_type="stored",
@@ -132,7 +131,7 @@ class KVCacheEvent:
             block_hashes=block_hashes,
             parent_block_hash=parent_block_hash,
             token_ids=token_ids,
-            block_size=block_size
+            block_size=block_size,
         )
 
     @classmethod
@@ -152,7 +151,7 @@ class KVCacheEvent:
             block_hashes=block_hashes,
             parent_block_hash=None,
             token_ids=None,
-            block_size=None
+            block_size=None,
         )
 
     @classmethod
@@ -164,7 +163,7 @@ class KVCacheEvent:
             block_hashes=[],
             parent_block_hash=None,
             token_ids=None,
-            block_size=None
+            block_size=None,
         )
 
     # ── Tag resolution ───────────────────────────────────────────────────
@@ -233,9 +232,7 @@ def _convert_token_ids(raw_ids: list[int], block_size: int) -> list[bytes]:
     if block_size <= 0:
         raise ValueError(f"block_size must be > 0, got {block_size}")
     if len(raw_ids) % block_size != 0:
-        raise ValueError(
-            f"token_ids len={len(raw_ids)} not divisible by block_size={block_size}"
-        )
+        raise ValueError(f"token_ids len={len(raw_ids)} not divisible by block_size={block_size}")
     num_blocks = len(raw_ids) // block_size
     result: list[bytes] = []
     for i in range(num_blocks):

--- a/uni_agent/llm_router/collectors/decoder/vllm/metrics.py
+++ b/uni_agent/llm_router/collectors/decoder/vllm/metrics.py
@@ -1,0 +1,67 @@
+"""VLLMMetricsDecoder — vLLM Prometheus metrics decoder.
+
+Parses Prometheus exposition-format text and writes results
+to MetricsStore.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from typing import Any
+
+from uni_agent.llm_router.collectors.decoder.base import Decoder
+from uni_agent.llm_router.metric_spec import METRIC_SPECS, MetricKey
+from uni_agent.llm_router.store.metrics_store import MetricsStore
+
+logger = logging.getLogger(__name__)
+
+
+class VLLMMetricsDecoder(Decoder):
+    """vLLM Prometheus metrics decoder — parses HTTP response text
+    and writes results to MetricsStore.
+
+    vLLM Prometheus raw name → canonical key mapping:
+        ``vllm:kv_cache_usage_perc``  → ``KV_CACHE_USAGE_PERC``
+        ``vllm:num_requests_running`` → ``NUM_REQUESTS_RUNNING``
+        ``vllm:num_requests_waiting`` → ``NUM_REQUESTS_WAITING``
+    """
+
+    store_cls = MetricsStore
+
+    _PROMETHEUS_MAP: dict[str, str] = {
+        "vllm:kv_cache_usage_perc":  MetricKey.KV_CACHE_USAGE_PERC,
+        "vllm:num_requests_running": MetricKey.NUM_REQUESTS_RUNNING,
+        "vllm:num_requests_waiting": MetricKey.NUM_REQUESTS_WAITING,
+    }
+
+    def __init__(self) -> None:
+        self._store = self.store_cls.default()
+
+    def decode(self, raw_data: bytes | str, node_id: str) -> None:
+        """Parse Prometheus text and write results to store.
+
+        Args:
+            raw_data: HTTP response text (Prometheus exposition format).
+            node_id: Source replica identifier.
+        """
+        # HTTP delivers str; ignore bytes data
+        if isinstance(raw_data, bytes):
+            logger.debug("VLLMMetricsDecoder received bytes data, expected str — skipping")
+            return
+
+        result: dict[str, Any] = {}
+        for line in raw_data.splitlines():
+            if line.startswith("#") or not line.strip():
+                continue
+            try:
+                raw_name = line.split("{")[0] if "{" in line else line.split()[0]
+                value = float(line.split()[-1])
+            except (ValueError, IndexError):
+                continue
+            canonical = self._PROMETHEUS_MAP.get(raw_name)
+            if canonical:
+                value_type = METRIC_SPECS[canonical].get("value_type", float)
+                result[canonical] = value_type(value)
+
+        self._store.refresh({node_id: result})

--- a/uni_agent/llm_router/collectors/decoder/vllm/metrics.py
+++ b/uni_agent/llm_router/collectors/decoder/vllm/metrics.py
@@ -7,7 +7,6 @@ to MetricsStore.
 from __future__ import annotations
 
 import logging
-
 from typing import Any
 
 from uni_agent.llm_router.collectors.decoder.base import Decoder
@@ -30,7 +29,7 @@ class VLLMMetricsDecoder(Decoder):
     store_cls = MetricsStore
 
     _PROMETHEUS_MAP: dict[str, str] = {
-        "vllm:kv_cache_usage_perc":  MetricKey.KV_CACHE_USAGE_PERC,
+        "vllm:kv_cache_usage_perc": MetricKey.KV_CACHE_USAGE_PERC,
         "vllm:num_requests_running": MetricKey.NUM_REQUESTS_RUNNING,
         "vllm:num_requests_waiting": MetricKey.NUM_REQUESTS_WAITING,
     }

--- a/uni_agent/llm_router/collectors/provider.py
+++ b/uni_agent/llm_router/collectors/provider.py
@@ -1,0 +1,141 @@
+"""RouteDataProvider — unified query entry point for routing decisions.
+
+Strategy layers call ``RouteDataProvider`` methods to get metrics data.
+It delegates to store instances (``MetricsStore`` for polling metrics,
+``KVCacheStore`` for GPU prefix cache data).
+
+Collectors are created from ``BUILTIN_REGISTRY`` as ``Collector``
+instances combining Transport + Decoder.  Stores are singletons —
+deduplication happens automatically at the store level.
+
+All query computations are delegated to the respective store classes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from uni_agent.llm_router.config.router import CollectorConfig
+from uni_agent.llm_router.store.kv_cache_store import KVCacheStore
+from uni_agent.llm_router.store.metrics_store import MetricsStore
+from uni_agent.llm_router.collectors.registry import BUILTIN_REGISTRY
+from uni_agent.llm_router.logging import get_router_logger
+
+logger = get_router_logger("provider")
+
+
+class RouteDataProvider:
+    """Unified query entry point — strategies use this to access all metrics.
+
+    ``RouteDataProvider`` creates collectors via the registry, which
+    combines Transport + Decoder into ``Collector`` instances.  Store
+    deduplication is handled by the store classes themselves (singleton).
+
+    All query computations are delegated to the respective store classes.
+
+    Args:
+        collectors_config: ``CollectorConfig`` — provides common settings
+            and endpoint addresses.
+        collection_names: List of collection names to initialize (e.g.
+            ``["vllm_metrics", "vllm_zmq"]``).
+        server_addresses: ``{replica_id: ip:port}`` for HTTP transport.
+        kv_event_endpoints: ``{replica_id: [sub_addr, replay_addr]}`` for ZMQ transport.
+    """
+
+    def __init__(
+        self,
+        collectors_config,
+        collection_names,
+        server_addresses: dict[str, str] | None = None,
+        kv_event_endpoints: dict[str, list[str]] | None = None,
+    ) -> None:
+        self._collectors: list[Any] = []
+        # Snapshot the collection names for lifecycle logging.
+        self._collection_names = list(collection_names)
+
+        http_polling = collectors_config.http_polling
+        long_conn = collectors_config.long_connection
+
+        for name in collection_names:
+            if name == "vllm_metrics":
+                collector = BUILTIN_REGISTRY.get_collector(
+                    name,
+                    endpoints=server_addresses or {},
+                    interval=http_polling["polling_interval"],
+                    http_timeout=http_polling["http_timeout"],
+                )
+            elif name == "vllm_zmq":
+                collector = BUILTIN_REGISTRY.get_collector(
+                    name,
+                    endpoints=kv_event_endpoints or {},
+                    base_retry_delay=long_conn["base_retry_delay"],
+                    max_retry_delay=long_conn["max_retry_delay"],
+                    max_retry_attempts=long_conn["max_retry_attempts"],
+                    retry_backoff_factor=long_conn["retry_backoff_factor"],
+                )
+            else:
+                collector = BUILTIN_REGISTRY.get_collector(name)
+            self._collectors.append(collector)
+
+        logger.info(
+            "RouteDataProvider created: collection_names=%s, collectors=[%s]",
+            collection_names,
+            ", ".join(type(c).__name__ for c in self._collectors) or "<none>",
+        )
+
+    # ── Lifecycle ───────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        """Start all collectors."""
+        logger.info("RouteDataProvider starting %d collector(s)", len(self._collectors))
+        for name, collector in zip(self._collection_names, self._collectors):
+            collector.start()
+            logger.info(
+                "collector started: name=%s type=%s",
+                name, type(collector).__name__,
+            )
+
+    def stop(self) -> None:
+        """Stop all collectors and await their cleanup."""
+        logger.info("RouteDataProvider stopping %d collector(s)", len(self._collectors))
+        for collector in self._collectors:
+            collector.stop()
+
+    # ── Query proxies (delegate to the singleton stores) ────────────────
+    #
+    # The strategy layer calls these on the provider; they forward to the
+    # appropriate singleton store so callers don't need to know which store
+    # holds which data.  Computation lives in the store classes — the
+    # provider is only a routing shim.
+
+    def get_gpu_prefix_hit_rate(self, prompt_ids: list[int]) -> dict[str, int]:
+        """Per-replica GPU prefix-cache hit percent (0–100).
+
+        Delegates to ``KVCacheStore.default().get_gpu_prefix_hit_rate``.
+        """
+        return KVCacheStore.default().get_gpu_prefix_hit_rate(prompt_ids)
+
+    def get_metrics(self, node_id: str) -> dict[str, Any]:
+        """Get a node's full polling metrics snapshot.
+
+        Delegates to ``MetricsStore.default().get(node_id)``.
+        """
+        return MetricsStore.default().get(node_id)
+
+    def get_metric(self, node_id: str, key: str) -> Any:
+        """Query a single polling metric by canonical key.
+
+        Delegates to ``MetricsStore.default().get(node_id, key)``.
+        """
+        return MetricsStore.default().get(node_id, key)
+
+    def get_tier_prefix_hit_rate(
+        self, node_id: str, prompt_ids: list[int], tier: str,
+    ) -> float | None:
+        """Tier-level (cpu/ssd) prefix-cache hit rate, or ``None`` if unavailable.
+
+        Mooncake tier collection is not yet implemented; the store returns
+        ``0.0`` in that case, which we surface as ``None`` so the slow-path
+        caller can distinguish "no data" from a genuine 0% hit and warn.
+        """
+        return KVCacheStore.default().get_tier_prefix_hit_rate(node_id, prompt_ids, tier) or None

--- a/uni_agent/llm_router/collectors/provider.py
+++ b/uni_agent/llm_router/collectors/provider.py
@@ -15,11 +15,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from uni_agent.llm_router.config.router import CollectorConfig
-from uni_agent.llm_router.store.kv_cache_store import KVCacheStore
-from uni_agent.llm_router.store.metrics_store import MetricsStore
 from uni_agent.llm_router.collectors.registry import BUILTIN_REGISTRY
 from uni_agent.llm_router.logging import get_router_logger
+from uni_agent.llm_router.store.kv_cache_store import KVCacheStore
+from uni_agent.llm_router.store.metrics_store import MetricsStore
 
 logger = get_router_logger("provider")
 
@@ -88,11 +87,12 @@ class RouteDataProvider:
     def start(self) -> None:
         """Start all collectors."""
         logger.info("RouteDataProvider starting %d collector(s)", len(self._collectors))
-        for name, collector in zip(self._collection_names, self._collectors):
+        for name, collector in zip(self._collection_names, self._collectors, strict=False):
             collector.start()
             logger.info(
                 "collector started: name=%s type=%s",
-                name, type(collector).__name__,
+                name,
+                type(collector).__name__,
             )
 
     def stop(self) -> None:
@@ -130,7 +130,10 @@ class RouteDataProvider:
         return MetricsStore.default().get(node_id, key)
 
     def get_tier_prefix_hit_rate(
-        self, node_id: str, prompt_ids: list[int], tier: str,
+        self,
+        node_id: str,
+        prompt_ids: list[int],
+        tier: str,
     ) -> float | None:
         """Tier-level (cpu/ssd) prefix-cache hit rate, or ``None`` if unavailable.
 

--- a/uni_agent/llm_router/collectors/registry.py
+++ b/uni_agent/llm_router/collectors/registry.py
@@ -1,0 +1,115 @@
+"""Registry — lazy registry for transport + decoder combinations.
+
+Built-in entries are registered as ``collection_name → (transport_path, decoder_path)``
+strings.  Classes are imported on first lookup and cached.  A ``Collector``
+is created by combining the resolved Transport and Decoder instances.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+
+from typing import Any
+
+from uni_agent.llm_router.collectors.collector import Collector
+
+logger = logging.getLogger(__name__)
+
+
+class Registry:
+    """Lazy registry — maps collection_name to transport + decoder combination.
+
+    ``register_entry(name, transport_path, decoder_path)`` stores
+    ``"module.path:ClassName"`` strings; classes are imported on first
+    ``get_collector`` call and cached in-place.
+
+    ``get_collector(name, **kwargs)`` resolves both classes, instantiates
+    them, and returns a ``Collector(transport, decoder)`` instance.
+
+    ``get_store(name)`` resolves the decoder and reads its ``store_cls``.
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[str, dict[str, str | type]] = {}
+
+    def register_entry(
+        self,
+        name: str,
+        transport_path: str,
+        decoder_path: str,
+    ) -> None:
+        """Register a lazy entry-point combination.
+
+        Paths use ``"module.path:ClassName"`` format (setuptools entry-point style).
+        """
+        self._entries[name] = {
+            "transport": transport_path,
+            "decoder": decoder_path,
+        }
+
+    def get_collector(self, name: str, **kwargs: Any) -> Collector:
+        """Create a Collector by combining resolved Transport + Decoder.
+
+        Args:
+            name: Collection name key.
+            **kwargs: Keyword arguments forwarded to the Transport
+                constructor.  Decoders are always constructed with no
+                arguments.
+
+        Returns:
+            A ``Collector`` instance with transport + decoder composed.
+        """
+        entry = self._entries.get(name)
+        if entry is None:
+            raise ValueError(
+                f"Unknown collector: '{name}'. Registered: {sorted(self._entries.keys())}"
+            )
+
+        transport_cls = self._resolve(entry["transport"], "transport", name)
+        decoder_cls = self._resolve(entry["decoder"], "decoder", name)
+
+        transport = transport_cls(**kwargs)
+        decoder = decoder_cls()
+
+        return Collector(transport, decoder)
+
+    def get_store(self, name: str) -> type:
+        """Look up the store class for a collection name.
+
+        Derived from the decoder's ``store_cls`` attribute.
+        """
+        entry = self._entries.get(name)
+        if entry is None:
+            raise ValueError(
+                f"Unknown store: '{name}'. Registered: {sorted(self._entries.keys())}"
+            )
+        decoder_cls = self._resolve(entry["decoder"], "decoder", name)
+        return decoder_cls.store_cls
+
+    def _resolve(self, entry: str | type, role: str, name: str) -> type:
+        """Resolve a lazy entry — import from string or return cached class."""
+        if isinstance(entry, type):
+            return entry
+        # Lazy import — "module.path:ClassName"
+        module_path, class_name = entry.rsplit(":", 1)
+        cls = getattr(importlib.import_module(module_path), class_name)
+        # Cache-in-place in the entry dict
+        self._entries[name][role] = cls
+        logger.info("Lazy-imported %s for '%s': %s", role, name, cls.__qualname__)
+        return cls
+
+
+# ── Module-level built-in registration (lazy) ─────────────────────────
+
+BUILTIN_REGISTRY = Registry()
+BUILTIN_REGISTRY.register_entry(
+    "vllm_metrics",
+    transport_path="uni_agent.llm_router.collectors.transport.http:HTTPTransport",
+    decoder_path="uni_agent.llm_router.collectors.decoder.vllm.metrics:VLLMMetricsDecoder",
+)
+BUILTIN_REGISTRY.register_entry(
+    "vllm_zmq",
+    transport_path="uni_agent.llm_router.collectors.transport.zmq:ZMQTransport",
+    decoder_path="uni_agent.llm_router.collectors.decoder.vllm.kv:VLLMKVDecoder",
+)

--- a/uni_agent/llm_router/collectors/registry.py
+++ b/uni_agent/llm_router/collectors/registry.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import importlib
 import logging
-
 from typing import Any
 
 from uni_agent.llm_router.collectors.collector import Collector
@@ -62,9 +61,7 @@ class Registry:
         """
         entry = self._entries.get(name)
         if entry is None:
-            raise ValueError(
-                f"Unknown collector: '{name}'. Registered: {sorted(self._entries.keys())}"
-            )
+            raise ValueError(f"Unknown collector: '{name}'. Registered: {sorted(self._entries.keys())}")
 
         transport_cls = self._resolve(entry["transport"], "transport", name)
         decoder_cls = self._resolve(entry["decoder"], "decoder", name)
@@ -81,9 +78,7 @@ class Registry:
         """
         entry = self._entries.get(name)
         if entry is None:
-            raise ValueError(
-                f"Unknown store: '{name}'. Registered: {sorted(self._entries.keys())}"
-            )
+            raise ValueError(f"Unknown store: '{name}'. Registered: {sorted(self._entries.keys())}")
         decoder_cls = self._resolve(entry["decoder"], "decoder", name)
         return decoder_cls.store_cls
 

--- a/uni_agent/llm_router/collectors/transport/__init__.py
+++ b/uni_agent/llm_router/collectors/transport/__init__.py
@@ -1,0 +1,5 @@
+"""Transport layers — ZMQ, HTTP, etc."""
+
+from uni_agent.llm_router.collectors.transport.base import Transport
+
+__all__ = ["Transport"]

--- a/uni_agent/llm_router/collectors/transport/base.py
+++ b/uni_agent/llm_router/collectors/transport/base.py
@@ -1,0 +1,39 @@
+"""Transport — abstract base for data transport layers.
+
+A Transport fetches raw data from a network source (ZMQ, HTTP, etc.)
+and delivers it to a handler callback.  It does NOT decode or interpret
+the data — that is the Decoder's job.
+
+Lifecycle:
+    ``subscribe(handler)`` — async; starts the data-fetch loop,
+        calls ``handler(raw_data, node_id)`` for each received item.
+    ``stop()`` — sync; blocks until the transport has fully shut down.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Callable
+
+
+class Transport(ABC):
+    """Abstract base for data transport layers.
+
+    Subclasses implement ``subscribe()`` with their protocol-specific
+    connection and data-fetch logic.  ``stop()`` cancels connections
+    and blocks until cleanup is complete.
+    """
+
+    @abstractmethod
+    async def subscribe(self, handler: Callable[[bytes | str, str], None]) -> None:
+        """Start data acquisition and deliver each item to handler.
+
+        Args:
+            handler: Callback that receives (raw_data, node_id).
+                raw_data is ``bytes`` (ZMQ) or ``str`` (HTTP response text).
+                node_id identifies the source replica/node.
+        """
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Stop the transport synchronously — blocks until cleanup is done."""

--- a/uni_agent/llm_router/collectors/transport/http.py
+++ b/uni_agent/llm_router/collectors/transport/http.py
@@ -1,0 +1,85 @@
+"""HTTPTransport — Prometheus HTTP polling transport.
+
+Polls ``http://{address}/metrics`` for each replica at a fixed interval
+and delivers response text to the handler callback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from typing import Callable
+
+import httpx
+
+from uni_agent.llm_router.collectors.transport.base import Transport
+
+logger = logging.getLogger(__name__)
+
+
+class HTTPTransport(Transport):
+    """HTTP polling transport — fetches Prometheus metrics from replicas.
+
+    Each replica endpoint is polled at ``interval`` via ``httpx.AsyncClient``.
+    Response text is delivered to the handler callback for decoding.
+
+    Args:
+        endpoints: ``{replica_id: ip:port}`` — each address polls
+            ``http://{address}/metrics``.
+        interval: Polling interval in seconds.
+        http_timeout: HTTP request timeout in seconds.
+    """
+
+    def __init__(
+        self,
+        endpoints: dict[str, str],
+        interval: float = 5.0,
+        http_timeout: float = 10.0,
+    ) -> None:
+        self._endpoints: dict[str, str] = {
+            nid: f"http://{addr}/metrics" for nid, addr in endpoints.items()
+        }
+        self._interval = interval
+        self._http_timeout = http_timeout
+        self._client: httpx.AsyncClient | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    async def subscribe(self, handler: Callable[[bytes | str, str], None]) -> None:
+        """Start the HTTP polling loop — delivers response text to handler."""
+        self._loop = asyncio.get_running_loop()
+        # trust_env=False: bypass HTTP(S)_PROXY env vars so polling requests to
+        # replica /metrics endpoints (e.g. 172.17.x or 127.0.0.1) are not hijacked
+        # by a container's outbound proxy — that would blind the router.
+        self._client = httpx.AsyncClient(timeout=self._http_timeout, trust_env=False)
+        try:
+            while True:
+                coros = {nid: self._client.get(url) for nid, url in self._endpoints.items()}
+                responses = await asyncio.gather(*coros.values(), return_exceptions=True)
+                for nid, resp in zip(coros.keys(), responses):
+                    if isinstance(resp, Exception):
+                        continue  # failed node — handler falls back to defaults
+                    try:
+                        handler(resp.text, nid)
+                    except Exception as exc:
+                        logger.debug("Handler error for node %s: %s", nid, exc)
+                await asyncio.sleep(self._interval)
+        except asyncio.CancelledError:
+            pass
+
+    def stop(self) -> None:
+        """Stop HTTP polling — close the client on the event-loop thread.
+
+        The Collector cancels the subscribe task, which exits the loop.  The
+        AsyncClient must be closed *on the running loop* (httpx/anyio raise
+        ``NoEventLoopError`` if aclose runs after the loop stops), so we
+        schedule the close via ``run_coroutine_threadsafe`` while the loop is
+        still alive.
+        """
+        if self._client is not None and self._loop is not None and self._loop.is_running():
+            try:
+                fut = asyncio.run_coroutine_threadsafe(self._client.aclose(), self._loop)
+                fut.result(timeout=5)
+            except Exception as exc:
+                logger.debug("Error closing HTTP client: %s", exc)
+            self._client = None

--- a/uni_agent/llm_router/collectors/transport/http.py
+++ b/uni_agent/llm_router/collectors/transport/http.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-
 from typing import Callable
 
 import httpx
@@ -37,9 +36,7 @@ class HTTPTransport(Transport):
         interval: float = 5.0,
         http_timeout: float = 10.0,
     ) -> None:
-        self._endpoints: dict[str, str] = {
-            nid: f"http://{addr}/metrics" for nid, addr in endpoints.items()
-        }
+        self._endpoints: dict[str, str] = {nid: f"http://{addr}/metrics" for nid, addr in endpoints.items()}
         self._interval = interval
         self._http_timeout = http_timeout
         self._client: httpx.AsyncClient | None = None
@@ -56,7 +53,7 @@ class HTTPTransport(Transport):
             while True:
                 coros = {nid: self._client.get(url) for nid, url in self._endpoints.items()}
                 responses = await asyncio.gather(*coros.values(), return_exceptions=True)
-                for nid, resp in zip(coros.keys(), responses):
+                for nid, resp in zip(coros.keys(), responses, strict=False):
                     if isinstance(resp, Exception):
                         continue  # failed node — handler falls back to defaults
                     try:

--- a/uni_agent/llm_router/collectors/transport/zmq.py
+++ b/uni_agent/llm_router/collectors/transport/zmq.py
@@ -1,0 +1,244 @@
+"""ZMQTransport — ZMQ replay + sub dual socket transport.
+
+Connects to per-replica ZMQ endpoints (sub + replay), subscribes to
+live events, and delivers raw payloads to the handler callback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from dataclasses import dataclass
+from typing import Callable
+
+import zmq
+import zmq.asyncio
+
+from uni_agent.llm_router.collectors.transport.base import Transport
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _ReplicaSocketSet:
+    """Per-replica ZMQ socket bundle (internal — not exported)."""
+
+    node_id: str
+    context: zmq.asyncio.Context
+    sub_socket: zmq.asyncio.Socket
+    replay_socket: zmq.asyncio.Socket
+
+
+class ZMQTransport(Transport):
+    """ZMQ transport — replay + sub dual socket per replica.
+
+    Each replica endpoint gets its own ZMQ context, socket pair, and
+    background coroutine — all replicas subscribe concurrently.
+
+    Args:
+        endpoints: ``{replica_id: [sub_ip:port, replay_ip:port]}``
+            — per-replica ZMQ endpoint addresses.
+        topic: ZMQ subscription topic filter (default ``"kv-events"``).
+        base_retry_delay: Initial retry delay in seconds.
+        max_retry_delay: Maximum retry delay cap in seconds.
+        max_retry_attempts: Maximum number of retries per replica.
+        retry_backoff_factor: Exponential backoff multiplier.
+    """
+
+    def __init__(
+        self,
+        endpoints: dict[str, list[str]],
+        topic: str = "kv-events",
+        base_retry_delay: float = 1.0,
+        max_retry_delay: float = 30.0,
+        max_retry_attempts: int = 5,
+        retry_backoff_factor: float = 2.0,
+    ) -> None:
+        self._topic = topic
+        self._base_retry_delay = base_retry_delay
+        self._max_retry_delay = max_retry_delay
+        self._max_retry_attempts = max_retry_attempts
+        self._retry_backoff_factor = retry_backoff_factor
+
+        self._sub_endpoints: dict[str, str] = {}
+        self._replay_endpoints: dict[str, str] = {}
+        for replica_id, addrs in endpoints.items():
+            self._sub_endpoints[replica_id] = f"tcp://{addrs[0]}"
+            self._replay_endpoints[replica_id] = f"tcp://{addrs[1]}"
+
+        self._stopped = False
+        self._replica_sockets: dict[str, _ReplicaSocketSet] = {}
+        self._retry_counts: dict[str, int] = {}
+        self._sub_tasks: dict[str, asyncio.Task] = {}
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    async def subscribe(self, handler: Callable[[bytes | str, str], None]) -> None:
+        """Spawn per-replica subscription tasks, deliver payloads to handler."""
+        self._loop = asyncio.get_running_loop()
+        sub_tasks = []
+        for node_id in self._sub_endpoints:
+            sub_addr = self._sub_endpoints[node_id]
+            replay_addr = self._replay_endpoints[node_id]
+            t = asyncio.create_task(
+                self._subscribe_for_replica(node_id, sub_addr, replay_addr, handler)
+            )
+            self._sub_tasks[node_id] = t
+            sub_tasks.append(t)
+        try:
+            await asyncio.gather(*sub_tasks, return_exceptions=True)
+        except asyncio.CancelledError:
+            for t in self._sub_tasks.values():
+                t.cancel()
+        finally:
+            self._close_all_zmq_sockets()
+
+    def stop(self) -> None:
+        """Stop ZMQ subscription synchronously — blocks until cleanup is done."""
+        self._stopped = True
+        for task in self._sub_tasks.values():
+            task.cancel()
+        for task in self._sub_tasks.values():
+            try:
+                if self._loop is not None:
+                    done_future = asyncio.run_coroutine_threadsafe(
+                        self._wait_task(task), self._loop,
+                    )
+                    done_future.result(timeout=10)
+            except (asyncio.CancelledError, Exception) as exc:
+                logger.debug("Error waiting for ZMQ sub task to finish: %s", exc)
+        self._sub_tasks.clear()
+        self._close_all_zmq_sockets()
+
+    async def _wait_task(self, task: asyncio.Task) -> None:
+        """Await a task — used by stop() for blocking wait."""
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    # ── ZMQ connection management ───────────────────────────────────────
+
+    async def _connect_zmq_for(
+        self, node_id: str, sub_addr: str, replay_addr: str,
+    ) -> bool:
+        """Create ZMQ context and replay + sub dual socket for a single replica."""
+        try:
+            ctx = zmq.asyncio.Context()
+
+            sub_socket = ctx.socket(zmq.SUB)
+            sub_socket.connect(sub_addr)
+            sub_socket.setsockopt_string(zmq.SUBSCRIBE, self._topic)
+
+            replay_socket = ctx.socket(zmq.REQ)
+            replay_socket.connect(replay_addr)
+
+            self._replica_sockets[node_id] = _ReplicaSocketSet(
+                node_id=node_id,
+                context=ctx,
+                sub_socket=sub_socket,
+                replay_socket=replay_socket,
+            )
+            self._retry_counts[node_id] = 0
+            return True
+
+        except zmq.ZMQError as exc:
+            logger.warning("ZMQ connection error for node %s: %s", node_id, exc)
+            self._close_zmq_sockets_for(node_id)
+            return False
+
+    def _close_zmq_sockets_for(self, node_id: str) -> None:
+        """Safely close ZMQ sockets and context for a single replica."""
+        sockets = self._replica_sockets.pop(node_id, None)
+        if sockets is None:
+            return
+        sockets.sub_socket.close()
+        sockets.replay_socket.close()
+        sockets.context.term()
+
+    def _close_all_zmq_sockets(self) -> None:
+        """Close all per-replica ZMQ sockets and contexts."""
+        for node_id in list(self._replica_sockets.keys()):
+            self._close_zmq_sockets_for(node_id)
+
+    async def _reconnect_with_backoff_for(
+        self, node_id: str, sub_addr: str, replay_addr: str,
+    ) -> bool:
+        """Exponential backoff reconnect for a single replica."""
+        retry_count = self._retry_counts.get(node_id, 0)
+        while retry_count < self._max_retry_attempts:
+            delay = min(
+                self._base_retry_delay * (self._retry_backoff_factor ** retry_count),
+                self._max_retry_delay,
+            )
+            await asyncio.sleep(delay)
+            retry_count += 1
+            self._retry_counts[node_id] = retry_count
+
+            if await self._connect_zmq_for(node_id, sub_addr, replay_addr):
+                return True
+
+        return False
+
+    # ── Per-replica subscription ────────────────────────────────────────
+
+    async def _subscribe_for_replica(
+        self, node_id: str, sub_addr: str, replay_addr: str,
+        handler: Callable[[bytes | str, str], None],
+    ) -> None:
+        """Per-replica subscription: connect → replay → subscribe loop."""
+        try:
+            if not await self._connect_zmq_for(node_id, sub_addr, replay_addr):
+                if not await self._reconnect_with_backoff_for(node_id, sub_addr, replay_addr):
+                    return
+
+            await self._replay_historical_data_for(node_id, handler)
+
+            sockets = self._replica_sockets.get(node_id)
+            if sockets is None:
+                return
+
+            while not self._stopped:
+                try:
+                    parts = await sockets.sub_socket.recv_multipart()
+                    payload = parts[-1]
+                    handler(payload, node_id)
+                except zmq.ZMQError:
+                    self._close_zmq_sockets_for(node_id)
+                    if not await self._reconnect_with_backoff_for(node_id, sub_addr, replay_addr):
+                        break
+                    await self._replay_historical_data_for(node_id, handler)
+
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self._close_zmq_sockets_for(node_id)
+
+    # ── Replay ──────────────────────────────────────────────────────────
+
+    async def _replay_historical_data_for(
+        self, node_id: str, handler: Callable[[bytes | str, str], None],
+    ) -> None:
+        """Request replay of historical data for a single replica.
+        Degrade to subscription-only on failure."""
+        sockets = self._replica_sockets.get(node_id)
+        if sockets is None or sockets.replay_socket is None:
+            return
+
+        try:
+            await sockets.replay_socket.send(b"replay")
+
+            try:
+                replay_data = await asyncio.wait_for(
+                    sockets.replay_socket.recv(), timeout=5.0,
+                )
+            except asyncio.TimeoutError:
+                return  # timeout → degrade to subscription-only
+
+            if replay_data:
+                for line in replay_data.splitlines():
+                    if line.strip():
+                        handler(line, node_id)
+
+        except zmq.ZMQError as exc:
+            logger.warning("ZMQ replay error for node %s: %s", node_id, exc)

--- a/uni_agent/llm_router/collectors/transport/zmq.py
+++ b/uni_agent/llm_router/collectors/transport/zmq.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-
 from dataclasses import dataclass
 from typing import Callable
 
@@ -80,9 +79,7 @@ class ZMQTransport(Transport):
         for node_id in self._sub_endpoints:
             sub_addr = self._sub_endpoints[node_id]
             replay_addr = self._replay_endpoints[node_id]
-            t = asyncio.create_task(
-                self._subscribe_for_replica(node_id, sub_addr, replay_addr, handler)
-            )
+            t = asyncio.create_task(self._subscribe_for_replica(node_id, sub_addr, replay_addr, handler))
             self._sub_tasks[node_id] = t
             sub_tasks.append(t)
         try:
@@ -102,7 +99,8 @@ class ZMQTransport(Transport):
             try:
                 if self._loop is not None:
                     done_future = asyncio.run_coroutine_threadsafe(
-                        self._wait_task(task), self._loop,
+                        self._wait_task(task),
+                        self._loop,
                     )
                     done_future.result(timeout=10)
             except (asyncio.CancelledError, Exception) as exc:
@@ -120,7 +118,10 @@ class ZMQTransport(Transport):
     # ── ZMQ connection management ───────────────────────────────────────
 
     async def _connect_zmq_for(
-        self, node_id: str, sub_addr: str, replay_addr: str,
+        self,
+        node_id: str,
+        sub_addr: str,
+        replay_addr: str,
     ) -> bool:
         """Create ZMQ context and replay + sub dual socket for a single replica."""
         try:
@@ -162,13 +163,16 @@ class ZMQTransport(Transport):
             self._close_zmq_sockets_for(node_id)
 
     async def _reconnect_with_backoff_for(
-        self, node_id: str, sub_addr: str, replay_addr: str,
+        self,
+        node_id: str,
+        sub_addr: str,
+        replay_addr: str,
     ) -> bool:
         """Exponential backoff reconnect for a single replica."""
         retry_count = self._retry_counts.get(node_id, 0)
         while retry_count < self._max_retry_attempts:
             delay = min(
-                self._base_retry_delay * (self._retry_backoff_factor ** retry_count),
+                self._base_retry_delay * (self._retry_backoff_factor**retry_count),
                 self._max_retry_delay,
             )
             await asyncio.sleep(delay)
@@ -183,7 +187,10 @@ class ZMQTransport(Transport):
     # ── Per-replica subscription ────────────────────────────────────────
 
     async def _subscribe_for_replica(
-        self, node_id: str, sub_addr: str, replay_addr: str,
+        self,
+        node_id: str,
+        sub_addr: str,
+        replay_addr: str,
         handler: Callable[[bytes | str, str], None],
     ) -> None:
         """Per-replica subscription: connect → replay → subscribe loop."""
@@ -217,7 +224,9 @@ class ZMQTransport(Transport):
     # ── Replay ──────────────────────────────────────────────────────────
 
     async def _replay_historical_data_for(
-        self, node_id: str, handler: Callable[[bytes | str, str], None],
+        self,
+        node_id: str,
+        handler: Callable[[bytes | str, str], None],
     ) -> None:
         """Request replay of historical data for a single replica.
         Degrade to subscription-only on failure."""
@@ -230,7 +239,8 @@ class ZMQTransport(Transport):
 
             try:
                 replay_data = await asyncio.wait_for(
-                    sockets.replay_socket.recv(), timeout=5.0,
+                    sockets.replay_socket.recv(),
+                    timeout=5.0,
                 )
             except asyncio.TimeoutError:
                 return  # timeout → degrade to subscription-only

--- a/uni_agent/llm_router/config/__init__.py
+++ b/uni_agent/llm_router/config/__init__.py
@@ -1,0 +1,20 @@
+"""KVCAware LLM Router configuration package.
+"""
+
+from uni_agent.llm_router.config.base import (
+    ConfigError,
+    StrategyConfig,
+)
+from uni_agent.llm_router.config.cache import CacheStoreConfig
+from uni_agent.llm_router.config.collector import CollectorConfig
+from uni_agent.llm_router.config.router import KVCAwareConfig
+from uni_agent.llm_router.config.strategy import KVCAwareStrategyConfig
+
+__all__ = [
+    "CacheStoreConfig",
+    "CollectorConfig",
+    "ConfigError",
+    "KVCAwareConfig",
+    "KVCAwareStrategyConfig",
+    "StrategyConfig",
+]

--- a/uni_agent/llm_router/config/__init__.py
+++ b/uni_agent/llm_router/config/__init__.py
@@ -1,5 +1,4 @@
-"""KVCAware LLM Router configuration package.
-"""
+"""KVCAware LLM Router configuration package."""
 
 from uni_agent.llm_router.config.base import (
     ConfigError,

--- a/uni_agent/llm_router/config/base.py
+++ b/uni_agent/llm_router/config/base.py
@@ -1,0 +1,108 @@
+"""Base config classes and multi-line repr helpers for KVCAware LLM Router.
+
+This module holds the shared config primitives and the ``_multiline_repr`` helpers
+used by every config dataclass.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields, is_dataclass
+from typing import Any
+
+from omegaconf import DictConfig, ListConfig
+
+
+class ConfigError(ValueError):
+    """Raised when config validation fails."""
+
+
+# ============================================================
+# Multi-line repr helpers (shared by all config dataclasses)
+# ============================================================
+
+
+def _format_value(value: Any, indent: int) -> str:
+    """Format a value for multi-line repr, recursing into nested containers."""
+    if is_dataclass(value) and not isinstance(value, type):
+        return _multiline_repr(value, indent)
+    if isinstance(value, (list, ListConfig)):
+        items = list(value)
+        if not items:
+            return "[]"
+        inner = ",\n".join(
+            f"{' ' * (indent + 2)}{_format_value(v, indent + 2)}" for v in items
+        )
+        return f"[\n{inner},\n{' ' * indent}]"
+    if isinstance(value, (dict, DictConfig)):
+        pairs = list(value.items())
+        if not pairs:
+            return "{}"
+        inner = ",\n".join(
+            f"{' ' * (indent + 2)}{k!r}: {_format_value(v, indent + 2)}"
+            for k, v in pairs
+        )
+        return "{\n" + inner + f",\n{' ' * indent}}}"
+    return repr(value)
+
+
+def _multiline_repr(obj: Any, indent: int = 0) -> str:
+    """Multi-line indented repr for a dataclass instance.
+
+    Each field on its own line; nested dataclasses/lists/dicts recurse with
+    deeper indentation.  Produces a readable tree, e.g.::
+
+        KVCAwareConfig(
+          strategies=[
+            KVCAwareStrategyConfig(
+              weight=1.0,
+              ...
+            ),
+          ],
+          ...
+        )
+    """
+    pad = " " * indent
+    inner_pad = " " * (indent + 2)
+    parts = []
+    for f in fields(obj):
+        if not f.repr:
+            continue
+        val = getattr(obj, f.name)
+        parts.append(f"{f.name}={_format_value(val, indent + 2)}")
+    if not parts:
+        return f"{type(obj).__name__}()"
+    body = ",\n".join(f"{inner_pad}{p}" for p in parts)
+    return f"{type(obj).__name__}(\n{body},\n{pad})"
+
+
+# ============================================================
+# Strategy base class
+# ============================================================
+
+@dataclass(repr=False)
+class StrategyConfig:
+    """Base config for routing strategies.
+
+    All strategy configs inherit this and must provide ``weight`` and
+    ``collector_names`` (the list of collector names this strategy uses).
+
+    Attributes:
+        weight: Multi-strategy weighting coefficient (0 < weight ≤ 1).
+        collector_names: Collector names this strategy binds to.
+    """
+
+    weight: float
+    collector_names: list[str]
+
+    def __post_init__(self) -> None:
+        if not (0 < self.weight <= 1):
+            raise ConfigError(f"weight must be in (0, 1], got {self.weight}")
+        if not isinstance(self.collector_names, (list, ListConfig)):
+            raise ConfigError(
+                f"collector_names must be a list, got {type(self.collector_names).__name__}"
+            )
+        # Normalize ListConfig → plain list for consistent downstream use
+        if isinstance(self.collector_names, ListConfig):
+            object.__setattr__(self, "collector_names", list(self.collector_names))
+
+    __repr__ = _multiline_repr

--- a/uni_agent/llm_router/config/base.py
+++ b/uni_agent/llm_router/config/base.py
@@ -25,22 +25,17 @@ def _format_value(value: Any, indent: int) -> str:
     """Format a value for multi-line repr, recursing into nested containers."""
     if is_dataclass(value) and not isinstance(value, type):
         return _multiline_repr(value, indent)
-    if isinstance(value, (list, ListConfig)):
+    if isinstance(value, list | ListConfig):
         items = list(value)
         if not items:
             return "[]"
-        inner = ",\n".join(
-            f"{' ' * (indent + 2)}{_format_value(v, indent + 2)}" for v in items
-        )
+        inner = ",\n".join(f"{' ' * (indent + 2)}{_format_value(v, indent + 2)}" for v in items)
         return f"[\n{inner},\n{' ' * indent}]"
-    if isinstance(value, (dict, DictConfig)):
+    if isinstance(value, dict | DictConfig):
         pairs = list(value.items())
         if not pairs:
             return "{}"
-        inner = ",\n".join(
-            f"{' ' * (indent + 2)}{k!r}: {_format_value(v, indent + 2)}"
-            for k, v in pairs
-        )
+        inner = ",\n".join(f"{' ' * (indent + 2)}{k!r}: {_format_value(v, indent + 2)}" for k, v in pairs)
         return "{\n" + inner + f",\n{' ' * indent}}}"
     return repr(value)
 
@@ -79,6 +74,7 @@ def _multiline_repr(obj: Any, indent: int = 0) -> str:
 # Strategy base class
 # ============================================================
 
+
 @dataclass(repr=False)
 class StrategyConfig:
     """Base config for routing strategies.
@@ -97,10 +93,8 @@ class StrategyConfig:
     def __post_init__(self) -> None:
         if not (0 < self.weight <= 1):
             raise ConfigError(f"weight must be in (0, 1], got {self.weight}")
-        if not isinstance(self.collector_names, (list, ListConfig)):
-            raise ConfigError(
-                f"collector_names must be a list, got {type(self.collector_names).__name__}"
-            )
+        if not isinstance(self.collector_names, list | ListConfig):
+            raise ConfigError(f"collector_names must be a list, got {type(self.collector_names).__name__}")
         # Normalize ListConfig → plain list for consistent downstream use
         if isinstance(self.collector_names, ListConfig):
             object.__setattr__(self, "collector_names", list(self.collector_names))

--- a/uni_agent/llm_router/config/cache.py
+++ b/uni_agent/llm_router/config/cache.py
@@ -1,0 +1,29 @@
+"""CacheStore config."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from uni_agent.llm_router.config.base import ConfigError, _multiline_repr
+
+
+_VALID_KV_CACHE_STORE_TYPES = {"list", "radix_tree"}
+
+
+@dataclass(repr=False)
+class CacheStoreConfig:
+    """Config for CacheStore — passive storage layer for decoded metrics data."""
+
+    kv_cache_store_type: str = "list"
+    ttl: float = 30.0
+
+    def __post_init__(self) -> None:
+        if self.kv_cache_store_type not in _VALID_KV_CACHE_STORE_TYPES:
+            raise ConfigError(
+                f"kv_cache_store_type must be one of {_VALID_KV_CACHE_STORE_TYPES}, "
+                f"got '{self.kv_cache_store_type}'"
+            )
+        if self.ttl <= 0:
+            raise ConfigError(f"ttl must be > 0, got {self.ttl}")
+
+    __repr__ = _multiline_repr

--- a/uni_agent/llm_router/config/cache.py
+++ b/uni_agent/llm_router/config/cache.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 
 from uni_agent.llm_router.config.base import ConfigError, _multiline_repr
 
-
 _VALID_KV_CACHE_STORE_TYPES = {"list", "radix_tree"}
 
 
@@ -20,8 +19,7 @@ class CacheStoreConfig:
     def __post_init__(self) -> None:
         if self.kv_cache_store_type not in _VALID_KV_CACHE_STORE_TYPES:
             raise ConfigError(
-                f"kv_cache_store_type must be one of {_VALID_KV_CACHE_STORE_TYPES}, "
-                f"got '{self.kv_cache_store_type}'"
+                f"kv_cache_store_type must be one of {_VALID_KV_CACHE_STORE_TYPES}, got '{self.kv_cache_store_type}'"
             )
         if self.ttl <= 0:
             raise ConfigError(f"ttl must be > 0, got {self.ttl}")

--- a/uni_agent/llm_router/config/collector.py
+++ b/uni_agent/llm_router/config/collector.py
@@ -1,0 +1,90 @@
+"""Collector config: connection-type tuning parameters shared by all collectors.
+
+Individual collectors are referenced by name (via ``collector_names`` on
+strategies); this config carries the shared tuning knobs grouped by
+connection type, not per-collector definitions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from uni_agent.llm_router.config.base import ConfigError, _multiline_repr
+
+
+_DEFAULT_HTTP_POLLING: dict[str, float] = {
+    "polling_interval": 5.0,
+    "http_timeout": 10.0,
+}
+
+_DEFAULT_LONG_CONNECTION: dict[str, float | int] = {
+    "base_retry_delay": 1.0,
+    "max_retry_delay": 30.0,
+    "max_retry_attempts": 5,
+    "retry_backoff_factor": 2.0,
+}
+
+
+def _validate_http_polling(params: dict[str, float]) -> None:
+    """Validate http_polling dict parameters.
+
+    Only validates keys that are present; absent keys are left to defaults
+    at runtime.  Future HTTP polling parameters can be added without
+    changing this signature.
+    """
+    pi = params.get("polling_interval", 5.0)
+    ht = params.get("http_timeout", 10.0)
+    if "polling_interval" in params and pi <= 0:
+        raise ConfigError(f"polling_interval must be > 0, got {pi}")
+    if "http_timeout" in params and ht <= 0:
+        raise ConfigError(f"http_timeout must be > 0, got {ht}")
+
+
+def _validate_long_connection(params: dict[str, float | int]) -> None:
+    """Validate long_connection dict parameters.
+
+    Only validates keys that are present; absent keys are left to defaults
+    at runtime.  Future long-connection parameters can be added without
+    changing this signature.
+    """
+    brd = params.get("base_retry_delay", 1.0)
+    mrd = params.get("max_retry_delay", 30.0)
+    mra = params.get("max_retry_attempts", 5)
+    rbf = params.get("retry_backoff_factor", 2.0)
+    if "base_retry_delay" in params and brd <= 0:
+        raise ConfigError(f"base_retry_delay must be > 0, got {brd}")
+    if "max_retry_delay" in params and mrd < brd:
+        raise ConfigError(
+            f"max_retry_delay must be >= base_retry_delay, "
+            f"got max_retry_delay={mrd} < base_retry_delay={brd}"
+        )
+    if "max_retry_attempts" in params and mra < 1:
+        raise ConfigError(f"max_retry_attempts must be >= 1, got {mra}")
+    if "retry_backoff_factor" in params and rbf <= 0:
+        raise ConfigError(f"retry_backoff_factor must be > 0, got {rbf}")
+
+
+@dataclass(repr=False)
+class CollectorConfig:
+    """Config for the collectors module: connection-type tuning parameters.
+
+    Tuning parameters are grouped by connection type as plain dicts:
+    - ``http_polling``: HTTP polling-related parameters (e.g. polling_interval,
+      http_timeout).  More HTTP parameters may be added in the future.
+    - ``long_connection``: Long-connection-related parameters (e.g. base_retry_delay,
+      max_retry_delay, max_retry_attempts, retry_backoff_factor).  More
+      long-connection parameters may be added in the future.
+
+    Attributes:
+        http_polling: HTTP polling tuning parameters dict.
+        long_connection: Long-connection tuning parameters dict.
+    """
+
+    http_polling: dict[str, float] = field(default_factory=lambda: dict(_DEFAULT_HTTP_POLLING))
+    long_connection: dict[str, float | int] = field(default_factory=lambda: dict(_DEFAULT_LONG_CONNECTION))
+
+    def __post_init__(self) -> None:
+        _validate_http_polling(self.http_polling)
+        _validate_long_connection(self.long_connection)
+
+    __repr__ = _multiline_repr

--- a/uni_agent/llm_router/config/collector.py
+++ b/uni_agent/llm_router/config/collector.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass, field
 
 from uni_agent.llm_router.config.base import ConfigError, _multiline_repr
 
-
 _DEFAULT_HTTP_POLLING: dict[str, float] = {
     "polling_interval": 5.0,
     "http_timeout": 10.0,
@@ -55,8 +54,7 @@ def _validate_long_connection(params: dict[str, float | int]) -> None:
         raise ConfigError(f"base_retry_delay must be > 0, got {brd}")
     if "max_retry_delay" in params and mrd < brd:
         raise ConfigError(
-            f"max_retry_delay must be >= base_retry_delay, "
-            f"got max_retry_delay={mrd} < base_retry_delay={brd}"
+            f"max_retry_delay must be >= base_retry_delay, got max_retry_delay={mrd} < base_retry_delay={brd}"
         )
     if "max_retry_attempts" in params and mra < 1:
         raise ConfigError(f"max_retry_attempts must be >= 1, got {mra}")

--- a/uni_agent/llm_router/config/router.py
+++ b/uni_agent/llm_router/config/router.py
@@ -1,0 +1,224 @@
+"""Top-level KVCAwareConfig and parsing logic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from hydra.errors import InstantiationException
+from hydra.utils import instantiate
+from omegaconf import DictConfig, ListConfig, OmegaConf
+
+from uni_agent.llm_router.config.base import (
+    ConfigError,
+    StrategyConfig,
+    _multiline_repr,
+)
+from uni_agent.llm_router.config.cache import CacheStoreConfig
+from uni_agent.llm_router.config.collector import CollectorConfig
+
+
+# ============================================================
+# Top-level KVCAwareConfig
+# ============================================================
+
+_DEFAULT_COLLECTOR = CollectorConfig()
+_DEFAULT_CACHE_STORE = CacheStoreConfig()
+
+
+@dataclass(repr=False)
+class KVCAwareConfig:
+    """Top-level config for KVCAwareBalancer, parsed from OmegaConf DictConfig.
+
+    VeRL loads router YAML from ``router_config_path``, then passes the
+    resulting DictConfig to the Balancer constructor.  The Balancer calls
+    ``from_config(cfg)`` to obtain this fully-resolved dataclass instance.
+
+    Attributes:
+        strategies: Polymorphic strategy list (each with ``_target_``).
+        collector: Collector module connection-type tuning config.
+        cache_store: CacheStore configuration.
+        sticky_max_size: Capacity of the request_id→replica sticky-session LRU
+            table. Bound conversations stay affinity-bound to their replica
+            until it is removed or evicted by LRU. Default 10000 (mirrors verl
+            ``DEFAULT_ROUTING_CACHE_SIZE``).
+    """
+
+    strategies: list[StrategyConfig]  # required, no default
+    collector: CollectorConfig = field(default_factory=lambda: _DEFAULT_COLLECTOR)
+    cache_store: CacheStoreConfig = field(default_factory=lambda: _DEFAULT_CACHE_STORE)
+    sticky_max_size: int = 10000
+
+    @classmethod
+    def from_config(cls, cfg: DictConfig | dict) -> KVCAwareConfig:
+        """Two-step parsing of VeRL-transmitted config.
+
+        Step 1: OmegaConf.merge for auto-recursive dataclass fields
+                (collector, cache_store).
+
+        Step 2: Manual traversal of strategies (list or dict from Hydra
+                defaults composition) — instantiate each ``_target_`` entry.
+        """
+        if not isinstance(cfg, (DictConfig, dict)):
+            raise ConfigError(f"cfg must be DictConfig or dict, got {type(cfg)}")
+
+        cfg = OmegaConf.create(cfg)
+
+        # ── Extract polymorphic sections before merge ──────────────
+        # NOTE: VeRL passes a plain dict (from hydra.compose → to_container) that
+        # also carries `router_class` (Balancer FQN for VeRL's importlib lookup).
+        # `router_class` is VeRL-side metadata, NOT part of the config domain —
+        # from_config only extracts strategies/collector/cache_store below, so
+        # it is silently ignored. Top-level `_target_` is defensively popped too
+        # (legacy/structured-input compatibility); the current YAML has none.
+        strategies_raw = _extract_strategies(cfg)
+
+        # ── Step 1: merge dataclass-typed fields (collector, cache_store) ──
+        defaults = OmegaConf.create({
+            "collector": OmegaConf.structured(CollectorConfig),
+            "cache_store": OmegaConf.structured(CacheStoreConfig),
+        })
+        kwargs_for_merge = OmegaConf.create(cfg)
+        # Remove polymorphic sections to avoid ReadonlyConfigError
+        for key in ("strategies", "_target_"):
+            if key in kwargs_for_merge:
+                OmegaConf.set_struct(kwargs_for_merge, False)
+                kwargs_for_merge.pop(key, None)
+                OmegaConf.set_struct(kwargs_for_merge, True)
+
+        # Validate non-dict types for collector/cache_store
+        if ("collector" in kwargs_for_merge
+                and kwargs_for_merge.collector is not None
+                and not isinstance(kwargs_for_merge.collector, (dict, DictConfig))):
+            raise ConfigError(
+                f"collector must be a dict, got {type(kwargs_for_merge.collector).__name__}"
+            )
+        if ("cache_store" in kwargs_for_merge
+                and kwargs_for_merge.cache_store is not None
+                and not isinstance(kwargs_for_merge.cache_store, (dict, DictConfig))):
+            raise ConfigError(
+                f"cache_store must be a dict, got {type(kwargs_for_merge.cache_store).__name__}"
+            )
+
+        merged = OmegaConf.merge(defaults, kwargs_for_merge)
+        config_obj = OmegaConf.to_object(merged)
+
+        # Extract resolved dataclass fields
+        if isinstance(config_obj, dict):
+            collector_cfg = config_obj.get("collector") or CollectorConfig()
+            cache_store_cfg = config_obj.get("cache_store") or CacheStoreConfig()
+            sticky_max_size = config_obj.get("sticky_max_size", 10000)
+        else:
+            collector_cfg = getattr(config_obj, "collector", None) or CollectorConfig()
+            cache_store_cfg = getattr(config_obj, "cache_store", None) or CacheStoreConfig()
+            sticky_max_size = getattr(config_obj, "sticky_max_size", 10000)
+
+        # ── Step 2: parse strategies (polymorphic list) ────────────
+        if strategies_raw is None:
+            raise ConfigError("strategies is required — must be explicitly configured")
+        strategies = _parse_polymorphic_list(
+            strategies_raw, StrategyConfig, "strategies"
+        )
+
+        # ── Validate and construct ─────────────────────────────────
+        result = cls(
+            strategies=strategies,
+            collector=collector_cfg,
+            cache_store=cache_store_cfg,
+            sticky_max_size=int(sticky_max_size),
+        )
+        result.validate()
+        return result
+
+    def validate(self) -> None:
+        """Validate the full config. Raises ConfigError with all violations."""
+        errors: list[str] = []
+
+        if not self.strategies:
+            errors.append("strategies must be non-empty")
+        elif not isinstance(self.strategies, list):
+            errors.append("strategies must be a list")
+        else:
+            total_weight = sum(s.weight for s in self.strategies)
+            if not (0.9 <= total_weight <= 1.1):
+                errors.append(
+                    f"sum of strategy weights must be ~1.0, got {total_weight}"
+                )
+
+        if self.sticky_max_size <= 0:
+            errors.append(f"sticky_max_size must be > 0, got {self.sticky_max_size}")
+
+        if errors:
+            raise ConfigError("; ".join(errors))
+
+    def __repr__(self) -> str:
+        """Multi-line indented repr (delegates to the shared _multiline_repr)."""
+        return _multiline_repr(self)
+
+
+# ============================================================
+# Helper functions
+# ============================================================
+
+
+def _extract_strategies(cfg: DictConfig) -> list[Any] | None:
+    """Extract strategies from cfg, handling both list and dict formats.
+
+    Hydra defaults composition produces a dict (keyed by strategy name),
+    but direct YAML can be a list. Both are supported.
+    """
+    if "strategies" not in cfg:
+        return None
+    val = cfg["strategies"]
+    if val is None:
+        return None
+    if isinstance(val, (list, ListConfig)):
+        return list(val)
+    if isinstance(val, (dict, DictConfig)):
+        # Hydra defaults composition → dict of {name: strategy_cfg}
+        return list(val.values())
+    # Not a list or dict — will be caught by validation
+    return val
+
+
+def _parse_polymorphic_list(
+    items: list[Any],
+    base_class: type,
+    list_name: str,
+) -> list[Any]:
+    """Parse a polymorphic list where each item has ``_target_`` for hydra.instantiate.
+
+    Validates that each instantiated item is a subclass of ``base_class``.
+    """
+    result: list[Any] = []
+    if not items:
+        return result
+
+    for i, item in enumerate(items):
+        if not isinstance(item, (dict, DictConfig)):
+            raise ConfigError(f"{list_name}[{i}] must be a dict, got {type(item)}")
+
+        item_conf = OmegaConf.create(item) if isinstance(item, dict) else item
+
+        if "_target_" not in item_conf:
+            raise ConfigError(
+                f"{list_name}[{i}] must have '_target_' key, got keys: {list(item_conf.keys())}"
+            )
+
+        try:
+            parsed = instantiate(item_conf)
+        except (InstantiationException, ImportError, AttributeError) as e:
+            raise ConfigError(
+                f"{list_name}[{i}] failed to instantiate _target_ '{item_conf._target_}': {e}"
+            ) from e
+
+        if not isinstance(parsed, base_class):
+            raise ConfigError(
+                f"{list_name}[{i}] _target_ must inherit {base_class.__name__}, "
+                f"got {type(parsed).__name__}"
+            )
+
+        result.append(parsed)
+
+    return result

--- a/uni_agent/llm_router/config/router.py
+++ b/uni_agent/llm_router/config/router.py
@@ -1,5 +1,4 @@
-"""Top-level KVCAwareConfig and parsing logic.
-"""
+"""Top-level KVCAwareConfig and parsing logic."""
 
 from __future__ import annotations
 
@@ -17,7 +16,6 @@ from uni_agent.llm_router.config.base import (
 )
 from uni_agent.llm_router.config.cache import CacheStoreConfig
 from uni_agent.llm_router.config.collector import CollectorConfig
-
 
 # ============================================================
 # Top-level KVCAwareConfig
@@ -60,7 +58,7 @@ class KVCAwareConfig:
         Step 2: Manual traversal of strategies (list or dict from Hydra
                 defaults composition) — instantiate each ``_target_`` entry.
         """
-        if not isinstance(cfg, (DictConfig, dict)):
+        if not isinstance(cfg, DictConfig | dict):
             raise ConfigError(f"cfg must be DictConfig or dict, got {type(cfg)}")
 
         cfg = OmegaConf.create(cfg)
@@ -75,10 +73,12 @@ class KVCAwareConfig:
         strategies_raw = _extract_strategies(cfg)
 
         # ── Step 1: merge dataclass-typed fields (collector, cache_store) ──
-        defaults = OmegaConf.create({
-            "collector": OmegaConf.structured(CollectorConfig),
-            "cache_store": OmegaConf.structured(CacheStoreConfig),
-        })
+        defaults = OmegaConf.create(
+            {
+                "collector": OmegaConf.structured(CollectorConfig),
+                "cache_store": OmegaConf.structured(CacheStoreConfig),
+            }
+        )
         kwargs_for_merge = OmegaConf.create(cfg)
         # Remove polymorphic sections to avoid ReadonlyConfigError
         for key in ("strategies", "_target_"):
@@ -88,18 +88,18 @@ class KVCAwareConfig:
                 OmegaConf.set_struct(kwargs_for_merge, True)
 
         # Validate non-dict types for collector/cache_store
-        if ("collector" in kwargs_for_merge
-                and kwargs_for_merge.collector is not None
-                and not isinstance(kwargs_for_merge.collector, (dict, DictConfig))):
-            raise ConfigError(
-                f"collector must be a dict, got {type(kwargs_for_merge.collector).__name__}"
-            )
-        if ("cache_store" in kwargs_for_merge
-                and kwargs_for_merge.cache_store is not None
-                and not isinstance(kwargs_for_merge.cache_store, (dict, DictConfig))):
-            raise ConfigError(
-                f"cache_store must be a dict, got {type(kwargs_for_merge.cache_store).__name__}"
-            )
+        if (
+            "collector" in kwargs_for_merge
+            and kwargs_for_merge.collector is not None
+            and not isinstance(kwargs_for_merge.collector, dict | DictConfig)
+        ):
+            raise ConfigError(f"collector must be a dict, got {type(kwargs_for_merge.collector).__name__}")
+        if (
+            "cache_store" in kwargs_for_merge
+            and kwargs_for_merge.cache_store is not None
+            and not isinstance(kwargs_for_merge.cache_store, dict | DictConfig)
+        ):
+            raise ConfigError(f"cache_store must be a dict, got {type(kwargs_for_merge.cache_store).__name__}")
 
         merged = OmegaConf.merge(defaults, kwargs_for_merge)
         config_obj = OmegaConf.to_object(merged)
@@ -117,9 +117,7 @@ class KVCAwareConfig:
         # ── Step 2: parse strategies (polymorphic list) ────────────
         if strategies_raw is None:
             raise ConfigError("strategies is required — must be explicitly configured")
-        strategies = _parse_polymorphic_list(
-            strategies_raw, StrategyConfig, "strategies"
-        )
+        strategies = _parse_polymorphic_list(strategies_raw, StrategyConfig, "strategies")
 
         # ── Validate and construct ─────────────────────────────────
         result = cls(
@@ -142,9 +140,7 @@ class KVCAwareConfig:
         else:
             total_weight = sum(s.weight for s in self.strategies)
             if not (0.9 <= total_weight <= 1.1):
-                errors.append(
-                    f"sum of strategy weights must be ~1.0, got {total_weight}"
-                )
+                errors.append(f"sum of strategy weights must be ~1.0, got {total_weight}")
 
         if self.sticky_max_size <= 0:
             errors.append(f"sticky_max_size must be > 0, got {self.sticky_max_size}")
@@ -173,9 +169,9 @@ def _extract_strategies(cfg: DictConfig) -> list[Any] | None:
     val = cfg["strategies"]
     if val is None:
         return None
-    if isinstance(val, (list, ListConfig)):
+    if isinstance(val, list | ListConfig):
         return list(val)
-    if isinstance(val, (dict, DictConfig)):
+    if isinstance(val, dict | DictConfig):
         # Hydra defaults composition → dict of {name: strategy_cfg}
         return list(val.values())
     # Not a list or dict — will be caught by validation
@@ -196,27 +192,22 @@ def _parse_polymorphic_list(
         return result
 
     for i, item in enumerate(items):
-        if not isinstance(item, (dict, DictConfig)):
+        if not isinstance(item, dict | DictConfig):
             raise ConfigError(f"{list_name}[{i}] must be a dict, got {type(item)}")
 
         item_conf = OmegaConf.create(item) if isinstance(item, dict) else item
 
         if "_target_" not in item_conf:
-            raise ConfigError(
-                f"{list_name}[{i}] must have '_target_' key, got keys: {list(item_conf.keys())}"
-            )
+            raise ConfigError(f"{list_name}[{i}] must have '_target_' key, got keys: {list(item_conf.keys())}")
 
         try:
             parsed = instantiate(item_conf)
         except (InstantiationException, ImportError, AttributeError) as e:
-            raise ConfigError(
-                f"{list_name}[{i}] failed to instantiate _target_ '{item_conf._target_}': {e}"
-            ) from e
+            raise ConfigError(f"{list_name}[{i}] failed to instantiate _target_ '{item_conf._target_}': {e}") from e
 
         if not isinstance(parsed, base_class):
             raise ConfigError(
-                f"{list_name}[{i}] _target_ must inherit {base_class.__name__}, "
-                f"got {type(parsed).__name__}"
+                f"{list_name}[{i}] _target_ must inherit {base_class.__name__}, got {type(parsed).__name__}"
             )
 
         result.append(parsed)

--- a/uni_agent/llm_router/config/strategy.py
+++ b/uni_agent/llm_router/config/strategy.py
@@ -1,0 +1,40 @@
+"""Strategy-specific configs.
+
+Concrete routing strategy configs. The matching runtime strategy classes
+(e.g. ``KVCAwareStrategy``) live under ``uni_agent.llm_router.strategies``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from uni_agent.llm_router.config.base import ConfigError, StrategyConfig, _multiline_repr
+
+
+@dataclass(repr=False)
+class KVCAwareStrategyConfig(StrategyConfig):
+    """Config for KVCache-Aware routing strategy.
+
+    S = α × S_cache + (1-α) × S_load
+    """
+
+    alpha: float = 0.7
+    load_threshold: float = 0.9
+    layer_weights: dict[str, float] = field(default_factory=lambda: {"gpu": 0.7, "cpu": 0.2, "ssd": 0.1})
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if not 0 < self.load_threshold < 1:
+            raise ConfigError(f"load_threshold must be in (0, 1), got {self.load_threshold}")
+        valid_keys = {"gpu", "cpu", "ssd"}
+        if not set(self.layer_weights.keys()) == valid_keys:
+            raise ConfigError(
+                f"layer_weights keys must be {valid_keys} only, got {set(self.layer_weights.keys())}"
+            )
+        weights_sum = sum(self.layer_weights.values())
+        if abs(weights_sum - 1.0) > 1e-6:
+            raise ConfigError(
+                f"layer_weights values must sum to 1.0, got {weights_sum}"
+            )
+
+    __repr__ = _multiline_repr

--- a/uni_agent/llm_router/config/strategy.py
+++ b/uni_agent/llm_router/config/strategy.py
@@ -28,13 +28,9 @@ class KVCAwareStrategyConfig(StrategyConfig):
             raise ConfigError(f"load_threshold must be in (0, 1), got {self.load_threshold}")
         valid_keys = {"gpu", "cpu", "ssd"}
         if not set(self.layer_weights.keys()) == valid_keys:
-            raise ConfigError(
-                f"layer_weights keys must be {valid_keys} only, got {set(self.layer_weights.keys())}"
-            )
+            raise ConfigError(f"layer_weights keys must be {valid_keys} only, got {set(self.layer_weights.keys())}")
         weights_sum = sum(self.layer_weights.values())
         if abs(weights_sum - 1.0) > 1e-6:
-            raise ConfigError(
-                f"layer_weights values must sum to 1.0, got {weights_sum}"
-            )
+            raise ConfigError(f"layer_weights values must sum to 1.0, got {weights_sum}")
 
     __repr__ = _multiline_repr

--- a/uni_agent/llm_router/configs/cache_store.yaml
+++ b/uni_agent/llm_router/configs/cache_store.yaml
@@ -1,0 +1,2 @@
+kv_cache_store_type: list
+ttl: 30

--- a/uni_agent/llm_router/configs/collector.yaml
+++ b/uni_agent/llm_router/configs/collector.yaml
@@ -1,0 +1,13 @@
+# configs/collector.yaml — connection-type tuning config
+
+# HTTP polling connection parameters
+http_polling:
+    polling_interval: 5
+    http_timeout: 10
+
+# Long-connection (ZMQ subscription, etc.) parameters
+long_connection:
+    base_retry_delay: 1.0
+    max_retry_delay: 30.0
+    max_retry_attempts: 5
+    retry_backoff_factor: 2.0

--- a/uni_agent/llm_router/configs/kvc_aware_router.yaml
+++ b/uni_agent/llm_router/configs/kvc_aware_router.yaml
@@ -1,0 +1,20 @@
+defaults:
+    - strategies@strategies.kvc_aware_strategy: kvc_aware_strategy
+
+    - collector@collector
+
+    - cache_store@cache_store
+
+    - _self_
+
+router_class: uni_agent.llm_router.balancer.KVCAwareBalancer
+
+# Capacity of the request_id→replica sticky-session LRU table. A bound
+# conversation stays affinity-bound to its replica until the replica is
+# removed or the entry is evicted by LRU. Default 10000 mirrors verl's
+# DEFAULT_ROUTING_CACHE_SIZE (verl/verl/workers/rollout/router.py).
+sticky_max_size: 10000
+
+strategies:
+    kvc_aware_strategy:
+        weight: 1.0

--- a/uni_agent/llm_router/configs/strategies/kvc_aware_strategy.yaml
+++ b/uni_agent/llm_router/configs/strategies/kvc_aware_strategy.yaml
@@ -1,0 +1,12 @@
+# strategies/kvc_aware_strategy.yaml
+_target_: uni_agent.llm_router.config.strategy.KVCAwareStrategyConfig
+weight: 1.0
+alpha: 0.7
+load_threshold: 0.9  # overload when load > threshold (load ∈ [0,1], bigger=more loaded)
+layer_weights:
+    gpu: 0.7
+    cpu: 0.2
+    ssd: 0.1
+collector_names:
+    - vllm_zmq
+    - vllm_metrics

--- a/uni_agent/llm_router/hash.py
+++ b/uni_agent/llm_router/hash.py
@@ -1,0 +1,78 @@
+"""
+Chained xxhash prefix hash computation.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import xxhash
+
+
+def compute_hash(parent_hash: int, block_bytes: bytes, seed: int = 0) -> int:
+    """Compute xxhash for a single block given parent hash and token bytes.
+
+    Algorithm (matching aibrix ``SyncPrefixHashTable.computeHash``):
+        h = xxhash.xxh64(seed=seed)
+        h.update(parent_hash as 8-byte little-endian)
+        h.update(block_bytes)
+
+    The parent hash is **always** written — for the first block in a
+    chain, ``parent_hash`` should be ``seed`` (typically ``0``).
+
+    Args:
+        parent_hash: Parent (predecessor) prefix hash as ``int``.
+            Use ``seed`` for the first block in a chain.
+        block_bytes: Token bytes for this block, already encoded as
+            uint32 big-endian (4 bytes per token).
+        seed: xxhash seed value. Defaults to ``0``.
+
+    Returns:
+        Prefix hash as ``int`` (equivalent to Go ``uint64``).
+    """
+    h = xxhash.xxh64(seed=seed)
+    h.update(parent_hash.to_bytes(8, "little"))
+    h.update(block_bytes)
+    return h.intdigest()
+
+
+def get_prefix_hashes(
+    prompt_ids: list[int], block_size: int, seed: int = 0,
+) -> list[int]:
+    """Compute prefix hash sequence for prompt token IDs.
+
+    Algorithm (matching aibrix ``SyncPrefixHashTable.GetPrefixHashes``):
+        parent_hash = seed
+        for each full block:
+            block_bytes = encode tokens as uint32 big-endian
+            current_hash = compute_hash(parent_hash, block_bytes, seed)
+            parent_hash = current_hash
+
+    Only full blocks (exactly ``block_size`` tokens) are hashed.
+    Partial blocks at the tail are ignored.
+
+    Args:
+        prompt_ids: Prompt token IDs as ``list[int]``.
+        block_size: Number of tokens per block (must be > 0).
+        seed: xxhash seed value. Defaults to ``0``.
+
+    Returns:
+        List of prefix hashes as ``int`` (one per full block).
+    """
+    if block_size <= 0:
+        raise ValueError(f"block_size must be > 0, got {block_size}")
+
+    n_full_blocks = len(prompt_ids) // block_size
+    hashes: list[int] = []
+    parent_hash = seed
+
+    for i in range(n_full_blocks):
+        start = i * block_size
+        end = start + block_size
+        block_tokens = prompt_ids[start:end]
+        block_bytes = struct.pack(f">{block_size}I", *block_tokens)
+        current_hash = compute_hash(parent_hash, block_bytes, seed)
+        hashes.append(current_hash)
+        parent_hash = current_hash
+
+    return hashes

--- a/uni_agent/llm_router/hash.py
+++ b/uni_agent/llm_router/hash.py
@@ -37,7 +37,9 @@ def compute_hash(parent_hash: int, block_bytes: bytes, seed: int = 0) -> int:
 
 
 def get_prefix_hashes(
-    prompt_ids: list[int], block_size: int, seed: int = 0,
+    prompt_ids: list[int],
+    block_size: int,
+    seed: int = 0,
 ) -> list[int]:
     """Compute prefix hash sequence for prompt token IDs.
 

--- a/uni_agent/llm_router/logging.py
+++ b/uni_agent/llm_router/logging.py
@@ -1,0 +1,70 @@
+"""Centralised logging for the llm_router package.
+
+All llm_router components run inside a Ray actor process where no root
+logger handler is pre-configured — INFO-level messages would be swallowed.
+This module ensures loguru has a stdout sink so routing decisions reach
+Ray's captured log stream, and provides ``get_router_logger()`` for
+per-component bound loggers.
+
+The project standard is loguru (``uni_agent.async_logging``). This module
+replaces the copy-pasted ``logging.StreamHandler`` blocks that were
+duplicated across 4 llm_router files.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from loguru import logger
+
+
+# ── Ensure a stdout sink exists for the Ray actor process ────────────────
+# Equivalent to the old per-file ``if not logger.handlers: … StreamHandler
+# + propagate=False`` block, but done once centrally.
+_stream_sink_id: int | None = None
+
+
+def _ensure_stdout_sink() -> None:
+    """Add a loguru stdout sink if none exists yet.
+
+    Called at module import so that any ``get_router_logger()`` call
+    immediately produces visible output, even inside a bare Ray actor
+    process where loguru's default handler was removed by
+    ``async_logging.py``.
+    """
+    global _stream_sink_id
+    if _stream_sink_id is not None:
+        return
+    # Check whether any StreamSink (stdout/stderr) handler already exists
+    # from async_logging's DEBUG_MODE setup — don't add a duplicate.
+    for h in logger._core.handlers.values():
+        sink = h._sink
+        if hasattr(sink, "_stream") and sink._stream in (sys.stdout, sys.stderr):
+            return
+    _stream_sink_id = logger.add(
+        sys.stdout,
+        level="INFO",
+        format="{time:YYYY-MM-DD HH:mm:ss} | {extra[name]: <20} | {level: <8} | {message}",
+    )
+
+
+_ensure_stdout_sink()
+
+
+# ── Per-component logger factory ─────────────────────────────────────────
+
+def get_router_logger(name: str) -> "loguru.Logger":
+    """Return a loguru bound logger for an llm_router component.
+
+    Unlike the full ``async_logging.get_logger(name, run_id)`` which binds
+    a ``run_id``, llm_router components operate inside a Ray actor without
+    per-run context. We bind only ``name`` for readable log output.
+
+    Args:
+        name: Human-readable component label (e.g. ``"balancer"``).
+              Appears in the ``{extra[name]}`` column of the format string.
+
+    Returns:
+        A loguru ``BoundLogger`` that can be used as ``logger.info(…)`` etc.
+    """
+    return logger.bind(name=name)

--- a/uni_agent/llm_router/logging.py
+++ b/uni_agent/llm_router/logging.py
@@ -15,8 +15,8 @@ from __future__ import annotations
 
 import sys
 
+import loguru
 from loguru import logger
-
 
 # ── Ensure a stdout sink exists for the Ray actor process ────────────────
 # Equivalent to the old per-file ``if not logger.handlers: … StreamHandler
@@ -53,7 +53,8 @@ _ensure_stdout_sink()
 
 # ── Per-component logger factory ─────────────────────────────────────────
 
-def get_router_logger(name: str) -> "loguru.Logger":
+
+def get_router_logger(name: str) -> loguru.Logger:
     """Return a loguru bound logger for an llm_router component.
 
     Unlike the full ``async_logging.get_logger(name, run_id)`` which binds

--- a/uni_agent/llm_router/metric_spec.py
+++ b/uni_agent/llm_router/metric_spec.py
@@ -1,0 +1,46 @@
+"""Metric specifications — canonical key names, defaults, and metadata.
+
+This module is a **data definition layer** — it defines canonical key names,
+metric metadata (defaults, types, descriptions).
+
+Backend-specific Prometheus mappings and parsing logic live in each
+backend collector, not here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+# ── Canonical key constants ──────────────────────────────────────────
+# Strategies reference keys via MetricKey constants — never raw strings.
+
+class MetricKey:
+    """Canonical metric key names — backend-agnostic, strategy-layer unified."""
+
+    KV_CACHE_USAGE_PERC: str = "kv_cache_usage_perc"
+    NUM_REQUESTS_RUNNING: str = "num_requests_running"
+    NUM_REQUESTS_WAITING: str = "num_requests_waiting"
+
+
+# ── Metric definitions (single source of truth) ──────────────────────
+# key = canonical name (matches MetricKey constant values)
+# value = property dict: default / value_type / describe
+
+METRIC_SPECS: dict[str, dict[str, Any]] = {
+    MetricKey.KV_CACHE_USAGE_PERC: {
+        "default": 0.0,
+        "value_type": float,
+        "describe": "GPU KV cache usage percentage",
+    },
+    MetricKey.NUM_REQUESTS_RUNNING: {
+        "default": 0,
+        "value_type": int,
+        "describe": "Number of requests currently running",
+    },
+    MetricKey.NUM_REQUESTS_WAITING: {
+        "default": 0,
+        "value_type": int,
+        "describe": "Number of requests waiting to be processed",
+    },
+}

--- a/uni_agent/llm_router/metric_spec.py
+++ b/uni_agent/llm_router/metric_spec.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 
 from typing import Any
 
-
 # ── Canonical key constants ──────────────────────────────────────────
 # Strategies reference keys via MetricKey constants — never raw strings.
+
 
 class MetricKey:
     """Canonical metric key names — backend-agnostic, strategy-layer unified."""

--- a/uni_agent/llm_router/store/__init__.py
+++ b/uni_agent/llm_router/store/__init__.py
@@ -1,0 +1,9 @@
+"""Metric stores for polling data and KV cache state."""
+
+from uni_agent.llm_router.store.kv_cache_store import KVCacheStore
+from uni_agent.llm_router.store.metrics_store import MetricsStore
+
+__all__ = [
+    "KVCacheStore",
+    "MetricsStore",
+]

--- a/uni_agent/llm_router/store/kv_cache_store.py
+++ b/uni_agent/llm_router/store/kv_cache_store.py
@@ -1,0 +1,145 @@
+"""KVCacheStore — backend-agnostic data carrier for KV cache mapping tables."""
+
+from __future__ import annotations
+
+import threading
+
+from collections.abc import Iterable
+
+from uni_agent.llm_router.hash import get_prefix_hashes
+
+
+class KVCacheStore:
+    """Mutable data carrier for KV cache mapping tables.
+
+    Thread-safe — a ``threading.Lock`` protects all reads and writes,
+    because the store can be written by ZMQ event collector tasks (on
+    the event-loop thread) and read by the balancer (on a Ray actor
+    thread) concurrently.
+
+    Singleton — use ``KVCacheStore.default()`` to get the shared instance.
+    ``store_cls()`` (called by collectors) also returns the singleton via
+    the class-level ``__call__`` override.
+
+    Attributes:
+        block_size: Learned block size (None until first BlockStored event).
+        replicas_by_block: local prefix hash → set of replica_ids that
+            cache it.  Aligns with aibrix prefixMap (hash → pods).
+    """
+
+    _default: KVCacheStore | None = None
+
+    def __init__(self) -> None:
+        self.block_size: int | None = None
+        self.replicas_by_block: dict[str, set[str]] = {}
+        self._lock: threading.Lock = threading.Lock()
+
+    @classmethod
+    def default(cls) -> KVCacheStore:
+        """Return the shared singleton instance."""
+        if cls._default is None:
+            cls._default = cls()
+        return cls._default
+
+    # ── Replica management ──────────────────────────────────────────────
+
+    def clear_replica(self, replica_id: str) -> None:
+        """Clear all blocks for a replica from the reverse index.
+
+        Iterates ``replicas_by_block`` to remove the replica from every
+        block entry, then deletes empty entries.  O(n) in the number of
+        unique blocks, but replica count is typically small (< 100).
+        """
+        with self._lock:
+            stale_hashes: list[str] = []
+            for bh, replicas in self.replicas_by_block.items():
+                if replica_id in replicas:
+                    replicas.discard(replica_id)
+                    if not replicas:
+                        stale_hashes.append(bh)
+            for bh in stale_hashes:
+                del self.replicas_by_block[bh]
+
+    # ── Block management ────────────────────────────────────────────────
+
+    def add_blocks(self, replica_id: str, block_hashes: Iterable[str]) -> None:
+        """Add blocks to a replica, updating the reverse index."""
+        with self._lock:
+            for bh in block_hashes:
+                if bh not in self.replicas_by_block:
+                    self.replicas_by_block[bh] = set()
+                self.replicas_by_block[bh].add(replica_id)
+
+    def remove_blocks(self, replica_id: str, block_hashes: Iterable[str]) -> None:
+        """Remove blocks from a replica, updating the reverse index."""
+        with self._lock:
+            for bh in block_hashes:
+                if bh in self.replicas_by_block:
+                    self.replicas_by_block[bh].discard(replica_id)
+                    if not self.replicas_by_block[bh]:
+                        del self.replicas_by_block[bh]
+
+    # ── Prefix hit rate queries ─────────────────────────────────────────
+
+    def get_gpu_prefix_hit_rate(self, prompt_ids: list[int]) -> dict[str, int]:
+        """Match prefix hashes against cached blocks, return per-replica hit percent.
+
+        Algorithm (matching aibrix MatchPrefix):
+            1. Compute prefix hashes via get_prefix_hashes
+            2. For each prefix hash, check replicas_by_block to find replicas
+            3. Stop at first hash where no replica matches (chain break)
+            4. Compute percent = (matched_count * 100) // total_hashes
+
+        The entire computation runs inside the lock so the snapshot is
+        consistent — no partial reads interleaved with concurrent writes.
+
+        Args:
+            prompt_ids: Current request's prompt token IDs.
+
+        Returns:
+            Dict of replica_id → prefix_match_percent (0–100).
+            Empty dict if block_size is unknown or no full blocks.
+        """
+        with self._lock:
+            if self.block_size is None:
+                return {}
+
+            prefix_hashes = get_prefix_hashes(prompt_ids, self.block_size)
+            if not prefix_hashes:
+                return {}
+
+            hash_strs = [str(h) for h in prefix_hashes]
+
+            # Sequential prefix matching (aibrix MatchPrefix pattern)
+            prefix_match_replicas: dict[str, int] = {}
+
+            for i, hs in enumerate(hash_strs):
+                cached_replicas = self.replicas_by_block.get(hs)
+                if cached_replicas is None or len(cached_replicas) == 0:
+                    break  # chain break — no replica caches this hash
+
+                prefix_match_percent = (i + 1) * 100 // len(hash_strs)
+
+                for replica_id in cached_replicas:
+                    prefix_match_replicas[replica_id] = prefix_match_percent
+
+            return prefix_match_replicas
+
+    def get_tier_prefix_hit_rate(
+        self, node_id: str, prompt_ids: list[int], tier: str,
+    ) -> float:
+        """Query tier-level prefix cache hit rate (slow-path data).
+
+        v1: placeholder — returns 0.0 when tier metrics are not yet available.
+        v2: will call Mooncake /batch_query_keys API for real-time query.
+
+        Args:
+            node_id: Target node.
+            prompt_ids: Current request's prompt token IDs.
+            tier: "cpu" or "ssd".
+
+        Returns:
+            Hit rate 0.0–1.0; returns 0.0 if no data in snapshot.
+        """
+        # v1 placeholder — read from snapshot when tier metrics are available
+        return 0.0

--- a/uni_agent/llm_router/store/kv_cache_store.py
+++ b/uni_agent/llm_router/store/kv_cache_store.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import threading
-
 from collections.abc import Iterable
 
 from uni_agent.llm_router.hash import get_prefix_hashes
@@ -126,7 +125,10 @@ class KVCacheStore:
             return prefix_match_replicas
 
     def get_tier_prefix_hit_rate(
-        self, node_id: str, prompt_ids: list[int], tier: str,
+        self,
+        node_id: str,
+        prompt_ids: list[int],
+        tier: str,
     ) -> float:
         """Query tier-level prefix cache hit rate (slow-path data).
 

--- a/uni_agent/llm_router/store/metrics_store.py
+++ b/uni_agent/llm_router/store/metrics_store.py
@@ -1,0 +1,116 @@
+"""Unified metrics store for reading/writing polling metric data."""
+
+from __future__ import annotations
+
+import threading
+
+from typing import Any
+
+from uni_agent.llm_router.metric_spec import METRIC_SPECS
+
+
+class MetricsStore:
+    """Unified metrics store: ``{node_id: {canonical_key: value}}``.
+
+    Thread-safe — a ``threading.Lock`` protects all reads and writes,
+    because the store can be written by collector asyncio tasks (on the
+    event-loop thread) and read by the balancer (on a Ray actor thread)
+    concurrently.
+
+    Singleton — use ``MetricsStore.default()`` to get the shared instance.
+    ``store_cls()`` (called by collectors) also returns the singleton via
+    the class-level ``__call__`` override.
+
+    - ``get(node_id, key)``  → single value; falls back to ``METRIC_SPECS[key]["default"]``;
+                               raises ``KeyError`` if key is not a valid canonical key
+    - ``get(node_id)``       → entire node dict (empty dict if unknown)
+    - ``refresh(new_data)``  → batch update; only updates nodes present in ``new_data``,
+                               existing nodes NOT in ``new_data`` are left untouched
+    """
+
+    _default: MetricsStore | None = None
+
+    def __init__(self) -> None:
+        self._data: dict[str, dict[str, Any]] = {}
+        self._lock: threading.Lock = threading.Lock()
+
+    @classmethod
+    def default(cls) -> MetricsStore:
+        """Return the shared singleton instance."""
+        if cls._default is None:
+            cls._default = cls()
+        return cls._default
+
+    def _get(self, node_id: str, key: str | None = None) -> Any | dict[str, Any]:
+        """Read metrics.
+
+        ``get(node_id, key)``  → single value, falls back to spec default.
+            Raises ``KeyError`` if ``key`` is not a valid canonical key
+            (i.e. not present in ``METRIC_SPECS``).
+        ``get(node_id)``       → entire node dict
+        """
+        if key is not None:
+            if key not in METRIC_SPECS:
+                raise KeyError(
+                    f"Unknown metric key '{key}'. "
+                    f"Valid keys: {sorted(METRIC_SPECS.keys())}"
+                )
+            with self._lock:
+                node = self._data.get(node_id, {})
+                if key in node:
+                    return node[key]
+                return METRIC_SPECS[key]["default"]
+        with self._lock:
+            return dict(self._data.get(node_id, {}))
+
+    # Public aliases — ``get`` / ``get_metric`` / ``get_metrics`` all delegate
+    # to ``_get`` so callers can use whichever naming fits their context.
+    def get(self, node_id: str, key: str | None = None) -> Any | dict[str, Any]:
+        """Read metrics (public alias for ``_get``)."""
+        return self._get(node_id, key)
+
+    def refresh(self, new_data: dict[str, dict[str, Any]]) -> None:
+        """Batch refresh from collectors.
+
+        For each node in ``new_data``: merge with existing data
+        (new values overwrite same keys).  Nodes NOT in ``new_data``
+        are left untouched.
+        """
+        with self._lock:
+            for node_id, metrics in new_data.items():
+                existing = self._data.get(node_id, {})
+                merged = dict(existing)
+                merged.update(metrics)
+                self._data[node_id] = merged
+
+    def all_ids(self) -> list[str]:
+        """Return all node IDs currently in the store."""
+        with self._lock:
+            return list(self._data.keys())
+        
+    def get_metric(self, node_id: str, key: str) -> Any:
+        """Query a polling metric by canonical key.
+
+        Delegates to ``MetricsStore.get(node_id, key)``.
+
+        Args:
+            node_id: Target node.
+            key: ``MetricKey`` constant, e.g. ``MetricKey.KV_CACHE_USAGE_PERC``.
+
+        Returns:
+            Metric value; falls back to ``METRIC_SPECS`` default if
+            node or metric is absent.
+        """
+        return self._get(node_id, key)
+
+    def get_metrics(self, node_id: str) -> dict[str, Any]:
+        """Get a node's full polling metrics snapshot.
+
+        Args:
+            node_id: Target node.
+
+        Returns:
+            Dict of canonical_key → value; empty dict if node
+            is absent in the store.
+        """
+        return self._get(node_id)

--- a/uni_agent/llm_router/store/metrics_store.py
+++ b/uni_agent/llm_router/store/metrics_store.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import threading
-
 from typing import Any
 
 from uni_agent.llm_router.metric_spec import METRIC_SPECS
@@ -51,10 +50,7 @@ class MetricsStore:
         """
         if key is not None:
             if key not in METRIC_SPECS:
-                raise KeyError(
-                    f"Unknown metric key '{key}'. "
-                    f"Valid keys: {sorted(METRIC_SPECS.keys())}"
-                )
+                raise KeyError(f"Unknown metric key '{key}'. Valid keys: {sorted(METRIC_SPECS.keys())}")
             with self._lock:
                 node = self._data.get(node_id, {})
                 if key in node:
@@ -87,7 +83,7 @@ class MetricsStore:
         """Return all node IDs currently in the store."""
         with self._lock:
             return list(self._data.keys())
-        
+
     def get_metric(self, node_id: str, key: str) -> Any:
         """Query a polling metric by canonical key.
 

--- a/uni_agent/llm_router/strategies/__init__.py
+++ b/uni_agent/llm_router/strategies/__init__.py
@@ -1,0 +1,22 @@
+"""Runtime strategy classes, registry, and route entry for the KVCAware router.
+
+The Balancer imports from here (detailed_balancer.md §2.3).
+"""
+
+from __future__ import annotations
+
+from uni_agent.llm_router.strategies.base import ReplicaInfo
+from uni_agent.llm_router.strategies.kvc_aware import KVCacheAwareStrategy, StrategyError
+from uni_agent.llm_router.strategies.registry import StrategyRegistry
+from uni_agent.llm_router.strategies.routing import RoutingStrategy, route
+from uni_agent.llm_router.strategies.sticky_session import StickySessionTable
+
+__all__ = [
+    "KVCacheAwareStrategy",
+    "ReplicaInfo",
+    "RoutingStrategy",
+    "StrategyError",
+    "StrategyRegistry",
+    "StickySessionTable",
+    "route",
+]

--- a/uni_agent/llm_router/strategies/base.py
+++ b/uni_agent/llm_router/strategies/base.py
@@ -1,0 +1,16 @@
+"""Shared routing value types consumed by strategies and the Balancer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReplicaInfo:
+    """Descriptor of a routable replica.
+
+    Carries only the replica id — the actor handle never leaves the Balancer's
+    ``_servers`` dict (detailed_balancer.md §2.3).
+    """
+
+    replica_id: str

--- a/uni_agent/llm_router/strategies/kvc_aware.py
+++ b/uni_agent/llm_router/strategies/kvc_aware.py
@@ -1,0 +1,271 @@
+"""KVCache-aware runtime strategy."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from uni_agent.llm_router.metric_spec import MetricKey
+from uni_agent.llm_router.config.strategy import KVCAwareStrategyConfig
+from uni_agent.llm_router.logging import get_router_logger
+from uni_agent.llm_router.strategies.load_score import (
+    DEFAULT_LOAD_WEIGHTS,
+    LOAD_FNS,
+    resolve_max_num_seqs,
+)
+from uni_agent.llm_router.strategies.registry import StrategyRegistry
+
+if TYPE_CHECKING:
+    from uni_agent.llm_router.collectors.provider import RouteDataProvider
+    from uni_agent.llm_router.strategies.base import ReplicaInfo
+
+logger = get_router_logger("kvc-aware-strategy")
+
+# Sticky short-circuit places the bound replica first by giving it a finite
+# top score (others 0.0). Must be finite — route()'s _rank_key treats NaN/inf
+# as worst — and large enough to outrank any combined score (which is bounded
+# by alpha*1 + (1-alpha)*1 = 1.0).
+STICKY_TOP_SCORE = 1e9
+
+
+class StrategyError(Exception):
+    """Strategy construction or scoring error."""
+
+
+class KVCacheAwareStrategy:
+    """Runtime strategy constructed from a ``KVCAwareStrategyConfig``."""
+
+    def __init__(
+        self,
+        *,
+        alpha: float,
+        load_threshold: float,
+        layer_weights: dict[str, float],
+        collector_names: list[str],
+        weight: float,
+        load_fn: str = "normalized",
+        load_weights: tuple[float, float, float] = DEFAULT_LOAD_WEIGHTS,
+        max_num_seqs: int | None = None,
+    ) -> None:
+        if not 0 <= alpha <= 1:
+            raise StrategyError(f"alpha must be in [0, 1], got {alpha}")
+        if not 0 < load_threshold < 1:
+            raise StrategyError(f"load_threshold must be in (0, 1), got {load_threshold}")
+        _valid_tiers = {"gpu", "cpu", "ssd"}
+        if set(layer_weights.keys()) != _valid_tiers:
+            raise StrategyError(
+                f"layer_weights keys must be {_valid_tiers}, got {set(layer_weights.keys())}"
+            )
+        for tier, tier_weight in layer_weights.items():
+            if tier_weight < 0:
+                raise StrategyError(f"layer_weights[{tier}] must be >= 0, got {tier_weight}")
+        weights_sum = sum(layer_weights.values())
+        if abs(weights_sum - 1.0) > 1e-6:
+            raise StrategyError(f"layer_weights values must sum to 1.0, got {weights_sum}")
+        if load_fn not in LOAD_FNS:
+            raise StrategyError(f"load_fn must be one of {list(LOAD_FNS)}, got '{load_fn}'")
+        if len(load_weights) != 3:
+            raise StrategyError(f"load_weights must have 3 elements (a,b,c), got len={len(load_weights)}")
+        if any(w < 0 for w in load_weights):
+            raise StrategyError(f"load_weights must be >= 0, got {load_weights}")
+        if abs(sum(load_weights) - 1.0) > 1e-6:
+            raise StrategyError(f"load_weights must sum to 1.0, got {sum(load_weights)}")
+
+        self.alpha = float(alpha)
+        self.load_threshold = float(load_threshold)
+        self.layer_weights = dict(layer_weights)
+        self.collector_names = collector_names
+        self.weight = weight
+        self.load_fn = load_fn
+        self.load_weights = tuple(load_weights)
+        self._load_fn = LOAD_FNS[load_fn]
+        # max_num_seqs drives the normalized load formula's running term.
+        # None → resolve from the MAX_NUM_SEQS env var (default 64).
+        self._max_num_seqs = int(max_num_seqs) if max_num_seqs is not None else resolve_max_num_seqs()
+        logger.info(
+            f"KVCacheAwareStrategy created: alpha={self.alpha:.2f}, "
+            f"load_threshold={self.load_threshold:.2f}, layer_weights={self.layer_weights}, "
+            f"load_fn='{self.load_fn}', load_weights={self.load_weights}, max_num_seqs={self._max_num_seqs}",
+        )
+
+    @classmethod
+    def from_config(cls, cfg: KVCAwareStrategyConfig) -> "KVCacheAwareStrategy":
+        """Construct a strategy instance carrying its parsed config fields.
+
+        Load-function selection (``load_fn`` / ``load_weights``) is code-level —
+        not exposed via YAML — so ``from_config`` uses code defaults. The
+        ``load_threshold`` field (semantics: overload when ``load > threshold``)
+        comes from the config.
+        """
+        return cls(
+            alpha=cfg.alpha,
+            load_threshold=cfg.load_threshold,
+            layer_weights=cfg.layer_weights,
+            collector_names=cfg.collector_names,
+            weight=cfg.weight,
+        )
+
+    # ── Load scoring ──
+
+    def _compute_load(
+        self, kv_usage: float, running: int | float, waiting: int | float,
+    ) -> float:
+        """Compute ``load ∈ [0,1]`` (bigger = more loaded) via the selected fn."""
+        return self._load_fn(
+            kv_usage, running, waiting,
+            max_num_seqs=self._max_num_seqs, weights=self.load_weights,
+        )
+
+    def is_overloaded(
+        self, provider: "RouteDataProvider", replica: "ReplicaInfo",
+    ) -> bool:
+        """Return True if ``replica`` is overloaded (``load > load_threshold``).
+
+        Used only by the sticky short-circuit to decide whether to send a
+        returning session back to its bound replica. Combined scoring never
+        consults overload.
+        """
+        m = provider.get_metrics(replica.replica_id)
+        kv_usage = m.get(MetricKey.KV_CACHE_USAGE_PERC, 0.0)
+        running = m.get(MetricKey.NUM_REQUESTS_RUNNING, 0)
+        waiting = m.get(MetricKey.NUM_REQUESTS_WAITING, 0)
+        return self._compute_load(kv_usage, running, waiting) > self.load_threshold
+
+    def _sticky_shortcut(
+        self,
+        provider: "RouteDataProvider",
+        replicas: list["ReplicaInfo"],
+        request_id: str | None,
+        sticky_table: Any,
+    ) -> list[float] | None:
+        """Return a pre-built score list if a sticky replica should win, else None.
+
+        Sticky replica wins when: ``request_id``/``sticky_table`` are provided,
+        the bound replica is present in ``replicas``, and it is NOT overloaded.
+        On win, returns a list with ``STICKY_TOP_SCORE`` at the bound replica's
+        index and ``0.0`` elsewhere. On miss / overload / absence, returns
+        ``None`` so the caller falls through to combined scoring.
+        """
+        if not request_id or sticky_table is None:
+            return None
+        sticky_id = sticky_table.get(request_id)
+        if sticky_id is None:
+            return None
+        for idx, replica in enumerate(replicas):
+            if replica.replica_id == sticky_id:
+                m = provider.get_metrics(replica.replica_id)
+                kv_usage = m.get(MetricKey.KV_CACHE_USAGE_PERC, 0.0)
+                running = m.get(MetricKey.NUM_REQUESTS_RUNNING, 0)
+                waiting = m.get(MetricKey.NUM_REQUESTS_WAITING, 0)
+                load = self._compute_load(kv_usage, running, waiting)
+                metrics_str = (
+                    f"kv={kv_usage:.3f} running={running} waiting={waiting} "
+                    f"→ load={load:.4f} s_load={1.0 - load:.4f} (threshold={self.load_threshold:.2f})"
+                )
+                if load > self.load_threshold:
+                    logger.info(
+                        f"score(): STICKY replica={sticky_id} OVERLOADED [{metrics_str}] "
+                        f"→ fallback to COMBINED scoring"
+                    )
+                    return None
+                logger.info(
+                    f"score(): STICKY replica={sticky_id} HIT (not overloaded) [{metrics_str}] "
+                    f"→ short-circuit (top score)"
+                )
+                scores = [0.0] * len(replicas)
+                scores[idx] = STICKY_TOP_SCORE
+                return scores
+        # Bound replica no longer in pool — let the Balancer invalidate it.
+        logger.info(
+            f"score(): sticky replica={sticky_id} not in pool, fallback to combined scoring",
+        )
+        return None
+
+    def score(
+        self,
+        prompt_ids: list[int] | None,
+        provider: "RouteDataProvider",
+        replicas: list["ReplicaInfo"],
+        request_id: str | None = None,
+        sticky_table: Any = None,
+    ) -> list[float]:
+        """Score each replica. Larger is better.
+
+        Combined score (one pass — no fast/slow branching, no cache zeroing):
+            S = α·S_cache + (1-α)·S_load
+            S_cache = w_gpu·gpu_hit + w_cpu·cpu_hit + w_ssd·ssd_hit   (weights sum to 1)
+            S_load  = 1 - load                                         (bigger = less loaded)
+            load    = selected load_fn(kv, running, waiting, max_num_seqs, weights)
+
+        Every replica — overloaded or not — gets the full formula. Overload is
+        consulted only by the sticky short-circuit (``is_overloaded``).
+
+        Sticky short-circuit: when ``request_id`` and ``sticky_table`` are
+        provided and the bound replica is present and NOT overloaded, returns a
+        pre-built score list placing that replica first (sticky replica gets
+        ``STICKY_TOP_SCORE``, others ``0.0``), skipping combined scoring.
+        """
+        if not isinstance(replicas, list):
+            raise StrategyError(f"replicas must be a list, got {type(replicas).__name__}")
+        if not replicas:
+            return []
+
+        # Sticky short-circuit: bound, non-overloaded replica wins outright.
+        shortcut = self._sticky_shortcut(provider, replicas, request_id, sticky_table)
+        if shortcut is not None:
+            return shortcut
+
+        effective_prompt_ids = prompt_ids or []
+
+        # GPU prefix hit is the same prompt for every replica — query once.
+        # get_gpu_prefix_hit_rate returns {replica_id: 0-100}; _cache_score
+        # scales each replica's value to 0-1.
+        gpu_hit_pct = provider.get_gpu_prefix_hit_rate(effective_prompt_ids)
+
+        result = []
+        for replica in replicas:
+            m = provider.get_metrics(replica.replica_id)
+            kv_usage = m.get(MetricKey.KV_CACHE_USAGE_PERC, 0.0)
+            running = m.get(MetricKey.NUM_REQUESTS_RUNNING, 0)
+            waiting = m.get(MetricKey.NUM_REQUESTS_WAITING, 0)
+            load = self._compute_load(kv_usage, running, waiting)
+            s_load = 1.0 - load
+            s_cache = self._cache_score(provider, replica, effective_prompt_ids, gpu_hit_pct)
+            score = self.alpha * s_cache + (1 - self.alpha) * s_load
+            result.append(score)
+            gpu_hit = gpu_hit_pct.get(replica.replica_id, 0) / 100.0
+            logger.info(
+                f"score(): replica={replica.replica_id} kv={kv_usage:.3f} running={running} waiting={waiting} "
+                f"→ load={load:.4f} s_load={s_load:.4f} | gpu_hit={gpu_hit:.2f} s_cache={s_cache:.4f} "
+                f"({self.alpha:.2f}·cache + {1 - self.alpha:.2f}·load) → score={score:.4f}"
+            )
+        scores_str = ", ".join(f"{r.replica_id}={result[i]:.4f}" for i, r in enumerate(replicas))
+        logger.info(f"score(): COMBINED scores: {scores_str}")
+        return result
+
+    def _cache_score(
+        self,
+        provider: "RouteDataProvider",
+        replica: "ReplicaInfo",
+        prompt_ids: list[int],
+        gpu_hit_pct: dict[str, float],
+    ) -> float:
+        """Three-layer weighted prefix-cache hit score ∈ [0, 1].
+
+            S_cache = w_gpu·gpu_hit + w_cpu·cpu_hit + w_ssd·ssd_hit
+
+        ``gpu_hit`` comes from ``get_gpu_prefix_hit_rate`` (0-100, scaled to
+        0-1); ``cpu_hit``/``ssd_hit`` come from ``get_tier_prefix_hit_rate``
+        (``None`` → 0.0, e.g. when the mooncake tier collector is not yet
+        implemented). Weights come from ``self.layer_weights`` and are
+        validated to sum to 1.0 at construction, so the result is already in
+        [0, 1] with no extra normalization.
+        """
+        gpu_hit = gpu_hit_pct.get(replica.replica_id, 0) / 100.0
+        cpu_hit = provider.get_tier_prefix_hit_rate(replica.replica_id, prompt_ids, "cpu") or 0.0
+        ssd_hit = provider.get_tier_prefix_hit_rate(replica.replica_id, prompt_ids, "ssd") or 0.0
+        w = self.layer_weights
+        return w["gpu"] * gpu_hit + w["cpu"] * cpu_hit + w["ssd"] * ssd_hit
+
+
+# Auto-register: config dataclass type → runtime strategy class.
+StrategyRegistry.register(KVCAwareStrategyConfig, KVCacheAwareStrategy)

--- a/uni_agent/llm_router/strategies/kvc_aware.py
+++ b/uni_agent/llm_router/strategies/kvc_aware.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from uni_agent.llm_router.metric_spec import MetricKey
 from uni_agent.llm_router.config.strategy import KVCAwareStrategyConfig
 from uni_agent.llm_router.logging import get_router_logger
+from uni_agent.llm_router.metric_spec import MetricKey
 from uni_agent.llm_router.strategies.load_score import (
     DEFAULT_LOAD_WEIGHTS,
     LOAD_FNS,
@@ -52,9 +52,7 @@ class KVCacheAwareStrategy:
             raise StrategyError(f"load_threshold must be in (0, 1), got {load_threshold}")
         _valid_tiers = {"gpu", "cpu", "ssd"}
         if set(layer_weights.keys()) != _valid_tiers:
-            raise StrategyError(
-                f"layer_weights keys must be {_valid_tiers}, got {set(layer_weights.keys())}"
-            )
+            raise StrategyError(f"layer_weights keys must be {_valid_tiers}, got {set(layer_weights.keys())}")
         for tier, tier_weight in layer_weights.items():
             if tier_weight < 0:
                 raise StrategyError(f"layer_weights[{tier}] must be >= 0, got {tier_weight}")
@@ -88,7 +86,7 @@ class KVCacheAwareStrategy:
         )
 
     @classmethod
-    def from_config(cls, cfg: KVCAwareStrategyConfig) -> "KVCacheAwareStrategy":
+    def from_config(cls, cfg: KVCAwareStrategyConfig) -> KVCacheAwareStrategy:
         """Construct a strategy instance carrying its parsed config fields.
 
         Load-function selection (``load_fn`` / ``load_weights``) is code-level —
@@ -107,16 +105,24 @@ class KVCacheAwareStrategy:
     # ── Load scoring ──
 
     def _compute_load(
-        self, kv_usage: float, running: int | float, waiting: int | float,
+        self,
+        kv_usage: float,
+        running: int | float,
+        waiting: int | float,
     ) -> float:
         """Compute ``load ∈ [0,1]`` (bigger = more loaded) via the selected fn."""
         return self._load_fn(
-            kv_usage, running, waiting,
-            max_num_seqs=self._max_num_seqs, weights=self.load_weights,
+            kv_usage,
+            running,
+            waiting,
+            max_num_seqs=self._max_num_seqs,
+            weights=self.load_weights,
         )
 
     def is_overloaded(
-        self, provider: "RouteDataProvider", replica: "ReplicaInfo",
+        self,
+        provider: RouteDataProvider,
+        replica: ReplicaInfo,
     ) -> bool:
         """Return True if ``replica`` is overloaded (``load > load_threshold``).
 
@@ -132,8 +138,8 @@ class KVCacheAwareStrategy:
 
     def _sticky_shortcut(
         self,
-        provider: "RouteDataProvider",
-        replicas: list["ReplicaInfo"],
+        provider: RouteDataProvider,
+        replicas: list[ReplicaInfo],
         request_id: str | None,
         sticky_table: Any,
     ) -> list[float] | None:
@@ -163,8 +169,7 @@ class KVCacheAwareStrategy:
                 )
                 if load > self.load_threshold:
                     logger.info(
-                        f"score(): STICKY replica={sticky_id} OVERLOADED [{metrics_str}] "
-                        f"→ fallback to COMBINED scoring"
+                        f"score(): STICKY replica={sticky_id} OVERLOADED [{metrics_str}] → fallback to COMBINED scoring"
                     )
                     return None
                 logger.info(
@@ -183,8 +188,8 @@ class KVCacheAwareStrategy:
     def score(
         self,
         prompt_ids: list[int] | None,
-        provider: "RouteDataProvider",
-        replicas: list["ReplicaInfo"],
+        provider: RouteDataProvider,
+        replicas: list[ReplicaInfo],
         request_id: str | None = None,
         sticky_table: Any = None,
     ) -> list[float]:
@@ -244,8 +249,8 @@ class KVCacheAwareStrategy:
 
     def _cache_score(
         self,
-        provider: "RouteDataProvider",
-        replica: "ReplicaInfo",
+        provider: RouteDataProvider,
+        replica: ReplicaInfo,
         prompt_ids: list[int],
         gpu_hit_pct: dict[str, float],
     ) -> float:

--- a/uni_agent/llm_router/strategies/load_score.py
+++ b/uni_agent/llm_router/strategies/load_score.py
@@ -1,0 +1,110 @@
+"""Selectable load-score functions for KVCacheAwareStrategy.
+
+Every function returns ``load ∈ [0, 1]`` with the convention **bigger = more
+loaded** (a saturated replica scores 1.0, an idle one 0.0). The strategy
+converts to its internal ``s_load`` via ``s_load = 1 - load`` so the combined
+score ``α·S_cache + (1-α)·S_load`` keeps "bigger = preferred".
+
+Available functions (select by name via ``LOAD_FNS`` / ``get_load_fn``):
+    - ``"normalized"`` (default): convex combination of three normalized signals
+        running_usage = min(1, running / max_num_seqs)
+        waiting_usage = min(1, waiting / max_num_seqs)
+        load = a·kv_usage + b·running_usage + c·waiting_usage     (a+b+c=1)
+      Default weights (a, b, c) = (0.4, 0.3, 0.3); ``max_num_seqs`` from env
+      ``MAX_NUM_SEQS`` (default 64).
+    - ``"kv_over_pressure"`` (legacy): ``load = 1 - (1-kv)/(1+running+waiting)``
+      — the inverse of the pre-Phase-7 ``s_load``. Kept as a selectable
+      fallback / for A-B comparison; ignores weights and max_num_seqs.
+
+Selection is code-level (constructor ``load_fn`` name), not a YAML knob.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Callable
+
+# Default (a, b, c) weights for the normalized formula — kv / running / waiting.
+DEFAULT_LOAD_WEIGHTS: tuple[float, float, float] = (0.4, 0.3, 0.3)
+
+# Default scheduler capacity when MAX_NUM_SEQS is unset. Matches the project's
+# vLLM 24GB default (scripts/infer_multi.sh).
+DEFAULT_MAX_NUM_SEQS: int = 64
+
+
+def load_normalized(
+    kv_usage: float,
+    running: int | float,
+    waiting: int | float,
+    *,
+    max_num_seqs: int,
+    weights: tuple[float, float, float] = DEFAULT_LOAD_WEIGHTS,
+) -> float:
+    """Convex combination of KV fullness, scheduler occupancy, and backlog share.
+
+    Each term is normalized to [0, 1] and the weights sum to 1, so the result
+    is in [0, 1] (bigger = more loaded).
+    """
+    a, b, c = weights
+    # running_usage: fraction of scheduler capacity held by running sequences.
+    # Clamp to 1.0 (running can transiently exceed max_num_seqs); max_num_seqs=0
+    # degrades to fully occupied so we never divide by zero.
+    if max_num_seqs > 0:
+        running_usage = min(1.0, float(running) / float(max_num_seqs))
+    else:
+        running_usage = 1.0
+    # waiting_usage: fraction of scheduler capacity backlogged, mirroring
+    # running_usage's normalization (clamp to 1.0 — waiting can transiently
+    # exceed max_num_seqs under KV pressure). max_num_seqs=0 → fully occupied,
+    # so we never divide by zero.
+    if max_num_seqs > 0:
+        waiting_usage = min(1.0, float(waiting) / float(max_num_seqs))
+    else:
+        waiting_usage = 1.0
+    return a * float(kv_usage) + b * running_usage + c * waiting_usage
+
+
+def load_kv_over_pressure(
+    kv_usage: float,
+    running: int | float,
+    waiting: int | float,
+    *,
+    max_num_seqs: int,
+    weights: tuple[float, float, float] = DEFAULT_LOAD_WEIGHTS,
+) -> float:
+    """Legacy load formula — inverse of the pre-Phase-7 ``s_load``.
+
+    ``s_load_old = (1 - kv_usage) / (1 + running + waiting)`` (bigger = less
+    loaded), so ``load = 1 - s_load_old`` (bigger = more loaded). ``max_num_seqs``
+    and ``weights`` are accepted for signature uniformity but unused.
+    """
+    s_load_old = (1.0 - float(kv_usage)) / (1.0 + float(running) + float(waiting))
+    return 1.0 - s_load_old
+
+
+# Registry of selectable load functions. Add a name here to expose a new one.
+LOAD_FNS: dict[str, Callable[..., float]] = {
+    "normalized": load_normalized,
+    "kv_over_pressure": load_kv_over_pressure,
+}
+
+
+def get_load_fn(name: str) -> Callable[..., float]:
+    """Look up a load function by name; raise ``KeyError`` if unknown."""
+    return LOAD_FNS[name]
+
+
+def resolve_max_num_seqs() -> int:
+    """Read scheduler capacity from ``MAX_NUM_SEQS`` env var.
+
+    Returns ``DEFAULT_MAX_NUM_SEQS`` (64) when unset or non-parseable, so the
+    router degrades gracefully rather than crashing on a misconfigured env.
+    """
+    raw = os.environ.get("MAX_NUM_SEQS")
+    if raw is None:
+        return DEFAULT_MAX_NUM_SEQS
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_NUM_SEQS
+    return value if value > 0 else DEFAULT_MAX_NUM_SEQS

--- a/uni_agent/llm_router/strategies/registry.py
+++ b/uni_agent/llm_router/strategies/registry.py
@@ -1,0 +1,32 @@
+"""Runtime strategy registry.
+
+Maps a strategy *config dataclass type* to its *runtime* strategy class, so
+the Balancer can instantiate the right strategy from a parsed config without a
+name lookup. This is distinct from the config layer's ``_target_`` dispatch
+(hydra ``instantiate``), which resolves config dataclasses themselves.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+
+class StrategyRegistry:
+    """Class-level registry mapping strategy config type → strategy class."""
+
+    _registry: ClassVar[dict[type, type]] = {}
+
+    @classmethod
+    def register(cls, config_cls: type, strategy_cls: type) -> None:
+        """Register a runtime strategy class for a config dataclass type."""
+        cls._registry[config_cls] = strategy_cls
+
+    @classmethod
+    def get(cls, config_cls: type) -> type:
+        """Look up the runtime strategy class registered for ``config_cls``."""
+        if config_cls not in cls._registry:
+            raise KeyError(
+                f"No strategy registered for config type {config_cls!r}; "
+                f"registered: {list(cls._registry.keys())}"
+            )
+        return cls._registry[config_cls]

--- a/uni_agent/llm_router/strategies/registry.py
+++ b/uni_agent/llm_router/strategies/registry.py
@@ -26,7 +26,6 @@ class StrategyRegistry:
         """Look up the runtime strategy class registered for ``config_cls``."""
         if config_cls not in cls._registry:
             raise KeyError(
-                f"No strategy registered for config type {config_cls!r}; "
-                f"registered: {list(cls._registry.keys())}"
+                f"No strategy registered for config type {config_cls!r}; registered: {list(cls._registry.keys())}"
             )
         return cls._registry[config_cls]

--- a/uni_agent/llm_router/strategies/routing.py
+++ b/uni_agent/llm_router/strategies/routing.py
@@ -1,0 +1,108 @@
+"""route() — weighted replica ranking for the KVCAware router.
+
+The Balancer delegates each request to ``route(strategies, prompt_ids,
+provider, replicas)`` and maps ``ranking[0]`` back to a server handle
+(detailed_balancer.md §2.3).
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from typing import Any, Protocol, runtime_checkable
+
+from uni_agent.llm_router.logging import get_router_logger
+
+logger = get_router_logger("routing")
+
+
+@runtime_checkable
+class RoutingStrategy(Protocol):
+    """Routing scoring strategy.
+
+    Each strategy scores a batch of replicas independently and returns a list
+    of the same length and order. ``route()`` weighted-sums the outputs.
+    """
+
+    def score(
+        self,
+        prompt_ids: list[int] | None,
+        provider: Any,
+        replicas: list[Any],
+        request_id: str | None = None,
+        sticky_table: Any = None,
+    ) -> list[float]:
+        """Score each replica. Larger is better; negatives are allowed.
+
+        ``request_id`` + ``sticky_table`` enable sticky-session short-circuit:
+        a strategy may return a pre-built score list that places the bound
+        replica first when it is not overloaded (see ``KVCacheAwareStrategy``).
+        Strategies that ignore stickiness should accept the kwargs and proceed
+        with their own scoring.
+        """
+        ...
+
+
+def _rank_key(score: float) -> float:
+    """Sort key treating non-finite scores (NaN/inf) as worst."""
+    return score if math.isfinite(score) else float("-inf")
+
+
+def route(
+    strategies: list[tuple[Any, float]],
+    prompt_ids: list[int] | None,
+    provider: Any,
+    replicas: list[Any],
+    request_id: str | None = None,
+    sticky_table: Any = None,
+) -> list[str]:
+    """Return replica ids ranked best-first.
+
+    Falls back to a random shuffle of replica ids if any strategy raises or
+    returns a wrong-length score list — routing remains available even when
+    metrics are temporarily unavailable.
+
+    Args:
+        strategies: ``[(strategy, weight), ...]`` — weighted strategies.
+        prompt_ids: prompt token ids (content-aware routing; may be ``None``).
+        provider: ``RouteDataProvider`` for metric queries.
+        replicas: ``[ReplicaInfo, ...]`` — candidate replicas.
+        request_id: session id for sticky-session routing (may be ``None``).
+        sticky_table: ``StickySessionTable`` for sticky lookups (may be ``None``).
+
+    Returns:
+        Replica ids sorted by total score, best first. Falls back to random
+        order on scoring failure.
+
+    Raises:
+        RuntimeError: ``replicas`` is empty.
+    """
+    n = len(replicas)
+    if n == 0:
+        raise RuntimeError("no available replicas")
+
+    final = [0.0] * n
+    for strategy, weight in strategies:
+        name = type(strategy).__name__
+        try:
+            scores = strategy.score(
+                prompt_ids, provider, replicas, request_id, sticky_table,
+            )
+            if len(scores) != n:
+                raise ValueError(f"{name}.score() returned {len(scores)} scores, expected {n}")
+        except Exception as exc:  # noqa: BLE001
+            ids = [r.replica_id for r in replicas]
+            random.shuffle(ids)
+            logger.warning(
+                f"route(): {name} failed ({type(exc).__name__}: {exc}), falling back to random order",
+            )
+            return ids
+        for idx in range(n):
+            final[idx] += weight * scores[idx]
+
+    ranking = sorted(range(n), key=lambda idx: _rank_key(final[idx]), reverse=True)
+    scores_str = ", ".join(
+        f"{replicas[idx].replica_id}={final[idx]:.4f}" for idx in ranking
+    )
+    logger.info(f"route(): replicas={n} ranking=[{scores_str}]")
+    return [replicas[idx].replica_id for idx in ranking]

--- a/uni_agent/llm_router/strategies/routing.py
+++ b/uni_agent/llm_router/strategies/routing.py
@@ -86,7 +86,11 @@ def route(
         name = type(strategy).__name__
         try:
             scores = strategy.score(
-                prompt_ids, provider, replicas, request_id, sticky_table,
+                prompt_ids,
+                provider,
+                replicas,
+                request_id,
+                sticky_table,
             )
             if len(scores) != n:
                 raise ValueError(f"{name}.score() returned {len(scores)} scores, expected {n}")
@@ -101,8 +105,6 @@ def route(
             final[idx] += weight * scores[idx]
 
     ranking = sorted(range(n), key=lambda idx: _rank_key(final[idx]), reverse=True)
-    scores_str = ", ".join(
-        f"{replicas[idx].replica_id}={final[idx]:.4f}" for idx in ranking
-    )
+    scores_str = ", ".join(f"{replicas[idx].replica_id}={final[idx]:.4f}" for idx in ranking)
     logger.info(f"route(): replicas={n} ranking=[{scores_str}]")
     return [replicas[idx].replica_id for idx in ranking]

--- a/uni_agent/llm_router/strategies/sticky_session.py
+++ b/uni_agent/llm_router/strategies/sticky_session.py
@@ -1,0 +1,103 @@
+"""StickySessionTable — request_id → replica_id LRU mapping for sticky routing.
+
+Holds the sticky-session affinity table for the KVCAware router. The Balancer
+owns one instance and threads it into ``route()`` → ``strategy.score()`` so the
+strategy can short-circuit to a sticky replica when it is not overloaded; the
+table is also written back (``put``) by the Balancer after each routing
+decision so subsequent turns of the same ``request_id`` stay affinity-bound.
+
+Design notes:
+- **LRU eviction**: backed by ``cachetools.LRUCache`` (same dep verl's
+  ``GlobalRequestLoadBalancer`` uses). Access (``get``/``__contains__``)
+  refreshes recency, so a hot conversation is never evicted in favour of a
+  cold one.
+- **No locking**: the ``KVCAwareBalancer`` is a single Ray actor running
+  ``acquire_server`` serially, so the table is accessed from one thread.
+  Callers that share the table across threads must wrap it themselves.
+- **Replica removal**: ``invalidate_replica`` bulk-clears every request_id
+  bound to a removed replica, so stale stickiness never routes to a dead
+  server. This is O(n) in table size; ``remove_servers`` is a rare, elastic
+  event, so that cost is fine.
+
+Reference: verl ``router.py`` ``DEFAULT_ROUTING_CACHE_SIZE = 10000``.
+"""
+
+from __future__ import annotations
+
+from cachetools import LRUCache
+
+from uni_agent.llm_router.logging import get_router_logger
+
+logger = get_router_logger("sticky-session")
+
+DEFAULT_STICKY_MAX_SIZE = 10000
+
+
+class StickySessionTable:
+    """LRU map of ``request_id → replica_id`` for sticky-session routing.
+
+    Read by strategies during scoring (``get``); written by the Balancer after
+    each routing decision (``put``); invalidated on server removal
+    (``invalidate_replica``) or per-request expiry (``invalidate``).
+    """
+
+    def __init__(self, max_size: int = DEFAULT_STICKY_MAX_SIZE) -> None:
+        if max_size <= 0:
+            raise ValueError(f"max_size must be > 0, got {max_size}")
+        self._max_size = int(max_size)
+        self._table: LRUCache[str, str] = LRUCache(maxsize=self._max_size)
+        logger.info(f"StickySessionTable created: max_size={self._max_size}")
+
+    @property
+    def max_size(self) -> int:
+        """Configured LRU capacity."""
+        return self._max_size
+
+    def get(self, request_id: str) -> str | None:
+        """Return the bound replica_id, refreshing LRU recency on hit.
+
+        ``None`` means no sticky binding (cold start, or evicted by LRU).
+        Accessing the key on hit moves it to most-recently-used, mirroring
+        verl ``GlobalRequestLoadBalancer``'s ``__contains__`` + ``__getitem__``
+        pattern.
+        """
+        if request_id in self._table:
+            return self._table[request_id]
+        return None
+
+    def put(self, request_id: str, replica_id: str) -> None:
+        """Bind / refresh ``request_id → replica_id``.
+
+        Inserting an existing key refreshes recency and updates the bound
+        replica (e.g. when overload-fallback routed to a different server).
+        """
+        self._table[request_id] = replica_id
+
+    def invalidate(self, request_id: str) -> None:
+        """Drop a single request_id's binding (e.g. stale replica hit)."""
+        self._table.pop(request_id, None)
+
+    def invalidate_replica(self, replica_id: str) -> None:
+        """Drop every binding pointing at a removed replica.
+
+        Called from ``KVCAwareBalancer.remove_servers`` so a server going away
+        doesn't leave sticky entries routing into the void. O(n) in table size
+        — acceptable for the rare elastic-removal path.
+        """
+        stale = [rid for rid, sid in self._table.items() if sid == replica_id]
+        for rid in stale:
+            self._table.pop(rid, None)
+        if stale:
+            logger.info(
+                f"invalidate_replica: replica={replica_id} cleared {len(stale)} bindings",
+            )
+
+    def __len__(self) -> int:
+        return len(self._table)
+
+    def status(self) -> dict:
+        """Return a debugging snapshot of the table state."""
+        return {
+            "max_size": self._max_size,
+            "size": len(self._table),
+        }


### PR DESCRIPTION
### What does this PR do?

This PR adds **llm-router** — a pluggable KV-cache-aware + load-aware intelligent router for Agentic RL, serving as a load balancer for veRL's multi-replica (data-parallel) vLLM inference. It replaces the default `global_sticky_inflight` router with one that routes requests based on real-time KV cache state and replica load.

Highlights:
- **KVCAwareBalancer** routing framework with component lifecycle management and routing decisions.
- **Composite Collector** (Transport + Decoder) collecting vLLM KV events (ZMQ) and Prometheus metrics (HTTP).
- **KVCacheAwareStrategy** — combined scoring from KV cache hit rate + load, with a sticky-session table and overload fallback.
- **Store** — singletons (`KVCacheStore`, `MetricsStore`) caching collected metrics and KV block states.
- **MooncakeStoreConnector** integration for cross-replica KV sharing (conn-pool + CPU staging + lease fixes).
- `examples/llm_router/run_infer.sh` + `parallel_infer.py` end-to-end entry, plus `kvc_aware_router.yaml` config.

### Checklist Before Starting

- [x] Search for similar PRs or issues and paste at least one relevant link here: N/A — new module (no prior router PR).
- [x] Format the PR title as `[{modules}] {type}: {description}` (checked by CI)
  - Title: `[core, examples, docs] feat: add llm-router with KV-cache-aware load balancing for multi-replica vLLM inference`
  - `{modules}` may include `core`, `interaction`, `model`, `env`, `tools`, `deployment`, `reward`, `dashboard`, `docs`, `examples`, `data`, `train`, `ci`, `build`, `deps`, `misc`
  - If this PR involves multiple modules, separate them with `,` like `[interaction, tools, docs]`
  - `{type}` must be one of `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks an API, config contract, workflow, or other compatibility boundary, add `[BREAKING]` to the beginning of the title
  - For a stacked PR series, you may prepend a progress marker such as `[1/N]`
  - Example: `[BREAKING][deployment, docs] feat: simplify runtime env configuration`

### Test

Full CI suite lives in `tests/uni_agent/llm_router/ci_test.sh` (4 stages: `ut` / `st-cpu` / `st-gpu` / `e2e`), each tagged on `type` × `resource` pytest markers. `VLLM_MODEL` points to your local model path; `CUDA_VISIBLE_DEVICES` selects the GPUs (count must match the stage's TP/DP need).

**verl requirement** — the `st-gpu` and `e2e` stages exercise the ZMQ KV-event collector, which needs the **kv-cache-events fork of verl** (commit `e546f147`, "Merge PR #1 from yyyyrrrrif/kv-event", based on `v0.8.0`). That fork adds the `enable_kv_cache_events` ZMQ publisher that `KVEventCollector` subscribes to. `ut` and `st-cpu` (pure logic / Ray only) run fine on stock verl `v0.8.0`. Note: the committed submodule pointer currently tracks upstream verl `7aed6b2` (v0.8.0) — check out the kv-events fork (`e546f147`) before running `st-gpu`/`e2e`.

```bash
# ut + st-cpu + st-gpu (st-gpu needs ≥2 GPUs for TP=2)
CUDA_VISIBLE_DEVICES=0,1 VLLM_MODEL=<your-model-path> \
  bash tests/uni_agent/llm_router/ci_test.sh --ut --st-cpu --st-gpu

# e2e (tp2dp3 = 6 GPUs, TP=2 → DP=3)
CUDA_VISIBLE_DEVICES=0,1,2,3,4,5 VLLM_MODEL=<your-model-path> \
  bash tests/uni_agent/llm_router/ci_test.sh --e2e
```

Results:

| Stage | Result |
|-------|--------|
| ut (config / strategies / balancer logic) | **196 passed** |
| st-cpu (balancer integration over Ray) | **5 passed** |
| st-gpu (PollingCollector + KVEventCollector vs real vLLM) | **9 passed** |
| e2e router (KVCAware router via `run_infer.sh`, tp2dp3) | **1 passed** (~110s) |
| e2e mooncake (router + MooncakeStoreConnector, tp2dp3) | **1 passed** (~115s) |

Overall: **all 212 checks green**, exit 0. (e2e mooncake emits 1 warning: small-sample run may not trigger an External prefix cache hit — connector creation + zero TCP errors already prove mooncake wiring is correct.)

### API and Usage Example

`examples/llm_router/run_infer.sh` is a thin wrapper over `parallel_infer.py`. First 3 args are positional (`MODEL_PATH` required; `DATA_PATH`/`AGENT_CONFIG` default to the same dir); extra flags are forwarded via `$@`.

```bash
# Smoke test (defaults: 2 GPUs, TP=1, 1 sample)
bash examples/llm_router/run_infer.sh /path/to/Qwen3-4B

# Full data-parallel run with KVCAware router
bash examples/llm_router/run_infer.sh /path/to/Qwen3-4B \
    --num-workers 8 --n-gpus-per-node 8 --tensor-parallel-size 2 \
    --max-num-seqs 64 --max-samples -1 --prompt-length 31744 \
    --router-config-path pkg://uni_agent.llm_router.configs/kvc_aware_router.yaml

# With cross-replica KV sharing (MooncakeStoreConnector)
bash examples/llm_router/run_infer.sh /path/to/Qwen3-4B \
    --router-config-path pkg://uni_agent.llm_router.configs/kvc_aware_router.yaml \
    --enable-mooncake --mooncake-config-path mooncake_config.json
```

### Design & Code Changes

Module layout under `uni_agent/llm_router/`:

```
balancer.py            # KVCAwareBalancer — lifecycle, server pool, route() dispatch
collectors/            # composite Collector = Transport(zmq/http) + Decoder
   transport/{http.py, zmq.py}
strategies/            # KVCacheAwareStrategy + StickySessionTable + load_score
   kvc_aware.py load_score.py sticky_session.py routing.py registry.py
store/                 # KVCacheStore + MetricsStore (singletons)
config/ configs/       # router/strategy/collector/cache config + YAML
```

Key design points:
- **Composite over inheritance for collectors** — a `Collector` composes a `Transport` (ZMQ KV events / HTTP metrics) and a `Decoder`, so each concern varies independently instead of a deep collector class hierarchy.
- **Combined scoring** — `score = alpha * S_cache + (1 - alpha) * S_load`; `S_load` from KV usage / running / waiting, `S_cache` from GPU + tier prefix hit rate. Overloaded replicas (`(1 - s_load) > load_threshold`) fall back and rebind the sticky session.
- **Sticky session table** — binds `request_id → replica` across turns, with size cap and invalidation when the bound replica is removed or saturated.
- **MooncakeStoreConnector** — three-piece fix for cross-replica KV stability: TCP connection pool, CPU staging, and 60s lease.

Detailed design notes: `uni_agent/llm_router/docs/design/{detailed_balancer,detailed_strategy_module,detailed_config}.md`. User-facing guide: `examples/llm_router/README.md` (+ `README_cn.md`), env/image setup in `uni_agent/llm_router/docs/env.md`.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](../CONTRIBUTING.md)
- [x] Run `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add or update docs/examples for user-facing changes
- [x] Add tests or explain why tests are not practical
- [x] Confirm the PR title matches the required format
- [x] Confirm the placeholder text in this template has been replaced with real content