### PR TITLE
[deployment,core] fix: harden local sandbox lifecycle

### DIFF
--- a/docs/source/start/agent_env.md
+++ b/docs/source/start/agent_env.md
@@ -93,6 +93,13 @@ export LOCAL_DEPLOYMENT_IMAGE=python:3.12
 export LOCAL_DEPLOYMENT_EXTRA_ARGS="--bind /data:/data"
 ```
 
+**Startup limits.**
+
+- **`LOCAL_MAX_STARTING_PER_WORKER`** (default `16`) caps concurrent starts per rollout worker and event loop; queueing counts toward the attempt timeout and startup budget.
+- **`LOCAL_INIT_WALL_BUDGET`** (default `600` seconds) bounds startup across retries. Cleanup may extend elapsed time beyond this budget.
+
+For large runs, bake `swe-rex` into the image and pre-pull it on every rollout node.
+
 ### veFaaS deployment
 
 veFaaS is a Volcengine FaaS platform. For workloads with many concurrent runs, it is often more stable and scales better than self-hosted local instances.

--- a/tests/deployment/conftest.py
+++ b/tests/deployment/conftest.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import pytest
+
+from uni_agent.deployment.local import deployment as mod
+
+
+@pytest.fixture(autouse=True)
+def fixed_ports(monkeypatch):
+    """Sandboxes may deny socket.bind; tests never need real free ports."""
+    ports = iter(range(20000, 29999))
+    monkeypatch.setattr(mod, "_pick_free_port", lambda: next(ports))

--- a/tests/deployment/support.py
+++ b/tests/deployment/support.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import types
+import weakref
+from pathlib import Path
+
+from uni_agent.deployment.local import deployment as mod
+from uni_agent.deployment.local.deployment import LocalDeployment
+
+
+def reset_limiter(monkeypatch, *, per_worker=16, wall_budget=600.0):
+    monkeypatch.setenv("LOCAL_MAX_STARTING_PER_WORKER", str(per_worker))
+    monkeypatch.setenv("LOCAL_INIT_WALL_BUDGET", str(wall_budget))
+    monkeypatch.setattr(mod, "_LIMITERS", weakref.WeakKeyDictionary(), raising=True)
+
+
+def fast_backoff(monkeypatch):
+    monkeypatch.setattr(mod, "_retrydelay", lambda s: asyncio.sleep(0))
+
+
+def fast_rm(monkeypatch):
+    """Skip the real pause between the two rm attempts."""
+    monkeypatch.setattr(mod, "_RMPAUSE", 0)
+
+
+class RecordingLogger:
+    def __init__(self):
+        self.records = []
+
+    def _log(self, level, template, *args):
+        self.records.append((level, template, args))
+
+    def debug(self, template, *args):
+        self._log("debug", template, *args)
+
+    def info(self, template, *args):
+        self._log("info", template, *args)
+
+    def warning(self, template, *args):
+        self._log("warning", template, *args)
+
+    def error(self, template, *args):
+        self._log("error", template, *args)
+
+    def messages(self, level=None):
+        return [
+            template.format(*args) if args else template
+            for lvl, template, args in self.records
+            if not level or lvl == level
+        ]
+
+
+class FakeRuntime:
+    def __init__(self):
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+class FakeHandle:
+    def __init__(self, *, close=None):
+        self.closed = False
+        self._close = close
+
+    def close(self):
+        if self._close:
+            return self._close()
+        self.closed = True
+
+
+class FakeProcess:
+    def __init__(self, *, terminate=None, kill=None, wait=None):
+        self.terminated = False
+        self.killed = False
+        self.wait_timeout = None
+        self._terminate = terminate
+        self._kill = kill
+        self._wait = wait
+
+    def poll(self):
+        return None
+
+    def terminate(self):
+        if self._terminate:
+            return self._terminate()
+        self.terminated = True
+
+    def kill(self):
+        if self._kill:
+            return self._kill()
+        self.killed = True
+
+    def wait(self, timeout=None):
+        self.wait_timeout = timeout
+        if self._wait:
+            return self._wait(timeout)
+        return 0
+
+
+async def _ok(dep=None):
+    return None
+
+
+async def fail_start(dep):
+    raise RuntimeError("boom")
+
+
+async def hang_start(dep):
+    await asyncio.sleep(3600)
+
+
+class LoopDeployment(LocalDeployment):
+    """Drives the production retry loop with a faked OCI start."""
+
+    async def _enter(self, container_name, published_port):
+        self._starts += 1
+        self._names.append(container_name)
+        self._ports.append(published_port)
+        await self._starter(self)
+
+    async def _start_oci_container(self, token, container_name, published_port):  # type: ignore[override]
+        await self._enter(container_name, published_port)
+        self._runtime = types.SimpleNamespace(create_session=self._session, close=_ok)
+
+    async def _session(self, request):
+        await self._sessioner(self)
+
+    async def _wait_until_alive(self, timeout):  # type: ignore[override]
+        return None
+
+    def _get_container_logs(self, ref):  # type: ignore[override]
+        self._events.append("logs")
+        return ""
+
+    async def _cleanup(self):  # type: ignore[override]
+        await self._stopper(self)
+
+
+class OciDeployment(LoopDeployment):
+    """Drives the production OCI start too, so ownership is exercised; use with fake_docker()."""
+
+    async def _start_oci_container(self, token, container_name, published_port):  # type: ignore[override]
+        await self._enter(container_name, published_port)
+        await LocalDeployment._start_oci_container(self, token, container_name, published_port)
+        self._runtime = types.SimpleNamespace(create_session=self._session, close=_ok)
+
+    _cleanup = LocalDeployment._cleanup
+
+
+class ApptDeployment(LoopDeployment):
+    """Fakes Apptainer startup while exercising production cleanup."""
+
+    async def _start_apptainer(self, token, published_port):  # type: ignore[override]
+        await self._enter("apptainer", published_port)
+        self._runtime = types.SimpleNamespace(create_session=self._session, close=_ok)
+
+    _cleanup = LocalDeployment._cleanup
+
+
+def _new(cls, config):
+    config.setdefault("container_runtime", "docker")
+    dep = cls("test-run", type="local", **config)
+    dep.logger = RecordingLogger()
+    return dep
+
+
+def _wire(dep, *, starter, stopper, sessioner):
+    dep._starts = 0
+    dep._names = []
+    dep._ports = []
+    dep._events = []
+    dep._starter = starter or _ok
+    dep._stopper = stopper or _ok
+    dep._sessioner = sessioner or _ok
+    return dep
+
+
+def make_plain(**config):
+    return _new(LocalDeployment, config)
+
+
+def make_loop(*, starter=None, stopper=None, **config):
+    return _wire(_new(LoopDeployment, config), starter=starter, stopper=stopper, sessioner=None)
+
+
+def make_oci(*, starter=None, sessioner=None, **config):
+    return _wire(_new(OciDeployment, config), starter=starter, stopper=None, sessioner=sessioner)
+
+
+def make_apptainer(*, starter=None, sessioner=None, **config):
+    config["container_runtime"] = "apptainer"
+    return _wire(_new(ApptDeployment, config), starter=starter, stopper=None, sessioner=sessioner)
+
+
+def cid(n: int = 1) -> str:
+    """A container id shaped like the runtime's own: 64 lowercase hex. Anything shorter is a partial
+    write, and the deployment refuses to claim one."""
+    return f"{n:064x}"
+
+
+def completed(returncode=0, stderr="", stdout=""):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stderr=stderr, stdout=stdout)
+
+
+def fake_docker(monkeypatch, *, started=None, release=None, result=None):
+    """A docker CLI double. `started`/`release` let a test hold `docker run` inside its thread;
+    `result` overrides the run's CompletedProcess (e.g. a non-zero exit)."""
+    state = {"rm": [], "runs": 0}
+
+    def fake_run(args, **kwargs):
+        if args[1] == "run":
+            state["runs"] += 1
+            container_id = cid(state["runs"])
+            Path(args[args.index("--cidfile") + 1]).write_text(f"{container_id}\n")
+            if started is not None:
+                started.set()
+            if release is not None:
+                release.wait(timeout=10)
+            if result is not None:
+                return result
+            return completed(0, stdout=f"{container_id}\n")
+        if args[1] == "rm":
+            state["rm"].append(args[3])
+        return completed(0)
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    return state
+
+
+async def cancel_start(dep, *, until):
+    import pytest
+
+    task = asyncio.create_task(dep.start())
+    for _ in range(400):
+        if until():
+            break
+        await asyncio.sleep(0.005)
+    else:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=10)
+        raise AssertionError("cancel_start: until() never became true")
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, timeout=10)

--- a/tests/deployment/test_local_deployment.py
+++ b/tests/deployment/test_local_deployment.py
@@ -1,5 +1,6 @@
 import asyncio
 
+from tests.deployment.support import FakeProcess, FakeRuntime
 from uni_agent.deployment.local import deployment as local_deployment
 from uni_agent.deployment.local.deployment import (
     LocalDeployment,
@@ -136,42 +137,14 @@ def test_docker_command_keeps_published_to_runtime_port_mapping():
     ]
 
 
-class _FakeRuntime:
-    def __init__(self):
-        self.closed = False
-
-    async def close(self):
-        self.closed = True
-
-
-class _FakeProcess:
-    def __init__(self):
-        self.terminated = False
-        self.killed = False
-        self.wait_timeout = None
-
-    def poll(self):
-        return None
-
-    def terminate(self):
-        self.terminated = True
-
-    def wait(self, timeout=None):
-        self.wait_timeout = timeout
-        return 0
-
-    def kill(self):
-        self.killed = True
-
-
 def test_stop_closes_runtime_and_apptainer_process_without_docker_rm(tmp_path):
     deployment = LocalDeployment(
         run_id="test",
         type="local",
         container_runtime="apptainer",
     )
-    runtime = _FakeRuntime()
-    process = _FakeProcess()
+    runtime = FakeRuntime()
+    process = FakeProcess()
     log_path = tmp_path / "apptainer.log"
     log_path.write_text("server log", encoding="utf-8")
     log_handle = log_path.open("a", encoding="utf-8")
@@ -180,9 +153,7 @@ def test_stop_closes_runtime_and_apptainer_process_without_docker_rm(tmp_path):
     deployment._server_process = process
     deployment._server_log_path = log_path
     deployment._server_log_handle = log_handle
-    deployment._container_name = "sandbox-name"
     deployment._container_id = "container-id"
-    deployment._stopped = False
 
     asyncio.run(deployment.stop())
 
@@ -193,6 +164,5 @@ def test_stop_closes_runtime_and_apptainer_process_without_docker_rm(tmp_path):
     assert deployment._server_process is None
     assert deployment._server_log_handle is None
     assert deployment._server_log_path is None
-    assert deployment._container_name is None
     assert deployment._container_id is None
     assert not log_path.exists()

--- a/tests/deployment/test_local_finalizer.py
+++ b/tests/deployment/test_local_finalizer.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import asyncio
+import subprocess
+
+import pytest
+
+from tests.deployment.support import (
+    FakeHandle,
+    FakeProcess,
+    cancel_start,
+    cid,
+    completed,
+    fail_start,
+    fake_docker,
+    fast_backoff,
+    hang_start,
+    make_apptainer,
+    make_oci,
+    make_plain,
+    reset_limiter,
+)
+from uni_agent.deployment.local import deployment as mod
+
+
+def test_cancel_ids(monkeypatch):
+    reset_limiter(monkeypatch)
+    docker = fake_docker(monkeypatch)
+
+    dep = make_oci(sessioner=hang_start)
+
+    async def _go():
+        await cancel_start(dep, until=lambda: dep._owned)
+        assert dep._owned == (cid(1), "uni-agent-test-run")
+        await dep.stop()
+
+    asyncio.run(_go())
+    assert docker["rm"] == [cid(1)]
+    assert dep._owned is None
+
+
+@pytest.mark.parametrize("reap_ok", [True, False])
+def test_cancel_keep(monkeypatch, reap_ok):
+    reset_limiter(monkeypatch)
+    unlinked = []
+    if reap_ok:
+        proc = FakeProcess()
+        handle = FakeHandle()
+        path = type("P", (), {"unlink": staticmethod(lambda missing_ok=False: unlinked.append(True))})()
+    else:
+        proc = FakeProcess(kill=lambda: (_ for _ in ()).throw(OSError("kill failed")))
+        handle = FakeHandle(close=lambda: (_ for _ in ()).throw(OSError("close failed")))
+        path = type(
+            "P", (), {"unlink": staticmethod(lambda missing_ok=False: (_ for _ in ()).throw(OSError("busy")))}
+        )()
+
+    async def plant_and_hang(dep):
+        dep._server_process = proc
+        dep._server_log_handle = handle
+        dep._server_log_path = path
+        await asyncio.sleep(3600)
+
+    dep = make_apptainer(starter=plant_and_hang)
+
+    asyncio.run(cancel_start(dep, until=lambda: dep._server_process is proc))
+    assert dep._abandoned is True
+    if reap_ok:
+        assert proc.killed and proc.wait_timeout == mod._REAPWAIT
+        assert dep._server_process is None
+        assert handle.closed and dep._server_log_handle is None
+        assert unlinked == [True] and dep._server_log_path is None
+    else:
+        assert dep._server_process is proc
+        assert dep._server_log_handle is handle and dep._server_log_path is path
+        assert dep._has_cleanup()
+        warnings = dep.logger.messages("warning")
+        assert any("could not reap" in m for m in warnings)
+        assert any("failed to close" in m for m in warnings)
+        assert any("failed to unlink" in m for m in warnings)
+
+
+def test_stop_retry():
+    dep = make_plain(container_runtime="apptainer")
+    state = {"terminate": 0, "kill": 0, "kill_fails": True}
+
+    def _terminate():
+        state["terminate"] += 1
+        raise OSError("terminate failed")
+
+    def _kill():
+        state["kill"] += 1
+        if state["kill_fails"]:
+            raise OSError("kill failed")
+
+    proc = FakeProcess(terminate=_terminate, kill=_kill)
+    dep._server_process = proc
+
+    asyncio.run(dep.stop())
+    assert dep._server_process is proc
+    assert state["terminate"] == 1 and state["kill"] == 1
+
+    state["kill_fails"] = False
+    asyncio.run(dep.stop())
+    assert dep._server_process is None
+    assert state["kill"] == 2
+
+
+@pytest.mark.parametrize("resource", ["proc", "logs"])
+def test_stuck_res(monkeypatch, resource):
+    """A retry never starts over a resource the previous attempt's cleanup could not reclaim."""
+    reset_limiter(monkeypatch)
+    fast_backoff(monkeypatch)
+    if resource == "proc":
+        stale = FakeProcess(
+            terminate=lambda: (_ for _ in ()).throw(OSError("terminate failed")),
+            kill=lambda: (_ for _ in ()).throw(OSError("kill failed")),
+        )
+        attr = "_server_process"
+    else:
+        stale = type(
+            "P", (), {"unlink": staticmethod(lambda missing_ok=False: (_ for _ in ()).throw(OSError("file busy")))}
+        )()
+        attr = "_server_log_path"
+
+    async def plant_and_fail(dep):
+        setattr(dep, attr, stale)
+        raise RuntimeError("boom")
+
+    dep = make_apptainer(starter=plant_and_fail)
+
+    with pytest.raises(RuntimeError, match="not retrying"):
+        asyncio.run(dep.start(max_retries=2))
+    assert getattr(dep, attr) is stale
+    assert dep._starts == 1
+
+
+_SWEEP = {
+    "ok": {"rc": 0, "gone": True},
+    "no-such": {"rc": 1, "stderr": "Error: No such container: xid", "gone": True},
+    "no-container-with": {"rc": 1, "stderr": "Error: no container with name or ID xid", "gone": True},
+    "busy": {"rc": 1, "stderr": "daemon busy", "gone": False},
+    "timeout": {"rc": None, "gone": False},
+}
+
+
+@pytest.mark.parametrize("case", sorted(_SWEEP))
+def test_del_sweep(monkeypatch, case):
+    """An id leaves the ledger only on a confirmed removal; any other outcome keeps it and the barrier."""
+    spec = _SWEEP[case]
+    dep = make_plain()
+    dep._owned = (cid(1), "x")
+    dep._container_id = cid(1)
+    calls = []
+
+    def fake_run(args, **kw):
+        calls.append((args, kw))
+        if spec["rc"] is None:
+            raise subprocess.TimeoutExpired(cmd=args, timeout=kw.get("timeout"))
+        return completed(spec["rc"], stderr=spec.get("stderr", ""))
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    dep.__del__()
+    args, kwargs = calls[0]
+    assert len(calls) == 1
+    assert args[:4] == ["docker", "rm", "-f", cid(1)]
+    assert kwargs["timeout"] == mod._DELWAIT
+
+    if spec["gone"]:
+        assert dep._owned is None and dep._container_id is None
+        assert not dep._has_cleanup()
+    else:
+        assert dep._owned == (cid(1), "x") and dep._container_id == cid(1)
+        assert dep._has_cleanup()
+        assert any("may leak" in m for m in dep.logger.messages("error"))
+
+
+def _mute(dep):
+    """Give the deployment a logger that raises on every level (a torn-down sink)."""
+
+    def dead(*args, **kwargs):
+        raise RuntimeError("the sink is gone")
+
+    dep.logger = type("L", (), {"debug": dead, "info": dead, "warning": dead, "error": dead})()
+
+
+@pytest.mark.parametrize("case", ["removed", "barrier"])
+def test_del_mute(monkeypatch, tmp_path, case):
+    """A dead sink never aborts the sweep, in either lifecycle outcome: the orphan resolves to an id
+    and is removed (`removed`), or the query cannot answer and the barrier holds (`barrier`)."""
+    dep = make_plain()
+    cidfile = tmp_path / "cid"
+    cidfile.write_text("")
+    dep._orphan = (cidfile, "owner-uuid", True)
+    _mute(dep)
+    calls = []
+
+    def fake_run(args, **kw):
+        calls.append(args[1])
+        if args[1] != "ps":
+            return completed(0)
+        if case == "barrier":
+            raise subprocess.TimeoutExpired(cmd=args, timeout=kw.get("timeout"))
+        return completed(0, stdout=f"{cid(1)}\n")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    dep.__del__()
+    if case == "removed":
+        assert calls == ["ps", "rm"]
+        assert dep._orphan is None and dep._owned is None and not dep._has_cleanup()
+    else:
+        assert calls == ["ps"]
+        assert dep._orphan is not None and not cidfile.exists()
+
+
+def test_del_logs():
+    """A dead sink must not cost the finalizer the apptainer log file it was about to unlink."""
+    dep = make_plain(container_runtime="apptainer")
+    unlinked = []
+    dep._server_log_handle = FakeHandle(close=lambda: (_ for _ in ()).throw(OSError("busy")))
+    dep._server_log_path = type("P", (), {"unlink": staticmethod(lambda missing_ok=False: unlinked.append(True))})()
+    _mute(dep)
+
+    dep.__del__()
+    assert unlinked == [True]  # the failed close did not take the unlink with it
+    assert dep._server_log_handle is not None and dep._server_log_path is None
+
+
+def test_fail_mute(monkeypatch):
+    """A sink that raises on the failure record must not take the cleanup that record introduces."""
+    reset_limiter(monkeypatch)
+    fast_backoff(monkeypatch)
+    docker = fake_docker(monkeypatch)
+    dep = make_oci(sessioner=fail_start)
+    dep.logger.error = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("the sink is gone"))
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(asyncio.wait_for(dep.start(max_retries=1), timeout=20))
+    assert docker["rm"] == [cid(1)] and dep._owned is None
+
+
+def test_del_kept(monkeypatch, tmp_path):
+    """The finalizer names the container by tag but cannot remove it: the id it learned is kept."""
+    dep = make_plain()
+    dep._orphan = (tmp_path / "cid", "owner-uuid", True)
+
+    def fake_run(args, **kw):
+        if args[1] == "ps":
+            return completed(0, stdout=f"{cid(1)}\n")
+        return completed(1, stderr="daemon busy")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    dep.__del__()
+    assert dep._owned == (cid(1), cid(1)[: mod._IDLEN])
+    assert dep._orphan is None and dep._has_cleanup()  # named, so no longer nameless -- but not gone
+
+
+def test_del_orphan(monkeypatch, tmp_path):
+    """The finalizer probes for the container it could not name: by the owner tag, and bounded."""
+    dep = make_plain()
+    cidfile = tmp_path / "cid"
+    dep._orphan = (cidfile, "owner-uuid", True)
+    calls = []
+
+    def fake_run(args, **kw):
+        calls.append((args, kw))
+        if args[1] == "ps":
+            return completed(0, stdout=f"{cid(1)}\n")
+        return completed(0)
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    dep.__del__()
+    ps = [(a, kw) for a, kw in calls if a[1] == "ps"]
+    assert [a[-1] for a, _ in ps] == [f"label={mod._OWNERTAG}=owner-uuid"]
+    assert [kw["timeout"] for _, kw in ps] == [mod._DELWAIT]
+    assert [a[3] for a, _ in calls if a[1] == "rm"] == [cid(1)]
+    assert dep._orphan is None
+
+
+def test_del_stuck(monkeypatch, tmp_path):
+    """A finalizer that still cannot name the container drops the cidfile, logs the owner tag as the
+    handle left, and keeps the barrier (a hand-called __del__ must not let a start follow)."""
+    dep = make_plain()
+    cidfile = tmp_path / "cid"
+    cidfile.write_text("")
+    dep._orphan = (cidfile, "owner-uuid", False)
+    monkeypatch.setattr(mod.subprocess, "run", lambda args, **kw: completed(0, stdout=""))
+
+    dep.__del__()
+    assert not cidfile.exists()
+    assert dep._orphan is not None and dep._has_cleanup()
+    assert any("owner-uuid" in m for m in dep.logger.messages("error"))
+
+
+def test_del_proc(monkeypatch):
+    """__del__ reaps a pending Apptainer server without CLI calls."""
+    dep = make_plain(container_runtime="apptainer")
+    proc = FakeProcess()
+    dep._server_process = proc
+    dep._owned = (cid(1), "uni-agent-test-run")
+    calls = []
+    monkeypatch.setattr(mod.subprocess, "run", lambda args, **kw: calls.append(args) or completed(0))
+
+    dep.__del__()
+    assert proc.killed
+    assert dep._server_process is None
+    assert calls == []

--- a/tests/deployment/test_local_ownership.py
+++ b/tests/deployment/test_local_ownership.py
@@ -1,0 +1,810 @@
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import gc
+import shutil
+import subprocess
+import threading
+from pathlib import Path
+
+import pytest
+from loguru import logger as loguru_logger
+
+from tests.deployment.support import (
+    FakeProcess,
+    FakeRuntime,
+    cid,
+    completed,
+    fail_start,
+    fake_docker,
+    fast_backoff,
+    fast_rm,
+    make_loop,
+    make_oci,
+    make_plain,
+    reset_limiter,
+)
+from uni_agent.async_logging import add_file_handler, cleanup_handlers
+from uni_agent.deployment.local import deployment as mod
+
+
+def test_logs_gated(monkeypatch):
+    reset_limiter(monkeypatch)
+    dep = make_loop(starter=fail_start)
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(dep.start(max_retries=1))
+    assert "logs" not in dep._events
+    assert any("creation unconfirmed" in m for m in dep.logger.messages("error"))
+
+
+def test_cancel_reap(monkeypatch):
+    """Cancel with docker run in flight: nothing may start over it, stop() drains it, and the
+    container is removed exactly once -- by the thread that made it."""
+    reset_limiter(monkeypatch)
+    started, release = threading.Event(), threading.Event()
+    docker = fake_docker(monkeypatch, started=started, release=release)
+    dep = make_oci()
+
+    async def _go():
+        task = asyncio.create_task(dep.start(max_retries=1))
+        while not started.is_set():
+            await asyncio.sleep(0.005)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert docker["rm"] == []  # the daemon still holds the container
+        with pytest.raises(RuntimeError, match="stop\\(\\) must reclaim them first"):
+            await dep.start()
+        stopping = asyncio.create_task(dep.stop())
+        await asyncio.sleep(0.05)
+        assert not stopping.done()  # stop() waits for the call it cannot cancel
+        release.set()
+        await asyncio.wait_for(stopping, timeout=10)
+
+    asyncio.run(asyncio.wait_for(_go(), timeout=20))
+    assert docker["rm"] == [cid(1)]
+    assert dep._owned is None
+    assert dep._future is None
+    assert any("abandoned" in m for m in dep.logger.messages("warning"))
+
+
+def test_retry_slot(monkeypatch):
+    """The CLI timeout outlives the cleanup timeout, so cleanup may not get the call back; the loop
+    must then stop rather than submit over it."""
+    reset_limiter(monkeypatch)
+    fast_backoff(monkeypatch)
+    monkeypatch.setattr(mod, "_STARTPAD", 0.1)
+    monkeypatch.setattr(mod, "_CLEANWAIT", 0.2)
+    release = threading.Event()
+    docker = fake_docker(monkeypatch, release=release)
+    dep = make_oci(startup_timeout=0.1)
+
+    async def _go():
+        with pytest.raises(RuntimeError, match="not retrying"):
+            await dep.start(max_retries=2)
+        assert docker["runs"] == 1  # the second attempt never launched a container
+        held = dep._future
+        assert held is not None and not held.done()
+
+        stopping = asyncio.create_task(dep.stop())
+        await asyncio.sleep(0.05)
+        assert not stopping.done()  # stop() waits for the call the retry loop refused to abandon
+        assert dep._future is held  # and it is still the same call
+        release.set()
+        await asyncio.wait_for(stopping, timeout=10)
+
+    asyncio.run(asyncio.wait_for(_go(), timeout=20))
+    assert docker["rm"] == [cid(1)]
+    assert dep._future is None
+    assert dep._owned is None
+
+
+def test_rm_stops(monkeypatch):
+    """A container cleanup could not remove stays owned, and no retry may start a second one over it."""
+    reset_limiter(monkeypatch)
+    fast_backoff(monkeypatch)
+    runs = {"n": 0, "rm": 0}
+
+    def fake_run(args, **kwargs):
+        if args[1] == "run":
+            runs["n"] += 1
+            container_id = cid(runs["n"])
+            Path(args[args.index("--cidfile") + 1]).write_text(f"{container_id}\n")
+            return completed(0, stdout=f"{container_id}\n")
+        if args[1] == "rm":
+            runs["rm"] += 1
+            return completed(1, stderr="daemon busy")  # fails fast, twice
+        return completed(0)
+
+    fast_rm(monkeypatch)
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    dep = make_oci(sessioner=fail_start)
+
+    with pytest.raises(RuntimeError, match="not retrying"):
+        asyncio.run(dep.start(max_retries=2))
+
+    assert runs["n"] == 1  # the second attempt never launched a container
+    assert dep._owned == (cid(1), "uni-agent-test-run")
+    assert dep._container_id == cid(1)  # the diagnostics pointer survives a failed rm
+    dep._owned = None
+    dep._container_id = None
+
+
+def test_clean_drain(monkeypatch):
+    """A cleanup cancelled mid-rm leaves that rm in the slot; stop() drains the same call and the
+    container is never removed twice."""
+    reset_limiter(monkeypatch)
+    fast_backoff(monkeypatch)
+    monkeypatch.setattr(mod, "_CLEANWAIT", 0.2)
+    release = threading.Event()
+    runs = {"n": 0, "rm": 0}
+
+    def fake_run(args, **kwargs):
+        if args[1] == "run":
+            runs["n"] += 1
+            container_id = cid(runs["n"])
+            Path(args[args.index("--cidfile") + 1]).write_text(f"{container_id}\n")
+            return completed(0, stdout=f"{container_id}\n")
+        if args[1] == "rm":
+            runs["rm"] += 1
+            release.wait(timeout=10)  # the rm outlives the cleanup that started it
+            return completed(0)
+        return completed(0)
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    dep = make_oci(sessioner=fail_start)
+
+    async def _go():
+        with pytest.raises(RuntimeError, match="not retrying"):
+            await dep.start(max_retries=2)
+        assert runs["n"] == 1
+        assert runs["rm"] == 1
+        held = dep._future
+        assert held is not None and not held.done()
+
+        stopping = asyncio.create_task(dep.stop())
+        await asyncio.sleep(0.05)
+        assert dep._future is held  # stop() drains the very call the cleanup left behind
+        release.set()
+        await asyncio.wait_for(stopping, timeout=10)
+
+    asyncio.run(asyncio.wait_for(_go(), timeout=20))
+    assert runs["rm"] == 1  # never removed twice
+    assert dep._owned is None
+    assert dep._container_id is None
+    assert dep._future is None
+
+
+def test_drain_keep(monkeypatch):
+    """A cancelled drain leaves the call in flight; the next stop() consumes it, error and all."""
+    reset_limiter(monkeypatch)
+    started, release = threading.Event(), threading.Event()
+    unhandled = []
+    fake_docker(monkeypatch, started=started, release=release, result=completed(1, stderr="daemon died"))
+    dep = make_oci()
+
+    async def _go():
+        asyncio.get_running_loop().set_exception_handler(lambda loop, ctx: unhandled.append(ctx))
+        task = asyncio.create_task(dep.start(max_retries=1))
+        while not started.is_set():
+            await asyncio.sleep(0.005)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        stopping = asyncio.create_task(dep.stop())
+        await asyncio.sleep(0.05)
+        stopping.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await stopping
+        assert dep._has_cli()  # the call runs on; a later stop() drains it
+        assert dep._has_cleanup()
+
+        release.set()
+        await asyncio.wait_for(dep.stop(), timeout=10)
+        gc.collect()  # force Future.__del__ while the loop can still report it
+        await asyncio.sleep(0)
+
+    asyncio.run(asyncio.wait_for(_go(), timeout=20))
+    assert dep._future is None
+    assert any("failed after its attempt ended" in m for m in dep.logger.messages("warning"))
+    assert unhandled == []
+
+
+def test_permit_bind(monkeypatch):
+    """A cancelled attempt's permit is held until its CLI thread returns."""
+    reset_limiter(monkeypatch, per_worker=1)
+    started, release = threading.Event(), threading.Event()
+    docker = fake_docker(monkeypatch, started=started, release=release)
+    dep_a = make_oci()
+    dep_b = make_oci()
+
+    async def _go():
+        task = asyncio.create_task(dep_a.start(max_retries=1))
+        while not started.is_set():
+            await asyncio.sleep(0.005)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        second = asyncio.create_task(dep_b.start(max_retries=1))
+        await asyncio.sleep(0.1)
+        assert docker["runs"] == 1
+        release.set()
+        await asyncio.wait_for(second, timeout=10)
+        assert docker["runs"] == 2
+        await dep_a.stop()
+        await dep_b.stop()
+
+    asyncio.run(asyncio.wait_for(_go(), timeout=20))
+    assert cid(1) in docker["rm"]
+    assert dep_a._future is None and dep_b._future is None
+
+
+def test_reap_retry(monkeypatch):
+    """A failed late reap returns the id to the ledger for future sweeps."""
+    fast_rm(monkeypatch)
+    dep = make_plain()
+    dep._abandoned = True
+
+    def fake_run(args, **kwargs):
+        if args[1] == "run":
+            Path(args[args.index("--cidfile") + 1]).write_text(f"{cid(9)}\n")
+            return completed(0, stdout=f"{cid(9)}\n")
+        return completed(1, stderr="daemon busy")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    dep._run_container(["docker", "run", "-d", "img", "-lc", "cmd"], "n-x")
+    assert any("stays owned and may leak" in m for m in dep.logger.messages("error"))
+    assert dep._owned == (cid(9), "n-x")
+    dep._owned = None
+    dep._container_id = None
+
+
+def test_cid_queued(monkeypatch):
+    """A queued call the pool never dispatches must allocate nothing: no one is left to free it."""
+    reset_limiter(monkeypatch)
+    made = []
+    real_mkdtemp = mod.tempfile.mkdtemp
+
+    def spy(**kwargs):
+        made.append(Path(real_mkdtemp(**kwargs)))
+        return str(made[-1])
+
+    class Stall:
+        def __init__(self):
+            self.n = 0
+
+        def submit(self, call, *args):
+            self.n += 1
+            fut = concurrent.futures.Future()
+            if self.n == 1:
+                fut.set_result(call(*args))
+            return fut
+
+    pool = Stall()
+    monkeypatch.setattr(mod.tempfile, "mkdtemp", spy)
+    monkeypatch.setattr(mod, "_clipool", lambda: pool)
+    dep = make_plain(image="img")
+
+    async def _go():
+        task = asyncio.create_task(dep._start_oci_container("tok", "n-x", 8123))
+        while pool.n < 2:
+            await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(asyncio.wait_for(_go(), timeout=5))
+    assert made == []
+
+
+def test_cid_unread(monkeypatch):
+    """An unreadable cidfile is surfaced and kept; the run's stdout still confirms the id."""
+    reset_limiter(monkeypatch)
+    kept = {}
+
+    def fake_run(args, **kw):
+        if args[1] == "run":
+            # A directory where the id should be: read_text raises an OSError that is not "absent".
+            kept["path"] = Path(args[args.index("--cidfile") + 1])
+            kept["path"].mkdir()
+            return completed(0, stdout=f"{cid(2)}\n")
+        return completed(0)
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    dep = make_plain(image="img")
+
+    try:
+        asyncio.run(dep._start_oci_container("tok", "n-x", 8123))
+        assert dep._owned == (cid(2), "n-x")  # stdout named it, so no barrier is needed
+        assert dep._orphan is None
+        assert kept["path"].exists()  # the file could not be removed either, and that is reported
+        assert any("failed to remove cidfile" in m for m in dep.logger.messages("warning"))
+    finally:
+        shutil.rmtree(kept["path"].parent, ignore_errors=True)
+    dep._owned = None
+    dep._container_id = None
+    dep._runtime = None
+
+
+def test_inspect_gap(monkeypatch):
+    """Cancellation during the inspect phase must not submit docker run."""
+    reset_limiter(monkeypatch)
+    started = threading.Event()
+    release = threading.Event()
+    calls = []
+
+    def fake_run(args, **kw):
+        calls.append(args[1])
+        if args[1] == "inspect":
+            started.set()
+            release.wait(timeout=10)
+            return completed(0, stdout="bridge\n")
+        return completed(0, stdout="cid\n")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(mod, "_is_running_in_container", lambda: True)
+    monkeypatch.setenv("HOSTNAME", "host0")
+    dep = make_plain(image="img")
+
+    async def _go():
+        task = asyncio.create_task(dep._start_oci_container("tok", "n-x", 8123))
+        while not started.is_set():
+            await asyncio.sleep(0.005)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        release.set()
+        await dep.stop()  # drains the build call the cancellation left in the slot
+
+    asyncio.run(asyncio.wait_for(_go(), timeout=10))
+    assert calls == ["inspect"]  # docker run was never submitted
+    assert dep._future is None
+    assert dep._owned is None
+
+
+def test_cid_timeout(monkeypatch):
+    """A CLI timeout after the daemon created the container must not orphan it."""
+    reset_limiter(monkeypatch)
+    seen = {}
+
+    def fake_run(args, **kw):
+        if args[1] == "run":
+            seen["cid"] = Path(args[args.index("--cidfile") + 1])
+            seen["cid"].write_text(f"{cid(1)}\n")
+            raise subprocess.TimeoutExpired(cmd=args, timeout=600)
+        return completed(0, stdout="")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    dep = make_plain(image="img")
+
+    with pytest.raises(mod.CliError, match="timed out"):
+        asyncio.run(dep._start_oci_container("tok", "n-x", 8123))
+    assert dep._owned == (cid(1), "n-x")  # recoverable: stop()/__del__ can still remove it
+    assert not seen["cid"].parent.exists()
+    dep._owned = None
+    dep._container_id = None
+
+
+def test_oci_inspect(monkeypatch):
+    """Both CLI phases of a real OCI start run on the tracked pool."""
+    reset_limiter(monkeypatch)
+    calls = []
+    seen = {}
+
+    def fake_run(args, **kw):
+        calls.append(args[1])
+        if args[1] == "run":
+            # Real docker confirms the id twice: in the cidfile and on stdout.
+            seen["cid"] = Path(args[args.index("--cidfile") + 1])
+            seen["cid"].write_text(f"{cid(3)}\n")
+            return completed(0, stdout=f"{cid(3)}\n")
+        return completed(0, stdout="172.17.0.2\n")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+    dep = make_plain(network="bridge", image="img")
+
+    asyncio.run(dep._start_oci_container("tok", "name-x", 8123))
+    assert calls == ["run", "inspect"]
+    assert dep._future is None  # every phase handed its result back
+    assert dep._container_id == cid(3)
+    assert dep._owned == (cid(3), "name-x")
+    assert not seen["cid"].parent.exists()
+    dep._owned = None
+    dep._container_id = None
+    dep._runtime = None
+
+
+def test_start_owner(monkeypatch):
+    reset_limiter(monkeypatch)
+    fast_backoff(monkeypatch)
+    docker = fake_docker(monkeypatch)
+    tries = {"n": 0}
+
+    async def fail_once(dep):
+        tries["n"] += 1
+        if tries["n"] == 1:
+            raise RuntimeError("docker run failed")
+
+    dep = make_oci(starter=fail_once)
+
+    asyncio.run(dep.start())
+    base = "uni-agent-test-run"
+    assert dep._starts == 2
+    assert docker["runs"] == 1
+    assert dep._owned == (cid(1), f"{base}-r1")
+    infos = dep.logger.messages("info")
+    assert any("local sandbox alive in" in m and "(attempt 2)" in m and f"id={cid(1)[:12]}" in m for m in infos)
+
+    asyncio.run(dep.stop())
+    assert docker["rm"] == [cid(1)]
+    assert dep._owned is None
+    assert dep._container_id is None
+
+
+def test_session_err(monkeypatch):
+    """The training path calls start() with no argument: every attempt's container is swept."""
+    reset_limiter(monkeypatch)
+    fast_backoff(monkeypatch)
+    docker = fake_docker(monkeypatch)
+    dep = make_oci(sessioner=fail_start)
+
+    with pytest.raises(RuntimeError, match=r"after 5 attempt"):
+        asyncio.run(dep.start())
+    assert any("bash session creation failed" in m for m in dep.logger.messages("error"))
+    assert docker["rm"] == [cid(i) for i in range(1, 6)]
+    assert dep._owned is None
+
+
+_TOKEN = "s3kr1t-auth-token-value"
+
+
+def _token_docker(mode, running, release):
+    """A daemon that hands the token back where no `--auth-token <value>` pattern would find it."""
+
+    def fake_run(args, **kwargs):
+        if args[1] == "run":
+            if mode == "timeout":
+                assert _TOKEN in " ".join(args)  # else this branch would pass on an empty input
+                Path(args[args.index("--cidfile") + 1]).write_text(f"{cid(1)}\n")
+                raise subprocess.TimeoutExpired(cmd=args, timeout=600)
+            if mode == "exit":
+                # The real path runs with check=False: a failing daemon returns non-zero and echoes
+                # back the command it could not run.
+                return completed(125, stderr=f"OCI runtime failed: TOKEN={_TOKEN} start.sh")
+            if mode == "cancel":
+                running.set()
+                release.wait(timeout=10)
+                return completed(125, stderr=f"daemon died: https://host/start?token={_TOKEN}")
+            Path(args[args.index("--cidfile") + 1]).write_text(f"{cid(1)}\n")
+            return completed(0, stdout=f"{cid(1)}\n")
+        if args[1] == "logs":
+            return completed(0, stdout=f"swerex.server booting, TOKEN={_TOKEN}")
+        return completed(0)
+
+    return fake_run
+
+
+def _token_dep(monkeypatch, mode, *, running, release):
+    """A real LocalDeployment -- no double may short-circuit the container-log path under test."""
+    reset_limiter(monkeypatch)
+    monkeypatch.setattr(mod.LocalDeployment, "_get_token", lambda self: _TOKEN)
+    monkeypatch.setattr(mod.subprocess, "run", _token_docker(mode, running, release))
+    monkeypatch.setattr(mod.LocalRuntime, "from_config", lambda cfg, run_id=None: FakeRuntime())
+    dep = make_plain(image="img")
+    dep.logger = mod.get_logger("deployment", f"token-{mode}")
+
+    async def unhealthy(timeout):
+        # A deep cause carries the token; the wrapper that reaches the retry loop does not.
+        try:
+            raise ConnectionError(f"connect failed: TOKEN={_TOKEN}")
+        except ConnectionError as exc:
+            raise TimeoutError(f"runtime not alive within {timeout:.0f}s") from exc
+
+    dep._wait_until_alive = unhealthy
+    return dep
+
+
+async def _drive(dep, mode, *, running, release):
+    task = asyncio.create_task(dep.start(max_retries=1))
+    if mode != "cancel":
+        with pytest.raises(Exception) as excinfo:
+            await task
+        return excinfo.value
+    while not running.is_set():  # the blocked docker run, not the build call before it
+        await asyncio.sleep(0.005)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    release.set()
+    await asyncio.wait_for(dep.stop(), timeout=10)
+    return None
+
+
+@pytest.mark.parametrize(
+    ("mode", "wanted"),
+    [
+        ("exit", "TOKEN=***"),
+        ("timeout", "timed out after"),
+        ("unhealthy", "TOKEN=***"),
+        ("cancel", "token=***"),
+    ],
+)
+def test_no_token(monkeypatch, mode, wanted):
+    """The token must not reach a record by any route: an exception's message, a deep cause in its
+    chain, the container's own output, or a CLI error whose argv the exception carried.
+
+    The sandbox command is a user template, so the token can sit anywhere in it -- these fakes put it
+    where no `--auth-token <value>` pattern would find it.
+    """
+    running, release = threading.Event(), threading.Event()
+    dep = _token_dep(monkeypatch, mode, running=running, release=release)
+
+    captured = []
+    sink = loguru_logger.add(captured.append, level="DEBUG")
+    try:
+        asyncio.run(asyncio.wait_for(_drive(dep, mode, running=running, release=release), timeout=20))
+    finally:
+        release.set()
+        loguru_logger.remove(sink)
+
+    text = "\n".join(str(m) for m in captured)
+    record = "failed after its attempt ended" if mode == "cancel" else "failed to start local sandbox"
+    assert record in text, f"the {mode} scenario never logged the record under test"
+    assert wanted in text, f"the {mode} scenario dropped the output instead of redacting it"
+    assert _TOKEN not in text
+    # Cleanup reclaimed everything, so the tokens went with it.
+    assert dep._orphan is None and dep._owned is None and dep._secrets == set()
+
+
+def test_app_token():
+    """The apptainer server's own argv holds the token, so any exception from it carries the command."""
+    dep = make_plain(container_runtime="apptainer")
+    dep.logger = mod.get_logger("deployment", "token-apptainer")
+    dep._secrets.add(_TOKEN)
+    argv = ["apptainer", "exec", "img", "sh", "-lc", f"server --auth-token {_TOKEN}"]
+
+    def _wait(timeout=None):
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=timeout)
+
+    dep._server_process = FakeProcess(wait=_wait)
+
+    captured = []
+    sink = loguru_logger.add(captured.append, level="DEBUG")
+    try:
+        dep._kill_server()
+    finally:
+        loguru_logger.remove(sink)
+
+    text = "\n".join(str(m) for m in captured)
+    assert "could not reap the apptainer server process" in text
+    assert "--auth-token ***" in text  # redacted, not dropped
+    assert _TOKEN not in text
+    assert dep._server_process is not None  # a survivor is kept for the next stop()
+
+
+def test_final_token(monkeypatch):
+    """The error raised to the caller is redacted while the token is alive -- cleanup drops it."""
+    dep = _token_dep(monkeypatch, "unhealthy", running=threading.Event(), release=threading.Event())
+
+    async def echoing(timeout):
+        raise RuntimeError(f"server echoed TOKEN={_TOKEN}")
+
+    dep._wait_until_alive = echoing
+
+    with pytest.raises(RuntimeError) as excinfo:
+        asyncio.run(dep.start(max_retries=1))
+
+    assert dep._secrets == set()  # cleanup dropped them before this message was ever read
+    assert "TOKEN=***" in str(excinfo.value)
+    assert _TOKEN not in str(excinfo.value)
+
+
+# How the run ended, what the tag query then said, and -- once the container is left unnamed -- what a
+# later query says when the runtime can finally answer. "post-create" is the case that drives all of
+# this: docker exits non-zero and deletes the cidfile when the *post-create* id write fails, so a
+# failure exit proves nothing.
+_CASES = {
+    "post-create": {"code": 125, "ps": "one", "end": "claimed"},
+    "name-clash": {"code": 125, "ps": "none", "end": "cleared"},
+    "partial-cid": {"code": None, "ps": "one", "cid": "partial", "end": "claimed"},
+    "failed-multi": {"code": 125, "ps": "two", "end": "barrier", "recover": "one"},
+    "failed-junk": {"code": 125, "ps": "junk", "end": "barrier", "recover": "none"},
+    "killed-empty": {"code": None, "ps": "none", "end": "barrier", "recover": "one"},
+    "unknown-empty": {"code": "raise", "ps": "none", "end": "barrier", "recover": "one"},
+    "query-error": {"code": None, "ps": "error", "end": "barrier", "recover": "one"},
+}
+
+
+def _fake_cli(spec, calls):
+    """A container runtime that behaves as `spec` says, and holds the causality the recovery rests on:
+    a tag query must ask for the owner of the run it follows, or its answer is about someone else."""
+
+    def fake_run(args, **kwargs):
+        if args[1] == "run":
+            calls["run"] += 1
+            calls["owners"].append(next(a for a in args if a.startswith(f"{mod._OWNERTAG}=")).split("=", 1)[1])
+            if spec.get("cid") == "partial":
+                Path(args[args.index("--cidfile") + 1]).write_text(cid(1)[:20])
+            if spec["code"] == "raise":
+                raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")  # post-spawn decode
+            if spec["code"] is None:
+                raise subprocess.TimeoutExpired(cmd=args, timeout=600)
+            return completed(spec["code"], stderr="post-create failure" if spec["code"] else "")
+        if args[1] == "ps":
+            assert args[-1] == f"label={mod._OWNERTAG}={calls['owners'][-1]}"
+            calls["asked"] += 1
+            if spec["ps"] == "error":
+                raise subprocess.TimeoutExpired(cmd=args, timeout=60)
+            listing = {
+                "one": f"{cid(calls['run'])}\n",
+                "two": f"{cid(1)}\n{cid(2)}\n",
+                "junk": "deadbeef\n",
+                "none": "",
+            }[spec["ps"]]
+            return completed(0, stdout=listing)
+        if args[1] == "rm":
+            calls["rm"].append(args[3])
+        return completed(0)
+
+    return fake_run
+
+
+def _tagged_dep(monkeypatch):
+    """A real deployment whose start always fails after the run, so only the claim path is under test."""
+    reset_limiter(monkeypatch)
+    fast_backoff(monkeypatch)
+    monkeypatch.setattr(mod.LocalRuntime, "from_config", lambda cfg, run_id=None: FakeRuntime())
+    dep = make_plain(image="img")
+
+    async def never_alive(timeout):
+        raise TimeoutError("runtime not alive")
+
+    dep._wait_until_alive = never_alive
+    return dep
+
+
+@pytest.mark.parametrize("case", sorted(_CASES))
+def test_cid_owner(monkeypatch, case):
+    """No exit code proves a container was not created. With no full id, the owner tag decides -- but
+    only a runtime that ran, returned and reported failure makes an empty answer authoritative."""
+    spec = dict(_CASES[case])
+    calls = {"run": 0, "asked": 0, "rm": [], "owners": []}
+    monkeypatch.setattr(mod.subprocess, "run", _fake_cli(spec, calls))
+    dep = _tagged_dep(monkeypatch)
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(dep.start(max_retries=2))
+
+    if spec["end"] == "claimed":  # the tag found what no id could name: reclaimed by id, then retried
+        assert calls["run"] == 2 and calls["asked"] == 2 and calls["rm"] == [cid(1), cid(2)]
+    elif spec["end"] == "cleared":  # nothing of ours exists, so there is nothing to reclaim
+        assert calls["run"] == 2 and calls["asked"] == 2 and calls["rm"] == []
+    else:
+        _barrier(dep, spec, calls)
+    # A retry that reused the owner could be handed the container the attempt before it left behind.
+    assert len(set(calls["owners"])) == calls["run"]
+    assert dep._orphan is None and dep._owned is None
+    assert not dep._has_cleanup() and dep._secrets == set()
+
+
+def _barrier(dep, spec, calls):
+    """No answer, so we know nothing: nothing may start over it, and the token lives until it lifts."""
+    assert calls["run"] == 1 and calls["rm"] == []  # no second container over the one that may exist
+    assert calls["asked"] == 2  # the claim asked, and so did the cleanup that could not lift it
+    assert dep._orphan is not None and dep._has_cleanup()
+    assert dep._secrets, "the sandbox may exist and may still be logged about; its token must live"
+    with pytest.raises(RuntimeError, match="stop\\(\\) must reclaim them first"):
+        asyncio.run(dep.start())
+
+    spec["ps"] = spec["recover"]  # the runtime can answer now
+    asyncio.run(dep.stop())
+    assert calls["rm"] == ([cid(1)] if spec["recover"] == "one" else [])
+
+
+def test_info_token(monkeypatch):
+    """A start whose per-attempt announce raises before registration strands no token."""
+    reset_limiter(monkeypatch)
+    dep = make_plain(image="img")
+    dep.logger.info = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("the sink is gone"))
+
+    with pytest.raises(RuntimeError, match="the sink is gone"):
+        asyncio.run(dep.start(max_retries=1))
+    assert dep._secrets == set()
+    assert not dep._has_cleanup()
+
+
+def test_queue_token(monkeypatch):
+    """A start cancelled while it queues for a permit made nothing at all, so the token it registered
+    dies with it: no resource is left that a later stop() could log an exception carrying."""
+    monkeypatch.setattr(mod, "_get_limiter", lambda: sem)
+    sem = asyncio.Semaphore(1)
+    dep = make_plain(image="img")
+
+    async def _go():
+        await sem.acquire()  # the only permit is taken, so the attempt never gets past the queue
+        task = asyncio.create_task(dep.start(max_retries=1))
+        while not dep._secrets:
+            await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(asyncio.wait_for(_go(), timeout=5))
+    assert dep._secrets == set()
+    assert not dep._has_cleanup()
+
+
+def test_clean_token(monkeypatch):
+    """A cancel landing on the last await of the attempt's own cleanup: what it made is reclaimed, so
+    the cleanup's own release never runs -- and the token would outlive every resource it authorised."""
+    reset_limiter(monkeypatch)
+    reached = asyncio.Event()
+
+    async def hang_cleanup(dep):
+        reached.set()
+        await asyncio.sleep(3600)
+
+    dep = make_loop(starter=fail_start, stopper=hang_cleanup)
+
+    async def _go():
+        task = asyncio.create_task(dep.start(max_retries=2))
+        await asyncio.wait_for(reached.wait(), timeout=5)
+        assert dep._secrets  # the attempt registered one
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(asyncio.wait_for(_go(), timeout=10))
+    assert not dep._has_cleanup()
+    assert dep._secrets == set()
+
+
+def test_cid_handles():
+    """A --cidfile or same-name label in extra_run_args cannot override ours; ours go last and win."""
+    extra = ["--cidfile", "/tmp/evil", "--label", f"{mod._OWNERTAG}=evil"]
+    dep = make_plain(image="img", extra_run_args=extra)
+    dep._get_current_container_network = lambda: None
+
+    args = dep._with_cid(dep._build_run_command("n-x", 8000, "cmd"), Path("/tmp/ours"), "ours")
+
+    last_cid = len(args) - 1 - args[::-1].index("--cidfile")
+    assert args[last_cid + 1] == "/tmp/ours"
+    labels = [args[i + 1] for i, arg in enumerate(args) if arg == "--label"]
+    assert labels[-1] == f"{mod._OWNERTAG}=ours"
+    assert args[-3:] == ["img", "-lc", "cmd"]
+
+
+def test_dashdash():
+    """Reject an ambiguous bare --."""
+    dep = make_plain(image="img", extra_run_args=["--"])
+    dep._get_current_container_network = lambda: None
+
+    with pytest.raises(RuntimeError, match="bare '--'"):
+        dep._with_cid(dep._build_run_command("n-x", 8000, "cmd"), Path("/tmp/ours"), "ours")
+
+
+def test_log_token(monkeypatch, tmp_path):
+    """A caller logging the error this class raises must print neither the token nor a raw cause."""
+    running, release = threading.Event(), threading.Event()
+    dep = _token_dep(monkeypatch, "unhealthy", running=running, release=release)
+
+    log_file = tmp_path / "run.log"
+    add_file_handler(log_file, "token-unhealthy")
+    try:
+        escaped = asyncio.run(asyncio.wait_for(_drive(dep, "unhealthy", running=running, release=release), timeout=20))
+        assert escaped.__cause__ is None and escaped.__context__ is None
+        mod.get_logger("deployment", "token-unhealthy").opt(
+            exception=(type(escaped), escaped, escaped.__traceback__)
+        ).error("caller sees: {}", escaped)
+        loguru_logger.complete()  # the dispatch sink enqueues; wait for its writer thread
+    finally:
+        cleanup_handlers("token-unhealthy")
+
+    written = log_file.read_text()
+    assert "caller sees:" in written
+    assert "Traceback" in written  # the sink really rendered it -- just without the frame locals
+    assert "TOKEN=***" in written  # the deep cause reached the internal record, redacted
+    assert _TOKEN not in written

--- a/tests/deployment/test_local_starting_limiter.py
+++ b/tests/deployment/test_local_starting_limiter.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import asyncio
+import gc
+
+import pytest
+
+from tests.deployment.support import fail_start, fast_backoff, hang_start, make_loop, reset_limiter
+from uni_agent.deployment.local import deployment as mod
+from uni_agent.deployment.local.deployment import LocalDeployment
+
+
+def test_cache_free(monkeypatch):
+    """A limiter cache entry must not outlive its event loop."""
+    reset_limiter(monkeypatch, per_worker=1)
+
+    async def _use():
+        mod._get_limiter()
+
+    for _ in range(3):
+        asyncio.run(_use())
+    gc.collect()
+    assert not mod._LIMITERS
+
+
+@pytest.mark.parametrize(
+    ("var", "raw"),
+    [
+        ("LOCAL_MAX_STARTING_PER_WORKER", "0"),
+        ("LOCAL_MAX_STARTING_PER_WORKER", "junk"),
+        ("LOCAL_INIT_WALL_BUDGET", "nan"),
+        ("LOCAL_INIT_WALL_BUDGET", "0"),
+        ("LOCAL_INIT_WALL_BUDGET", "junk"),
+    ],
+)
+def test_env_reject(monkeypatch, var, raw):
+    """Invalid limits fail fast before any attempt starts."""
+    reset_limiter(monkeypatch)
+    monkeypatch.setenv(var, raw)
+    dep = make_loop()
+
+    with pytest.raises(ValueError, match="invalid"):
+        asyncio.run(dep.start())
+    assert dep._starts == 0
+
+
+def test_nap_clamp(monkeypatch):
+    """Retry backoff never sleeps past the wall deadline."""
+    reset_limiter(monkeypatch, wall_budget=0.5)
+    naps = []
+
+    async def spy(seconds):
+        naps.append(seconds)
+
+    monkeypatch.setattr(mod, "_retrydelay", spy)
+    dep = make_loop(starter=fail_start)
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(dep.start())
+    assert naps
+    assert all(n <= 0.5 for n in naps)
+
+
+def test_no_reentry(monkeypatch):
+    """A deployment's lifecycle is serial: neither an overlapping start nor one over a live sandbox."""
+    reset_limiter(monkeypatch)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def hang(dep):
+        started.set()
+        await release.wait()
+
+    dep = make_loop(starter=hang, stopper=LocalDeployment._cleanup)
+
+    async def _go():
+        first = asyncio.create_task(dep.start())
+        await started.wait()
+        with pytest.raises(RuntimeError, match="lifecycle is serial"):
+            await dep.start()
+        release.set()
+        await first
+        # The first start left a runtime behind, so a second one must go through stop() first.
+        with pytest.raises(RuntimeError, match="stop\\(\\) must reclaim them first"):
+            await dep.start()
+        assert dep._busy is None
+        await dep.stop()
+        await dep.start()
+
+    asyncio.run(asyncio.wait_for(_go(), timeout=5))
+    assert dep._starts == 2
+
+
+def test_hung_cancel(monkeypatch):
+    """A hung attempt is cancelled in bounded time and frees its permit."""
+    reset_limiter(monkeypatch, per_worker=1, wall_budget=0.5)
+    dep_a = make_loop(starter=hang_start)
+    dep_b = make_loop()
+
+    async def _go():
+        with pytest.raises(RuntimeError):
+            await asyncio.wait_for(dep_a.start(), timeout=10.0)
+        # The single permit is free again, so a second deployment can take it.
+        await asyncio.wait_for(dep_b.start(), timeout=2.0)
+
+    asyncio.run(_go())
+    assert dep_a._starts == 1
+    assert dep_a._abandoned is True
+    assert dep_b._starts == 1
+
+
+@pytest.mark.parametrize("pinned", [False, True])
+def test_repick(monkeypatch, pinned):
+    """Refresh unpinned names and ports between retries; keep pinned ones."""
+    reset_limiter(monkeypatch)
+    fast_backoff(monkeypatch)
+    picks = {"n": 0}
+
+    def next_port():
+        picks["n"] += 1
+        return 10000 + picks["n"]
+
+    monkeypatch.setattr(mod, "_pick_free_port", next_port)
+    config = {"published_port": 4567, "container_name": "pinned"} if pinned else {}
+    dep = make_loop(starter=fail_start, **config)
+
+    with pytest.raises(RuntimeError, match=r"after 2 attempt"):
+        asyncio.run(dep.start(max_retries=2))
+    if pinned:
+        assert picks["n"] == 0
+        assert dep._ports == [4567, 4567]
+        assert dep._names == ["pinned", "pinned"]
+    else:
+        base = "uni-agent-test-run"
+        assert dep._ports == [10001, 10002]
+        assert dep._names == [base, f"{base}-r1"]

--- a/tests/deployment/test_local_teardown.py
+++ b/tests/deployment/test_local_teardown.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import threading
+import time
+
+import pytest
+
+from tests.deployment.support import (
+    FakeHandle,
+    FakeProcess,
+    cid,
+    completed,
+    fail_start,
+    fast_backoff,
+    fast_rm,
+    hang_start,
+    make_loop,
+    make_plain,
+    reset_limiter,
+)
+from uni_agent.deployment.local import deployment as mod
+
+
+@pytest.mark.parametrize(("call", "bound"), [("exec", "_CLIWAIT"), ("logs", "_LOGWAIT"), ("rm", "_RMWAIT")])
+def test_cli_bounds(monkeypatch, call, bound):
+    dep = make_plain()
+    seen = []
+    monkeypatch.setattr(
+        mod.subprocess, "run", lambda args, **kw: seen.append(kw.get("timeout")) or completed(0, stdout="ok")
+    )
+    if call == "exec":
+        dep._runtime_exec(["docker", "inspect", cid(1)])
+    elif call == "logs":
+        dep._get_container_logs(cid(1))
+    else:
+        dep._force_remove(cid(1))
+    assert seen == [getattr(mod, bound)]
+
+
+def test_log_bound(monkeypatch):
+    """A log fetch that outlives its bound keeps the slot, so stop() waits for it before any rm."""
+    monkeypatch.setattr(mod, "_LOGWAIT", 0.1)
+    dep = make_plain()
+    dep._container_id = cid(1)
+    dep._owned = (cid(1), "n-x")
+    release = threading.Event()
+    order = []
+
+    def _exec(args, check=True, timeout=None):
+        order.append(args[1])
+        if args[1] == "logs":
+            release.wait(30)
+        return completed(0)
+
+    dep._runtime_exec = _exec
+
+    async def _go():
+        assert await dep._collect_logs("x") == "<log collection failed or timed out>"
+        assert dep._has_cli()  # the fetch runs on; the slot is still taken
+
+        stopping = asyncio.create_task(dep.stop())
+        await asyncio.sleep(0.05)
+        assert order == ["logs"]  # no rm has overtaken the log fetch
+        assert not stopping.done()
+        release.set()
+        await asyncio.wait_for(stopping, timeout=5)
+
+    asyncio.run(asyncio.wait_for(_go(), timeout=10))
+    assert order == ["logs", "rm"]
+    assert dep._future is None
+    assert dep._owned is None
+
+
+def test_close_bound(monkeypatch):
+    """Bound a hung runtime.close() so container teardown can continue."""
+    monkeypatch.setattr(mod, "_CLOSEWAIT", 0.1)
+    dep = make_plain()
+    dep._runtime = type("R", (), {"close": staticmethod(lambda: asyncio.sleep(3600))})()
+    dep._owned = (cid(1), "a")
+    dep._container_id = cid(1)
+    dep._secrets = {"tok"}
+    dep._runtime_exec = lambda args, check=True, timeout=None: completed(0)
+
+    asyncio.run(asyncio.wait_for(dep.stop(), timeout=5))
+    assert dep._runtime is None
+    assert dep._owned is None
+    assert not dep._has_cleanup()
+    assert dep._secrets == set()  # nothing is left that could still log it
+    assert any("runtime.close() failed" in m for m in dep.logger.messages("warning"))
+
+
+def test_clean_wait(monkeypatch):
+    """A hung teardown between retries is bounded by _CLEANWAIT and reported as a possible leak."""
+    reset_limiter(monkeypatch)
+    fast_backoff(monkeypatch)
+    monkeypatch.setattr(mod, "_CLEANWAIT", 0.2)
+    dep = make_loop(starter=fail_start, stopper=hang_start)
+
+    t0 = time.monotonic()
+    with pytest.raises(RuntimeError, match=r"after 2 attempt"):
+        asyncio.run(asyncio.wait_for(dep.start(max_retries=2), timeout=10))
+    assert time.monotonic() - t0 < 5.0
+    assert any("may leak" in m for m in dep.logger.messages("warning"))
+
+
+# A removal that the runtime confirms -- it went, or it was never there -- is not retried; one it
+# could not confirm is, exactly once.
+_RM_CASES = {
+    "ok": {"gone": True, "calls": 1},
+    "no-such-container": {"gone": True, "calls": 1},
+    "daemon-busy": {"gone": False, "calls": 2},
+    "timeout": {"gone": False, "calls": 2},
+}
+
+
+@pytest.mark.parametrize("case", sorted(_RM_CASES))
+def test_remove(monkeypatch, case):
+    fast_rm(monkeypatch)
+    dep = make_plain()
+    calls = []
+
+    def _exec(args, check=True, timeout=None):
+        calls.append(args)
+        if case == "timeout":
+            raise mod.CliTimeout(f"rm: timed out after {timeout:.0f}s")
+        if case == "no-such-container":
+            return completed(1, stderr=f"Error: No such container: {cid(1)}")
+        return completed(1, stderr="daemon busy") if case == "daemon-busy" else completed(0)
+
+    dep._runtime_exec = _exec
+    gone = _RM_CASES[case]["gone"]
+    assert dep._force_remove(cid(1)) is gone
+    assert len(calls) == _RM_CASES[case]["calls"]
+    if not gone:
+        assert any("retrying once" in m for m in dep.logger.messages("warning"))
+    else:
+        assert dep.logger.messages("warning") == []
+
+
+def test_sweep_again(monkeypatch):
+    fast_rm(monkeypatch)
+    dep = make_plain()
+    dep._owned = (cid(1), "a")
+    dep._container_id = cid(1)
+    state = {"fail": True}
+    dep._runtime_exec = lambda args, check=True, timeout=None: completed(
+        1 if state["fail"] else 0, stderr="daemon busy" if state["fail"] else ""
+    )
+
+    asyncio.run(dep.stop())
+    assert dep._owned == (cid(1), "a")
+    assert any("may leak" in m for m in dep.logger.messages("error"))
+
+    state["fail"] = False
+    asyncio.run(dep.stop())
+    assert dep._owned is None
+
+
+def test_stop_fails():
+    """A process that survives SIGKILL is retained, and cleanup still finishes."""
+    dep = make_plain(container_runtime="apptainer")
+    state = {"kills": 0}
+
+    def _kill():
+        state["kills"] += 1
+
+    def _wait(timeout=None):
+        raise subprocess.TimeoutExpired(cmd="server", timeout=timeout)
+
+    proc = FakeProcess(kill=_kill, wait=_wait)
+    proc.terminate = lambda: None
+    dep._server_process = proc
+    handle = FakeHandle()
+    dep._server_log_handle = handle
+
+    asyncio.run(dep.stop())
+    assert dep._server_process is proc
+    assert handle.closed and dep._server_log_handle is None
+    assert state["kills"] == 1
+    assert any("did not exit after SIGKILL" in m for m in dep.logger.messages("error"))
+
+
+@pytest.mark.parametrize("resource", ["handle", "path"])
+def test_log_cleanup(resource):
+    """Retain failed log cleanup so a later stop() can retry."""
+    dep = make_plain(container_runtime="apptainer")
+    state = {"n": 0}
+
+    def _fail_once():
+        state["n"] += 1
+        if state["n"] == 1:
+            raise OSError("busy")
+
+    if resource == "handle":
+        target = FakeHandle(close=_fail_once)
+        dep._server_log_handle = target
+        attr = "_server_log_handle"
+    else:
+        target = type("P", (), {"unlink": staticmethod(lambda missing_ok=False: _fail_once())})()
+        dep._server_log_path = target
+        attr = "_server_log_path"
+
+    asyncio.run(dep.stop())
+    assert getattr(dep, attr) is target
+    assert dep._has_cleanup()
+
+    asyncio.run(dep.stop())
+    assert getattr(dep, attr) is None
+    assert state["n"] == 2

--- a/uni_agent/async_logging.py
+++ b/uni_agent/async_logging.py
@@ -28,6 +28,7 @@ if _debug_enabled():
         level="INFO",
         format=_LOG_FORMAT,
         filter=lambda record: "name" in record["extra"],
+        diagnose=False,
     )
 
 
@@ -58,8 +59,9 @@ def _dispatch(message) -> None:
         pass
 
 
-# One global sink: O(1) dispatch by run_id, a single background writer thread.
-logger.add(_dispatch, level="DEBUG", format=_LOG_FORMAT, enqueue=True)
+# One global sink: O(1) dispatch by run_id, a single background writer thread. diagnose=False on
+# both sinks: a rendered traceback would otherwise carry every frame's locals, secrets included.
+logger.add(_dispatch, level="DEBUG", format=_LOG_FORMAT, enqueue=True, diagnose=False)
 
 
 def add_file_handler(file_path: Path, run_id: str, level: str = "info") -> str:

--- a/uni_agent/deployment/local/deployment.py
+++ b/uni_agent/deployment/local/deployment.py
@@ -1,12 +1,18 @@
 import asyncio
+import concurrent.futures
+import math
 import os
 import re
-import shlex
 import shutil
 import socket
 import subprocess
 import tempfile
+import threading
+import time
+import traceback
 import uuid
+import weakref
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Self
 
@@ -35,9 +41,109 @@ _IMAGE_URI_PREFIXES = (
     "file://",
 )
 
+_STARTCAP = 16
+_BUDGET = 600.0
+_LOGWAIT = 30.0
+_CLEANWAIT = 60.0
+_CLOSEWAIT = 10.0
+_RMWAIT = 60.0
+# A cancelled coroutine cannot stop a running subprocess.run, so this timeout is its only deadline.
+_CLIWAIT = 600.0
+_PROCWAIT = 10.0
+_REAPWAIT = 2.0
+_DELWAIT = 10.0
+_STARTPAD = 120.0
+_RETRYCAP = 10
+_BACKBASE = 2
+_RMTRIES = 2
+_SLOWQUEUE = 1.0
+_RMPAUSE = 1.0
+_LOGTAIL = 4000
+_IDLEN = 12
+# The runtime prints a container's id in full, so anything shorter is a partial write, not an id --
+# claiming one would be a guess.
+_IDRE = re.compile(r"^[0-9a-f]{64}$")
+# A random, non-sensitive tag on every container we launch, so one whose id we never learned can still
+# be found. Never the auth token, which must not reach a `docker inspect` away from us.
+_OWNERTAG = "uni-agent.owner"
+# Keyed on the loop itself, so an entry dies with it; the value is weak so an idle semaphore can go.
+_LIMITERS: weakref.WeakKeyDictionary = weakref.WeakKeyDictionary()
+# Dedicated CLI pool: stranded container runs must not exhaust asyncio's default executor.
+_CLIPOOL: concurrent.futures.ThreadPoolExecutor | None = None
+_POOLLOCK = threading.Lock()
 
-def _shell_join(parts: list[str]) -> str:
-    return " ".join(shlex.quote(part) for part in parts)
+
+def _env_cap() -> int:
+    raw = os.getenv("LOCAL_MAX_STARTING_PER_WORKER", "")
+    if not raw:
+        return _STARTCAP
+    try:
+        value = int(raw)
+    except ValueError:
+        value = 0
+    if value < 1:
+        raise ValueError(f"invalid LOCAL_MAX_STARTING_PER_WORKER={raw!r}; expected a positive integer")
+    return value
+
+
+def _clipool() -> concurrent.futures.ThreadPoolExecutor:
+    global _CLIPOOL
+    with _POOLLOCK:
+        if _CLIPOOL is None:
+            _CLIPOOL = concurrent.futures.ThreadPoolExecutor(max_workers=_env_cap(), thread_name_prefix="local-cli")
+        return _CLIPOOL
+
+
+def _get_limiter() -> asyncio.Semaphore:
+    """Per-event-loop STARTING semaphore, lazy so the env var is read at first use."""
+    loop = asyncio.get_running_loop()
+    ref = _LIMITERS.get(loop)
+    sem = ref() if ref is not None else None
+    if sem is None:
+        sem = asyncio.Semaphore(_env_cap())
+        _LIMITERS[loop] = weakref.ref(sem)
+    return sem
+
+
+def _get_budget() -> float:
+    raw = os.getenv("LOCAL_INIT_WALL_BUDGET", "")
+    if not raw:
+        return _BUDGET
+    try:
+        value = float(raw)
+    except ValueError:
+        value = 0.0
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError(f"invalid LOCAL_INIT_WALL_BUDGET={raw!r}; expected a finite positive number")
+    return value
+
+
+# Retry-delay seam so tests can skip real backoff without patching asyncio.
+_retrydelay = asyncio.sleep
+
+
+# Redact live auth tokens by value before logging or raising CLI errors.
+class CliError(RuntimeError):
+    """A container CLI failure that never carries the command it ran."""
+
+
+class CliTimeout(CliError):
+    """The CLI was killed before it returned. It may have created a container first."""
+
+
+class CliNoRun(CliError):
+    """The runtime binary is not there, so nothing ran and nothing was created."""
+
+
+def _confirmed_gone(result: subprocess.CompletedProcess[str]) -> bool:
+    stderr = (result.stderr or "").lower()
+    return result.returncode == 0 or "no such container" in stderr or "no container with" in stderr
+
+
+def _valid_id(text: str) -> str:
+    """The text if it is a full runtime container id, else "" -- a partial write is not an id."""
+    candidate = text.strip()
+    return candidate if _IDRE.match(candidate) else ""
 
 
 def _sanitize_name(value: str) -> str:
@@ -85,6 +191,12 @@ def _normalize_apptainer_image(image: str) -> str:
 
 
 class LocalDeployment(AbstractDeployment):
+    """A local container sandbox. Concurrency is across deployments (the STARTING limiter caps it);
+    one deployment's lifecycle is serial, so overlapping start/stop calls -- or a start over
+    resources no stop reclaimed -- raise. An uncancellable container CLI call holds a single slot
+    until someone takes its result back: nothing may start, retry or submit over it, and stop()
+    drains it first."""
+
     def __init__(self, run_id: str, **kwargs: Any):
         self.run_id = run_id
         config_kwargs = dict(kwargs)
@@ -94,12 +206,22 @@ class LocalDeployment(AbstractDeployment):
         self._runtime: LocalRuntime | None = None
         self.logger = get_logger("deployment", run_id)
         self._hooks = CombinedDeploymentHook()
-        self._container_name: str | None = None
         self._container_id: str | None = None
+        self._secrets: set[str] = set()  # live auth tokens
+        # (cidfile, owner, settled) of a run that may have created a container but named no id.
+        # Nothing may start over it. `settled` says the runtime ran, returned and reported failure --
+        # only then does "no container carries this owner" mean it, rather than "not yet".
+        self._orphan: tuple[Path, str, bool] | None = None
+        # The one container this deployment owns, as (id, name); the state machine allows no more.
+        self._owned: tuple[str, str] | None = None
+        # A late container result self-reaps after its attempt is abandoned.
+        self._abandoned = False
+        self._lock = threading.Lock()
+        self._busy: str | None = None
         self._server_process: subprocess.Popen[str] | None = None
+        self._future: concurrent.futures.Future | None = None
         self._server_log_path: Path | None = None
         self._server_log_handle: Any | None = None
-        self._stopped = False
 
     def add_hook(self, hook: DeploymentHook):
         self._hooks.add_hook(hook)
@@ -121,20 +243,225 @@ class LocalDeployment(AbstractDeployment):
     async def _wait_until_alive(self, timeout: float) -> IsAliveResponse:
         try:
             return await _wait_until_alive(self.is_alive, timeout=timeout, function_timeout=0.5)
-        except TimeoutError as e:
-            self.logger.error("Local runtime did not start within timeout.")
-            await self.stop()
-            raise e
+        except TimeoutError as exc:
+            # start() owns diagnostics and failure logging.
+            raise TimeoutError(f"runtime not alive within {timeout:.0f}s") from exc
 
     def _get_token(self) -> str:
         return str(uuid.uuid4())
 
-    def _runtime_exec(self, args: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
-        self.logger.debug(f"Running container runtime command: {_shell_join(args)}")
+    def _redact(self, text: str) -> str:
+        with self._lock:
+            secrets = tuple(self._secrets)
+        for secret in secrets:
+            text = text.replace(secret, "***")
+        return text
+
+    def _why(self, exc: BaseException) -> str:
+        """Render an exception into a redacted summary for a record. See the note above CliError."""
+        return self._redact(f"{type(exc).__name__}: {exc}")
+
+    def _runtime_exec(
+        self, args: list[str], check: bool = True, timeout: float | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        action = f"{_runtime_basename(args[0])} {args[1]}"
+        target = args[args.index("--name") + 1] if "--name" in args else ""
+        self._say("debug", f"container runtime call: {action} {target}".rstrip())
+        if timeout is None:
+            timeout = _CLIWAIT
         try:
-            return subprocess.run(args, check=check, text=True, capture_output=True)
-        except FileNotFoundError as exc:
-            raise RuntimeError(f"Container runtime {self._config.container_runtime!r} was not found in PATH") from exc
+            result = subprocess.run(args, check=False, text=True, capture_output=True, timeout=timeout)
+        except FileNotFoundError:
+            failure: Exception = CliNoRun(f"container runtime {self._config.container_runtime!r} not found in PATH")
+        except subprocess.TimeoutExpired:
+            failure = CliTimeout(f"{action}: timed out after {timeout:.0f}s")
+        else:
+            if check and result.returncode != 0:
+                detail = (
+                    self._redact(result.stderr or "")
+                    or self._redact(result.stdout or "")
+                    or f"exit code {result.returncode}"
+                ).strip()
+                raise CliError(f"{action}: {detail}")
+            return result
+        # Raised out here, never inside the except: `raise ... from None` only hides the original,
+        # which stays on __context__ with the whole argv -- and the auth token -- in .cmd.
+        raise failure
+
+    def _own_reap(self, container_id: str, name: str) -> None:
+        """Own a confirmed id, or try to reap it if abandoned (a failed reap re-owns it for the sweep)."""
+        with self._lock:
+            reap = self._abandoned
+            if not reap:
+                self._owned = (container_id, name)
+                self._container_id = container_id  # so diagnostics can fetch its logs
+        if reap:
+            self._reap_late(container_id, name)
+
+    def _read_cid(self, cidfile: Path) -> str:
+        """The id in the cidfile, or "" -- unreadable, empty and absent are one answer here.
+
+        None of them proves that no container exists: the daemon creates it before the CLI writes the
+        file. Only the caller knows whether the call could have created one, so it does the judging
+        and the logging; this only reports what is on disk.
+        """
+        try:
+            return cidfile.read_text(encoding="utf-8").strip()
+        except OSError:
+            return ""
+
+    def _drop_cid(self, cidfile: Path) -> None:
+        try:
+            cidfile.unlink(missing_ok=True)
+            cidfile.parent.rmdir()
+        except FileNotFoundError:
+            pass  # already gone: the finalizer drops the file of an orphan it still keeps the barrier for
+        except OSError as exc:
+            self._say("warning", "failed to remove cidfile {}: {}", cidfile, self._why(exc))
+
+    def _claim_cid(self, cidfile: Path, name: str, fallback: str, *, owner: str, outcome: str) -> None:
+        """Commit the id, or fall back to the owner tag, or raise the barrier. No exit code proves a
+        container was not created; an empty tag query is proof only for outcome=="failed" (the runtime
+        ran, returned, reported failure) -- every other outcome leaves the question open."""
+        container_id = _valid_id(self._read_cid(cidfile)) or _valid_id(fallback)
+        if container_id:
+            self._own_reap(container_id, name)
+            self._orphan = None
+            self._drop_cid(cidfile)
+            return
+        if outcome == "never-ran":
+            self._drop_cid(cidfile)  # the runtime binary is not there, so nothing ran
+            return
+        settled = outcome == "failed"
+        found = self._find_owned(owner, _RMWAIT)
+        if found is not None and len(found) == 1:
+            self._own_reap(found[0], name)
+            self._orphan = None
+            self._drop_cid(cidfile)
+            return
+        if found == [] and settled:
+            # It ran, it failed, and it carries nothing of ours: a name clash, a missing image.
+            self._drop_cid(cidfile)
+            return
+        self._orphan = (cidfile, owner, settled)
+        self.logger.error(
+            "the container runtime named no container (outcome={}); one may exist tagged {}={}, and "
+            "only that tag or {} can still find it, so nothing may start over it",
+            outcome,
+            _OWNERTAG,
+            owner,
+            cidfile,
+        )
+
+    def _run_container(self, args: list[str], name: str) -> subprocess.CompletedProcess[str]:
+        # The CLI thread owns the cidfile end to end: an undispatched run allocates nothing.
+        cidfile = Path(tempfile.mkdtemp(prefix="uni-agent-cid-")) / "cid"
+        owner = str(uuid.uuid4())
+        result: subprocess.CompletedProcess[str] | None = None
+        # Nothing has been handed to the runtime yet, so a failure here created nothing. The moment
+        # the command is built and about to be run, that stops being true: from then on the default
+        # is "unknown", because anything we did not foresee may land after the daemon created it.
+        outcome = "never-ran"
+        try:
+            tagged = self._with_cid(args, cidfile, owner)
+            outcome = "unknown"
+            result = self._runtime_exec(tagged)
+            outcome = "created"
+        except CliNoRun:
+            outcome = "never-ran"
+            raise
+        except CliTimeout:
+            outcome = "killed"  # it may already have created the container
+            raise
+        except CliError:
+            outcome = "failed"  # it ran and reported failure -- which still proves nothing on its own
+            raise
+        finally:
+            stdout_id = result.stdout.strip() if result is not None else ""
+            self._claim_cid(cidfile, name, stdout_id, owner=owner, outcome=outcome)
+        if self._orphan is not None:
+            # Nothing to inspect and nothing to connect to: we cannot name what we just made.
+            raise CliError("container runtime returned without a container id")
+        return result
+
+    def _kill_server(self) -> None:
+        """Clear the process reference only after confirmed exit; a survivor is kept for the next stop()."""
+        proc = self._server_process
+        if proc is None:
+            return
+        try:
+            if proc.poll() is None:
+                proc.kill()
+            proc.wait(timeout=_REAPWAIT)
+        except Exception as exc:
+            self._say(
+                "warning",
+                "could not reap the apptainer server process, keeping it for the next stop(): {}",
+                self._why(exc),
+            )
+            return
+        self._server_process = None
+
+    def _has_cli(self) -> bool:
+        """A CLI call nobody has taken the result back from -- running, or done but unconsumed."""
+        return getattr(self, "_future", None) is not None
+
+    def _probe_orphan(self, timeout: float) -> None:
+        """Re-probe for the unnamed container (cidfile, then owner tag). Only an answer lifts the
+        barrier: an id to remove by, or an empty that is authoritative (settled)."""
+        if self._orphan is None:
+            return
+        cidfile, owner, settled = self._orphan
+        container_id = _valid_id(self._read_cid(cidfile))
+        found = [container_id] if container_id else self._find_owned(owner, timeout)
+        if found is None:
+            return  # _find_owned already recorded why it could not answer; the barrier stays
+        if len(found) > 1 or (found == [] and not settled):
+            self._say("warning", "owner {} still names no single container; keeping the barrier", owner)
+            return
+        if found:
+            with self._lock:
+                self._owned = (found[0], found[0][:_IDLEN])
+        else:
+            self._say("warning", "no container carries owner {}; releasing the barrier", owner)
+        self._orphan = None
+        self._drop_cid(cidfile)
+
+    def _residue(self) -> str:
+        """What an earlier attempt left behind. No container may be started over any of it: doing so
+        is how one failed cleanup turns into two live containers."""
+        if self._has_cli():
+            return "a container runtime call is still in flight"
+        if self._orphan is not None:
+            return f"a container may exist that no id names; only owner {self._orphan[1]} can find it"
+        with self._lock:
+            owned = self._owned
+        if owned is not None:
+            return f"a container is still owned: {owned[1]}"
+        if self._server_process is not None:
+            return "an apptainer server process was not reaped"
+        if self._server_log_handle is not None or self._server_log_path is not None:
+            return "apptainer log resources were not cleaned"
+        return ""
+
+    def _has_cleanup(self) -> bool:
+        return bool(
+            getattr(self, "_owned", None)
+            or getattr(self, "_orphan", None) is not None
+            or self._has_cli()
+            or getattr(self, "_server_process", None) is not None
+            or getattr(self, "_runtime", None) is not None
+            or getattr(self, "_server_log_handle", None) is not None
+            or getattr(self, "_server_log_path", None) is not None
+        )
+
+    def _reap_late(self, container_id: str, name: str) -> None:
+        cid = container_id[:_IDLEN]
+        self._say("warning", "container runtime call finished after its attempt was abandoned; removing id={}", cid)
+        if not self._force_remove(container_id):
+            # _force_remove reported why; keep the id so the next sweep tries again.
+            with self._lock:
+                self._owned = (container_id, name)
 
     def _get_current_container_network(self) -> str | None:
         if not _is_running_in_container():
@@ -154,10 +481,8 @@ class LocalDeployment(AbstractDeployment):
                     "{{range $name, $_ := .NetworkSettings.Networks}}{{println $name}}{{end}}",
                 ]
             )
-        except subprocess.CalledProcessError as exc:
-            self.logger.warning(
-                f"Failed to inspect current container network: {exc.stderr.strip() or exc.stdout.strip()}"
-            )
+        except CliError as exc:
+            self.logger.warning("Failed to inspect current container network: {}", self._why(exc))
             return None
 
         networks = [line.strip() for line in result.stdout.splitlines() if line.strip()]
@@ -176,8 +501,8 @@ class LocalDeployment(AbstractDeployment):
                     "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}",
                 ]
             )
-        except subprocess.CalledProcessError as exc:
-            self.logger.warning(f"Failed to inspect sandbox IP: {exc.stderr.strip() or exc.stdout.strip()}")
+        except CliError as exc:
+            self.logger.warning("Failed to inspect sandbox IP: {}", self._why(exc))
             return None
 
         ip_address = result.stdout.strip()
@@ -233,10 +558,12 @@ class LocalDeployment(AbstractDeployment):
             return self._get_apptainer_logs()
 
         try:
-            result = self._runtime_exec([self._config.container_runtime, "logs", container_name], check=False)
+            result = self._runtime_exec(
+                [self._config.container_runtime, "logs", container_name], check=False, timeout=_LOGWAIT
+            )
         except Exception as exc:
-            return f"<failed to fetch logs: {exc}>"
-        return (result.stdout or result.stderr).strip()
+            return f"<failed to fetch logs: {self._why(exc)}>"
+        return self._redact((result.stdout or result.stderr).strip())
 
     def _get_apptainer_logs(self) -> str:
         if self._server_log_handle:
@@ -247,16 +574,16 @@ class LocalDeployment(AbstractDeployment):
         if not self._server_log_path:
             return ""
         try:
-            return self._server_log_path.read_text(encoding="utf-8", errors="replace").strip()
+            return self._redact(self._server_log_path.read_text(encoding="utf-8", errors="replace").strip())
         except Exception as exc:
-            return f"<failed to fetch logs: {exc}>"
+            return f"<failed to fetch logs: {self._why(exc)}>"
 
     def _start_apptainer_process(self, args: list[str]) -> subprocess.Popen[str]:
         fd, log_path = tempfile.mkstemp(prefix=f"uni-agent-local-{_sanitize_name(self.run_id)}-", suffix=".log")
         os.close(fd)
         self._server_log_path = Path(log_path)
         self._server_log_handle = self._server_log_path.open("w", encoding="utf-8", errors="replace")
-        self.logger.debug(f"Running Apptainer command: {_shell_join(args)}")
+        self.logger.debug("starting apptainer server process")
         return subprocess.Popen(
             args,
             stdout=self._server_log_handle,
@@ -275,13 +602,58 @@ class LocalDeployment(AbstractDeployment):
         )
         self._runtime = LocalRuntime.from_config(runtime_config, run_id=self.run_id)
 
+    async def _exec_bg(self, call: Callable[[], Any]) -> Any:
+        """Run a CLI call on the tracked thread; the slot holds it until its result is handed back."""
+        if self._has_cli():
+            raise RuntimeError("a container runtime call from a previous attempt has not been handed back")
+        fut = _clipool().submit(call)
+        self._future = fut
+        try:
+            return await asyncio.wrap_future(fut)
+        finally:
+            if fut.done() and self._future is fut:
+                self._future = None
+
+    def _with_cid(self, args: list[str], cidfile: Path, owner: str) -> list[str]:
+        """Inject the two handles right before the image, last so a repeated `--cidfile` or same-key
+        label from extra_run_args cannot override them. Refuse an ambiguous bare `--` rather than
+        guess where the options end (a literal goes as `--flag=value`)."""
+        if len(args) < 4 or args[-2] != "-lc":
+            raise RuntimeError("unexpected run command shape; the container handles have nowhere safe to go")
+        at = len(args) - 3  # the image
+        if "--" in args[:at]:
+            raise RuntimeError("a bare '--' in the run command is ambiguous; pass a literal value as --flag=value")
+        handles = ["--cidfile", str(cidfile), "--label", f"{_OWNERTAG}={owner}"]
+        return [*args[:at], *handles, *args[at:]]
+
+    def _find_owned(self, owner: str, timeout: float) -> list[str] | None:
+        """The ids carrying our owner tag, or None if the runtime could not tell us -- a failed query
+        or an unreadable answer is not proof that no container exists, so it is None, not []."""
+        try:
+            result = self._runtime_exec(
+                [self._config.container_runtime, "ps", "-aq", "--no-trunc", "--filter", f"label={_OWNERTAG}={owner}"],
+                timeout=timeout,
+            )
+        except Exception as exc:
+            self._say("warning", "could not list containers by owner {}: {}", owner, self._why(exc))
+            return None
+        found = []
+        for line in result.stdout.splitlines():
+            if not line.strip():
+                continue
+            container_id = _valid_id(line)
+            if not container_id:
+                self._say("warning", "the runtime listed something that is not a container id for owner {}", owner)
+                return None
+            found.append(container_id)
+        return found
+
     async def _start_oci_container(self, token: str, container_name: str, published_port: int) -> None:
         command = self._format_command(token=token, port=self._config.runtime_port)
-        result = await asyncio.to_thread(
-            self._runtime_exec, self._build_run_command(container_name, published_port, command)
-        )
-        self._container_id = result.stdout.strip()
-        host = await asyncio.to_thread(self._get_runtime_host, container_name)
+        # Phase 1 may run a network inspect; a cancellation here never submits docker run.
+        args = await self._exec_bg(lambda: self._build_run_command(container_name, published_port, command))
+        await self._exec_bg(lambda: self._run_container(args, container_name))
+        host = await self._exec_bg(lambda: self._get_runtime_host(container_name))
         runtime_config = LocalRuntimeConfig(
             auth_token=token,
             host=host,
@@ -290,47 +662,212 @@ class LocalDeployment(AbstractDeployment):
         )
         self._runtime = LocalRuntime.from_config(runtime_config, run_id=self.run_id)
 
-    async def start(self, max_retries: int = 5) -> None:
-        token = self._get_token()
-        published_port = self._config.published_port or _pick_free_port()
-        container_name = self._config.container_name or f"uni-agent-{_sanitize_name(self.run_id)}"
-        self._stopped = False
-        last_error: Exception | None = None
-        for attempt in range(max_retries):
-            self._stopped = False
-            self.logger.info(
-                f"Starting local deployment with runtime={self._config.container_runtime}, image={self._config.image}."
+    async def _start_once(self, token: str, container_name: str, published_port: int, *, attempt: int) -> None:
+        queue_t0 = time.monotonic()
+        sem = _get_limiter()
+        await sem.acquire()
+        try:
+            waited = time.monotonic() - queue_t0
+            if waited > _SLOWQUEUE:
+                self.logger.info(f"STARTING permit acquired after {waited:.1f}s")
+            await self._boot_once(token, container_name, published_port, attempt=attempt)
+        finally:
+            # The permit follows the CLI thread, not this cancellable coroutine.
+            fut = self._future
+            if fut is not None and not fut.done():
+                loop = asyncio.get_running_loop()
+
+                def _free(_, loop=loop):
+                    try:
+                        loop.call_soon_threadsafe(sem.release)
+                    except RuntimeError:
+                        pass  # Loop already closed; its limiter died with it.
+
+                fut.add_done_callback(_free)
+            else:
+                sem.release()
+
+    async def _boot_once(self, token: str, container_name: str, published_port: int, *, attempt: int) -> None:
+        start_t0 = time.monotonic()
+        self._hooks.on_custom_step("Creating local sandbox")
+        if residue := self._residue():
+            raise RuntimeError(f"cannot start a container: {residue}")
+
+        if _is_apptainer_runtime(self._config.container_runtime):
+            await self._start_apptainer(token=token, published_port=published_port)
+        else:
+            await self._start_oci_container(
+                token=token,
+                container_name=container_name,
+                published_port=published_port,
             )
-            self._hooks.on_custom_step("Creating local sandbox")
-            self._container_name = container_name
 
+        await self._wait_until_alive(timeout=self._config.startup_timeout)
+        try:
+            await self.runtime.create_session(
+                CreateBashSessionRequest(startup_source=["/root/.bashrc"], startup_timeout=60)
+            )
+        except Exception as exc:
+            raise RuntimeError("bash session creation failed after sandbox became alive") from exc
+        container_id = self._container_id[:_IDLEN] if self._container_id else "n/a"
+        self.logger.info(
+            f"local sandbox alive in {time.monotonic() - start_t0:.2f}s (attempt {attempt + 1}); "
+            f"container={container_name} id={container_id}"
+        )
+
+    def _begin_attempt(self, retry: int, max_retries: int, base_name: str) -> tuple[str, int, str]:
+        # Register only after the announcement succeeds; a raise before this strands no token.
+        published_port = self._config.published_port or _pick_free_port()
+        container_name = self._config.container_name or (base_name if retry == 0 else f"{base_name}-r{retry}")
+        token = self._get_token()
+        self.logger.info(
+            f"[attempt {retry + 1}/{max_retries}] starting local sandbox "
+            f"container={container_name} port={published_port} "
+            f"runtime={self._config.container_runtime} image={self._config.image}"
+        )
+        with self._lock:
+            self._secrets.add(token)
+            self._abandoned = False
+        return token, published_port, container_name
+
+    def _abandon_attempt(self) -> None:
+        with self._lock:
+            self._abandoned = True
+        self._kill_server()
+        self._close_logs()
+
+    def _release_token(self, token: str) -> None:
+        """Drop the token once nothing it authorised remains: a later stop() may still log an
+        exception carrying it, but only while some resource it opened is still here to fail."""
+        if not self._has_cleanup():
+            with self._lock:
+                self._secrets.discard(token)
+
+    async def _backoff(self, retry: int, max_retries: int, deadline: float) -> None:
+        nap_room = deadline - time.monotonic()
+        if retry < max_retries - 1 and nap_room > 0:
+            sleep_time = min(_RETRYCAP, _BACKBASE**retry, nap_room)
+            self.logger.info(f"Retrying local deployment startup in {sleep_time:.1f} seconds...")
+            await _retrydelay(sleep_time)
+
+    def _claim(self, phase: str) -> None:
+        with self._lock:
+            if self._busy is not None:
+                raise RuntimeError(f"{phase}() overlaps an in-flight {self._busy}(); the lifecycle is serial")
+            if phase == "start" and self._has_cleanup():
+                raise RuntimeError("the previous lifecycle left resources behind; stop() must reclaim them first")
+            self._busy = phase
+
+    def _release(self) -> None:
+        with self._lock:
+            self._busy = None
+
+    async def start(self, max_retries: int = 5) -> None:
+        self._claim("start")
+        try:
+            await self._start_loop(max_retries)
+        finally:
+            self._release()
+
+    async def _start_loop(self, max_retries: int) -> None:
+        """Stop launching retries after the deadline; refresh unpinned ports and names."""
+        base_name = f"uni-agent-{_sanitize_name(self.run_id)}"
+        # Redacted at the point of failure: _handle_failure cleans up, and cleanup drops the tokens.
+        summary = "no attempt ran"
+        wall_budget = _get_budget()
+        # Reject a bad cap here; inside the loop it would be retried per attempt.
+        _env_cap()
+        deadline = time.monotonic() + wall_budget
+        attempts = 0
+        reason = "retry limit reached"
+        for retry in range(max_retries):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                reason = "wall budget exhausted"
+                break
+            attempts += 1
+            token, published_port, container_name = self._begin_attempt(retry, max_retries, base_name)
+            attempt_timeout = min(remaining, self._config.startup_timeout + _STARTPAD)
             try:
-                if _is_apptainer_runtime(self._config.container_runtime):
-                    await self._start_apptainer(token=token, published_port=published_port)
-                else:
-                    await self._start_oci_container(
-                        token=token,
-                        container_name=container_name,
-                        published_port=published_port,
-                    )
-
-                await self._wait_until_alive(timeout=self._config.startup_timeout)
-                await self.runtime.create_session(
-                    CreateBashSessionRequest(startup_source=["/root/.bashrc"], startup_timeout=60)
+                await asyncio.wait_for(
+                    self._start_once(token, container_name, published_port, attempt=retry), timeout=attempt_timeout
                 )
-                self._stopped = False
                 return
+            except asyncio.CancelledError:
+                self._abandon_attempt()
+                raise
             except Exception as exc:
-                last_error = exc
-                logs = self._get_container_logs(container_name)
-                self.logger.error(f"Failed to start local sandbox: {exc}\nContainer logs:\n{logs}")
-                await self.stop()
-                if attempt < max_retries - 1:
-                    sleep_time = min(30, 2**attempt)
-                    self.logger.info(f"Retrying local deployment startup in {sleep_time} seconds...")
-                    await asyncio.sleep(sleep_time)
+                summary = self._why(exc)
+                await self._handle_failure(
+                    exc,
+                    attempt_label=f"[attempt {retry + 1}/{max_retries}]",
+                    container_name=container_name,
+                    published_port=published_port,
+                    attempt_timeout=attempt_timeout,
+                )
+                if residue := self._residue():
+                    reason = f"not retrying: {residue}"
+                    break
+                await self._backoff(retry, max_retries, deadline)
+            finally:
+                self._release_token(token)
 
-        raise RuntimeError(f"Failed to create local sandbox after {max_retries} retries") from last_error
+        # Unchained: _handle_failure logged the full chain, redacted; a raw cause reaching the
+        # caller's own logger would undo that.
+        raise RuntimeError(
+            f"Failed to create local sandbox after {attempts} attempt(s): {reason} "
+            f"(max_retries={max_retries}, wall budget {wall_budget}s); last error: {summary}"
+        )
+
+    async def _collect_logs(self, container_name: str) -> str:
+        """Never query OCI logs without a confirmed container ID, and never off the tracked pool: a
+        log fetch that outlives its timeout must hold the slot so no rm can overtake it."""
+        if self._has_cli():
+            return "<not collected: a container runtime call is still in flight>"
+        log_ref = container_name if _is_apptainer_runtime(self._config.container_runtime) else self._container_id
+        if not log_ref:
+            return "<not collected: container creation unconfirmed>"
+        try:
+            return await asyncio.wait_for(self._exec_bg(lambda: self._get_container_logs(log_ref)), timeout=_LOGWAIT)
+        except Exception:
+            return "<log collection failed or timed out>"
+
+    async def _handle_failure(
+        self,
+        exc: Exception,
+        *,
+        attempt_label: str,
+        container_name: str,
+        published_port: int,
+        attempt_timeout: float,
+    ) -> None:
+        if isinstance(exc, TimeoutError | asyncio.TimeoutError):
+            # Mark timeouts so a late run self-reaps.
+            with self._lock:
+                self._abandoned = True
+        logs = await self._collect_logs(container_name)
+        container_id = self._container_id[:_IDLEN] if self._container_id else "n/a"
+        reason = self._why(exc)
+        if isinstance(exc, TimeoutError | asyncio.TimeoutError) and not str(exc):
+            reason = f"{type(exc).__name__}: attempt timed out after {attempt_timeout:.0f}s"
+        # format_exception, not logger.opt(exception=...): see the note above CliError.
+        chain = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+        self._say(
+            "error",
+            "{}",
+            self._redact(
+                f"{attempt_label} failed to start local sandbox "
+                f"container={container_name} id={container_id} port={published_port}: {reason}\n"
+                f"container logs (last {_LOGTAIL} chars):\n{logs[-_LOGTAIL:]}\n{chain}"
+            ),
+        )
+        try:
+            await asyncio.wait_for(self._cleanup(), timeout=_CLEANWAIT)
+        except (TimeoutError, asyncio.TimeoutError):
+            self._say(
+                "warning",
+                f"teardown of failed attempt timed out after {_CLEANWAIT}s; container {container_name} may leak",
+            )
 
     async def copy_to_container(self, src: Path, tgt: Path):
         await self.runtime.execute(Command(command=["mkdir", "-p", str(tgt.parent)]))
@@ -341,63 +878,139 @@ class LocalDeployment(AbstractDeployment):
         """Directory inside the container where tool scripts are installed."""
         return Path("/usr/local/bin")
 
-    async def stop(self):
-        if self._stopped:
-            return
+    def _release_id(self, container_id: str) -> None:
+        """Drop a confirmed-gone id and its diagnostics pointer in one critical section, so a cancelled
+        sweep leaves neither the id for a second rm nor a pointer at a container that is not there."""
+        with self._lock:
+            if self._owned is not None and self._owned[0] == container_id:
+                self._owned = None
+            if self._container_id == container_id:
+                self._container_id = None
 
-        if self._runtime:
+    def _force_remove(self, container_id: str) -> bool:
+        """Force-remove with one retry. An id leaves the ledger only on a confirmed removal."""
+        detail = ""
+        for attempt in range(_RMTRIES):
             try:
-                await self._runtime.close()
-            except Exception as exc:
-                self.logger.error(f"Failed to close local runtime within timeout: {exc}")
-            self._runtime = None
-
-        if self._server_process:
-            try:
-                if self._server_process.poll() is None:
-                    self._server_process.terminate()
-                    await asyncio.to_thread(self._server_process.wait, 10)
-            except subprocess.TimeoutExpired:
-                self._server_process.kill()
-                await asyncio.to_thread(self._server_process.wait)
-            except Exception as exc:
-                self.logger.error(f"Failed to stop local Apptainer process: {exc}")
-            finally:
-                self._server_process = None
-
-        if self._server_log_handle:
-            try:
-                self._server_log_handle.close()
-            except Exception:
-                pass
-            finally:
-                self._server_log_handle = None
-
-        if self._server_log_path:
-            try:
-                self._server_log_path.unlink(missing_ok=True)
-            except Exception:
-                pass
-            finally:
-                self._server_log_path = None
-
-        if self._container_name and not _is_apptainer_runtime(self._config.container_runtime):
-            try:
-                await asyncio.to_thread(
-                    self._runtime_exec,
-                    [self._config.container_runtime, "rm", "-f", self._container_name],
-                    False,
+                result = self._runtime_exec(
+                    [self._config.container_runtime, "rm", "-f", container_id], check=False, timeout=_RMWAIT
                 )
             except Exception as exc:
-                self.logger.error(f"Failed to delete local sandbox {self._container_name}: {exc}")
-            finally:
-                self._container_name = None
-                self._container_id = None
-        else:
-            self._container_name = None
-            self._container_id = None
+                detail = self._why(exc)
+            else:
+                if _confirmed_gone(result):
+                    self._release_id(container_id)
+                    self._say("debug", f"local sandbox container {container_id} is gone")
+                    return True
+                detail = self._redact((result.stderr or result.stdout or f"exit code {result.returncode}").strip())
+            if attempt == 0:
+                self._say("warning", "rm -f {} failed ({}); retrying once", container_id, detail)
+                time.sleep(_RMPAUSE)
+        self._say("error", "rm -f {} failed twice ({}); the container stays owned and may leak", container_id, detail)
+        return False
 
-        self._stopped = True
+    async def _close_runtime(self) -> None:
+        """Drop the non-resource handle after one bounded close attempt."""
+        runtime = self._runtime
+        if runtime is None:
+            return
+        try:
+            await asyncio.wait_for(runtime.close(), timeout=_CLOSEWAIT)
+        except Exception as exc:
+            self._say("warning", "runtime.close() failed; dropping the handle anyway: {}", self._why(exc))
+        finally:
+            self._runtime = None
+
+    async def _stop_server(self) -> None:
+        """Terminate then kill the server process; a failure keeps the slot so a later stop retries."""
+        proc = self._server_process
+        if proc is None:
+            return
+        exited = False
+        try:
+            if proc.poll() is None:
+                proc.terminate()
+                await asyncio.to_thread(proc.wait, _PROCWAIT)
+            exited = True
+        except subprocess.TimeoutExpired:
+            exited = await self._kill_proc(proc)
+        except Exception as exc:
+            self._say("error", "Failed to stop local Apptainer process: {}", self._why(exc))
+            exited = await self._kill_proc(proc)
+        if exited:
+            self._server_process = None
+
+    async def _kill_proc(self, proc: subprocess.Popen[str]) -> bool:
+        """SIGKILL the captured process with a bounded wait; keep the reference if it survives."""
+        try:
+            if proc.poll() is None:
+                proc.kill()
+            # SIGKILL does not guarantee that wait() returns.
+            await asyncio.to_thread(proc.wait, _PROCWAIT)
+            return True
+        except subprocess.TimeoutExpired:
+            self._say("error", "apptainer server process did not exit after SIGKILL; keeping reference")
+        except Exception as exc:
+            self._say("error", "SIGKILL escalation failed: {}; keeping reference", self._why(exc))
+        return False
+
+    def _close_logs(self) -> None:
+        # As in _stop_server: a failure keeps its slot so the next stop() retries it.
+        handle, log_path = self._server_log_handle, self._server_log_path
+        if handle is not None:
+            try:
+                handle.close()
+            except Exception as exc:
+                self._say("warning", "failed to close apptainer log handle: {}", self._why(exc))
+            else:
+                self._server_log_handle = None
+        if log_path is not None:
+            try:
+                log_path.unlink(missing_ok=True)
+            except Exception as exc:
+                self._say("warning", "failed to unlink apptainer log file: {}", self._why(exc))
+            else:
+                self._server_log_path = None
+
+    async def _drain(self) -> None:
+        """Take back the call that outlived its attempt; subprocess.run is its only deadline."""
+        fut = self._future
+        if fut is None:
+            return
+        try:
+            await asyncio.wrap_future(fut)
+        except Exception as exc:
+            self._say("warning", "container runtime call failed after its attempt ended: {}", self._why(exc))
+        finally:
+            if fut.done() and self._future is fut:
+                self._future = None
+
+    async def stop(self):
+        self._claim("stop")
+        try:
+            await self._cleanup()
+        finally:
+            self._release()
+
+    async def _cleanup(self) -> None:
+        """Reclaim everything this deployment owns. Runs under the lifecycle, never claims it."""
+        await self._drain()
+        if self._orphan is not None:
+            await self._exec_bg(lambda: self._probe_orphan(_RMWAIT))
+        with self._lock:
+            pending = self._owned
+
+        await self._close_runtime()
+        await self._stop_server()
+        self._close_logs()
+        if _is_apptainer_runtime(self._config.container_runtime):
+            self._container_id = None
+        elif pending is not None:
+            # On the tracked pool, so a cancelled sweep leaves the rm in the slot, not adrift.
+            await self._exec_bg(lambda: self._force_remove(pending[0]))
+        if not self._has_cleanup():
+            with self._lock:
+                self._secrets.clear()
 
     @property
     def runtime(self) -> LocalRuntime:
@@ -413,18 +1026,66 @@ class LocalDeployment(AbstractDeployment):
         await self.stop()
 
     def __del__(self):
-        if hasattr(self, "_container_name") and self._container_name and not getattr(self, "_stopped", False):
-            msg = "Ensuring local deployment is stopped because object is deleted"
-            try:
-                self.logger.debug(msg)
-            except Exception:
-                print(msg)
-            try:
-                loop = asyncio.get_event_loop()
-                if loop.is_running():
-                    loop.create_task(self.stop())
-                else:
-                    loop.run_until_complete(self.stop())
-            except Exception:
-                pass
-        self._stopped = True
+        # Finalizers cannot rely on the original event loop.
+        if not self._has_cleanup():
+            return
+        try:
+            self._kill_server()
+        except Exception:
+            pass
+        try:
+            self._close_logs()
+        except Exception:
+            pass
+        try:
+            self._del_sweep()
+        except Exception:
+            pass
+
+    def _del_sweep(self) -> None:
+        lock = getattr(self, "_lock", None)
+        if lock is None:
+            return
+        # Synchronous: a finalizer cannot await the tracked pool. Each OCI call is bounded by _DELWAIT.
+        self._probe_orphan(_DELWAIT)
+        if self._orphan is not None:
+            cidfile, owner, _ = self._orphan
+            # Drop the cidfile but keep the owner barrier for a later stop.
+            self._say(
+                "error",
+                "a container may still exist that nothing here can name; remove it by hand with "
+                "`{} rm -f $({} ps -aq --filter label={}={})`",
+                self._config.container_runtime,
+                self._config.container_runtime,
+                _OWNERTAG,
+                owner,
+            )
+            self._drop_cid(cidfile)
+        with lock:
+            owned = self._owned
+        runtime = self._config.container_runtime
+        if owned is None or _is_apptainer_runtime(runtime):
+            return
+        container_id, name = owned
+        self._say("warning", "__del__ emergency teardown for container {}", name)
+        try:
+            result = subprocess.run(
+                [runtime, "rm", "-f", container_id],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=_DELWAIT,
+            )
+        except Exception:
+            result = None
+        if result is not None and _confirmed_gone(result):
+            self._release_id(container_id)
+        if self._owned is not None:
+            self._say("error", "__del__ could not remove container {}; it may leak", name)
+
+    def _say(self, level: str, message: str, *args: object) -> None:
+        """Log; swallow any sink failure so it cannot abort the caller (e.g. a teardown sweep)."""
+        try:
+            getattr(self.logger, level)(message, *args)
+        except Exception:
+            pass


### PR DESCRIPTION
### What does this PR do?

Hardens the `LocalDeployment` sandbox lifecycle for high-concurrency RL training, mirroring the Modal hardening from #47. Refs #43; it does not claim to close it. Blast radius: `uni_agent/deployment/local/deployment.py` plus `diagnose=False` on the two loguru sinks in `async_logging.py`.

### Checklist Before Starting

- [x] Search for similar PRs or issues and paste at least one relevant link here: #43 (target issue), #47 (Modal counterpart, merged), #44 (local endpoint-port fix -- semantically orthogonal, but real code overlap in `deployment.py`: it overlaps `_start_oci_container` and adjacent endpoint/network code, so whichever lands second must rebase; this branch keeps `_build_run_command` itself byte-identical to `main`, so #44's change to *that* function still grafts cleanly -- merge #44 first and rebase this onto it), #50 (no intersection: `agent_loop.py` is at `main` here), #63 (the only `async_logging.py` change here is `diagnose=False` on the two sink configs; the dispatch rework is untouched)
- [x] Format the PR title as `[{modules}] {type}: {description}` (checked by CI)
  - `{modules}` may include `core`, `interaction`, `model`, `env`, `tools`, `deployment`, `reward`, `dashboard`, `docs`, `examples`, `data`, `train`, `ci`, `build`, `deps`, `misc`
  - If this PR involves multiple modules, separate them with `,` like `[interaction, tools, docs]`
  - `{type}` must be one of `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks an API, config contract, workflow, or other compatibility boundary, add `[BREAKING]` to the beginning of the title
  - For a stacked PR series, you may prepend a progress marker such as `[1/N]`
  - Example: `[BREAKING][deployment, docs] feat: simplify runtime env configuration`

### Test

- `tests/deployment/` unit tests: 101 cases on this branch (the 2 config tests land in PR 2). `PYTHONPATH=. pytest tests/deployment/`. Python 3.11 venv. No container runtime is needed -- the tests replace `subprocess.run` / `Popen` with doubles, so no real `docker`/`apptainer` is ever invoked (an autouse fixture also stubs free-port picking). Most cases aim at failures the Docker gate cannot stage reliably (a CLI killed mid-create, a tag query that will not answer, a `close()` that hangs); the rest pin plain behaviour (command construction, config validation, the limiter's plumbing).
- The real-Docker E2E gate lives in PR 3 (it depends on this branch's behaviour and PR 2's config), so there is no live-Docker evidence in this PR.
- `pre-commit run --all-files` clean (ruff, ruff-format, mypy, compileall).

### Design & Code Changes


- **Serial lifecycle over one CLI slot.** Concurrency is *across* deployments (a STARTING limiter caps how many launch at once); one deployment's lifecycle is *serial* -- overlapping start/stop, or a start over resources no stop reclaimed, raise. That keeps the bookkeeping small: with at most one container CLI call alive, "abandoned" is a bool, not generations threaded through a ContextVar. A cancel cannot stop a running `docker run`, so its future (`_future`) holds a single slot until someone takes the result back; `_exec_bg`, `start()`, and `stop()` all refuse to run over an unclaimed one, and every event-loop CLI call (`run`/`logs`/`rm`) goes through it so no `rm` overtakes the log fetch that must precede it. A start happens only over a clean deployment: `start()` refuses unless `_has_cleanup()` is false (nothing owned, in flight, unnamed, a retained runtime handle, or an unreaped process/log). The failed-attempt cleanup between retries is bounded by `_CLEANWAIT`, but the `rm -f` it launches carries a larger bound (`2 x _RMWAIT + _RMPAUSE`) on an uncancellable thread -- so cleanup can return having reclaimed nothing, and a retry that started anyway would turn one failed cleanup into two live containers; the loop stops and demands an explicit `stop()`. (The GC finalizer is the exception: it shells out directly, each OCI call bounded by `_DELWAIT`, best-effort.)
- **Ownership by confirmed id -- no exit code proves non-creation.** Every OCI run carries an exclusive `--cidfile` and a random `uni-agent.owner=<uuid>` label, injected in `_with_cid` after every user option so `extra_run_args` cannot override them (so `_build_run_command` stays byte-identical to `main`); an untaggable shape or an ambiguous bare `--` is refused rather than launched. The docker CLI creates the cidfile empty, the daemon creates the container, and only then does the CLI write the id -- so a failed id-write exits non-zero and deletes the cidfile again: "non-zero, no cidfile, no stdout" can still be a live container, and the owner label is then the only *ownership-safe* way left to find it. Only a full 64-hex id is accepted; with none, the owner tag decides -- a single match is removed by id; two cases prove nothing of ours exists (the runtime never ran, or it ran and *reported failure* with an authoritative-empty query); every unresolved outcome is the state *the container may exist and we cannot name it*, kept, reported at ERROR, and blocking the retry and the next `start()` until `stop()` or the finalizer re-probes and removes by id. An id leaves the ledger only on a confirmed removal (`_confirmed_gone`), in the critical section that clears its diagnostics pointer. Removal is always by id, never by name (which could reach a foreign container).
- **Teardown: bounded close, apptainer, and a teardown logging failure that cannot abort cleanup.** A `RemoteRuntime` handle is an HTTP client, not evidence of container ownership; `_has_cleanup` does count a live handle as a barrier (it blocks re-entry until cleanup), but `close()` gets one bounded attempt (`_CLOSEWAIT`) and the handle is dropped afterward whatever happens -- a hung or failing close cannot barricade the deployment forever. Apptainer server processes get SIGTERM then SIGKILL with bounded waits, references cleared only on confirmed exit; a failed cleanup keeps the process and log *references* for the next `stop()`. Every teardown record -- cleanup, `stop()`, everything `__del__` reaches -- goes through one helper that swallows a raising sink, so a torn-down logger at interpreter shutdown cannot abort a sweep and strand a container; start-only records keep the plain logger and stay loud.
- **The auth token stays out of the logs**, as a contract: redacted *by value* (never by command syntax -- the sandbox `command` is a user template that may place it anywhere) and only *while it is still alive*. Logged exception summaries go through `_why`; rendered chains and all container output through `_redact`. Nothing carrying the raw argv or a raw cause reaches a caller's own logger -- `_runtime_exec` runs `check=False` and rebuilds its error outside the `except` (so no `__context__` leaks), and the retry loop raises an unchained, redacted summary; the loguru sinks run `diagnose=False`. It covers apptainer too, whose `Popen.args` hold the token. Tokens are registered last in `_begin_attempt` (after the announce, so a start that dies earlier strands nothing) and released once `_has_cleanup()` is false.
- **Observability, trade-offs, matrix.** One traceback-bearing record per non-cancelled failed attempt (id/attempt/port); the announce carries attempt/port/name; greppable "may leak" errors; invalid `LOCAL_*` limits fail fast with `ValueError`. Accepted: a cancelled `docker run` keeps pressuring the daemon until its 600s CLI timeout, and a `stop()` landing on one waits for it; a container that neither cidfile nor owner label ever names must be reclaimed by hand from the ERROR record. `LocalDeployment.start`'s `max_retries` stays at `main`'s 5 -- the value `AgentEnv.start` passes -- so the retry tests exercise the same retry contract `AgentEnv` relies on (they do not run the training path). Target matrix: Linux x86_64 + Docker on the rollout host; macOS is development-only.


### Checklist Before Submitting

- [x] Read the [Contribute Guide](../CONTRIBUTING.md)
- [x] Run `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add or update docs/examples for user-facing changes
- [x] Add tests or explain why tests are not practical
- [x] Confirm the PR title matches the required format
- [x] Confirm the placeholder text in this template has been replaced with real content

