### PR TITLE
[core] fix: wrap TQ write in try-except to prevent training hang on write failure

### DIFF
--- a/uni_agent/framework/framework.py
+++ b/uni_agent/framework/framework.py
@@ -117,7 +117,7 @@ def _short_failure_reason(error: BaseException) -> str:
     message = str(error)
     if not message:
         message = error.__class__.__name__
-    return message[:512]
+    return f"{error.__class__.__name__}:{message}"[:512]
 
 
 _TQ_NESTED_SEQUENCE_FIELDS = {
@@ -392,16 +392,22 @@ class OpenAICompatibleAgentFramework(AgentFramework):
                 failure_reasons.append(f"empty trajectories for uid={uid} session_index={session_index}")
                 continue
 
-            success_sessions += 1
-            await self._write_session_trajectories_to_tq(
-                uid=uid,
-                session_index=session_index,
-                trajectories=trajectories,
-                sample_fields=session_sample_fields,
-                global_steps=global_steps,
-                partition_id=partition_id,
-            )
-            success_outputs += len(trajectories)
+            try:
+                await self._write_session_trajectories_to_tq(
+                    uid=uid,
+                    session_index=session_index,
+                    trajectories=trajectories,
+                    sample_fields=session_sample_fields,
+                    global_steps=global_steps,
+                    partition_id=partition_id,
+                )
+            except Exception as e:
+                logger.exception(f"TQ write failed for uid={uid} session={session_index}: {e}")
+                failed_sessions += 1
+                failure_reasons.append(f"TQ write error: {e}")
+            else:
+                success_sessions += 1
+                success_outputs += len(trajectories)
 
         if success_sessions > 0:
             await tq.async_kv_put(key=uid, partition_id=partition_id, tag={"status": "finished"})


### PR DESCRIPTION
### What does this PR do?
  **Description**

  **Problem**

  When _write_session_trajectories_to_tq raises an exception during TransferQueue write (e.g., KeyError if required fields like finish_reason are missing from the trajectory), the exception propagates out of _run_prompt_sessions_to_tq before it can update the prompt's status in TQ ("finished" / "failure").

  This leaves the prompt permanently in "pending" state, causing _has_enough_samples in the replay buffer to never reach batch_size. The training loop hangs indefinitely, with no visible error other than a cryptic failure_reason: "'finish_reason'" in the logs (which loses the exception class name).

  **Root cause flow**

  1. _run_session returns trajectories successfully
  2. _write_session_trajectories_to_tq raises (e.g. KeyError)
  3. Exception propagates out of _run_prompt_sessions_to_tq → captured by asyncio.gather(return_exceptions=True) in _run_batch_to_tq
  4. _short_failure_reason calls str(KeyError('finish_reason')) which produces "'finish_reason'" — the exception type is lost
  5. Prompt remains "pending" in TQ → replay_buffer.sample() blocks forever

### Checklist Before Starting

- [ ] Search for similar PRs or issues and paste at least one relevant link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (checked by CI)
  - `{modules}` may include `core`, `interaction`, `model`, `env`, `tools`, `deployment`, `reward`, `dashboard`, `docs`, `examples`, `data`, `train`, `ci`, `build`, `deps`, `misc`
  - If this PR involves multiple modules, separate them with `,` like `[interaction, tools, docs]`
  - `{type}` must be one of `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks an API, config contract, workflow, or other compatibility boundary, add `[BREAKING]` to the beginning of the title
  - For a stacked PR series, you may prepend a progress marker such as `[1/N]`
  - Example: `[BREAKING][deployment, docs] feat: simplify runtime env configuration`

### Test

Defense against abnormal scenarios.

### API and Usage Example

N/A


### Design & Code Changes

  **Fix**

  1. _write_session_trajectories_to_tq: Wrap the call in try-except. On failure, log the full traceback via logger.exception, count the session as failed, and append the real error to
  failure_reasons. Move success_sessions and success_outputs to the else branch so they only increment on successful TQ write.
  2. _short_failure_reason: Include the exception class name in the output, so "'finish_reason'" becomes "KeyError: 'finish_reason'" for easier debugging.

  This ensures:
  - Full traceback is logged for TQ write failures
  - Prompt status is properly updated — no more stuck "pending" prompts
  - Real error message appears in generate_sequences summary's failure_reasons
  - Training continues instead of hanging silently

### Checklist Before Submitting

- [x] Read the [Contribute Guide](../CONTRIBUTING.md)
- [x] Run `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [ ] Add or update docs/examples for user-facing changes
- [x] Add tests or explain why tests are not practical
- [x] Confirm the PR title matches the required format
- [x] Confirm the placeholder text in this template has been replaced with real content
