### PR TITLE
[env] feat: add local Docker sandbox provider

### DIFF
--- a/docs/source/concepts/sandbox.md
+++ b/docs/source/concepts/sandbox.md
@@ -24,7 +24,7 @@ sandbox = build_sandbox(config)
 The standard fields are:
 
 - `provider`: registered backend name.
-- `image`: image used by remote providers.
+- `image`: container image used by image-backed providers such as Docker and Modal.
 - `runtime_timeout`: maximum remote sandbox lifetime.
 - `sandbox_kwargs`: provider-specific constructor arguments.
 
@@ -62,7 +62,7 @@ await sandbox.download(remote_path, local_path)
 await sandbox.expose_port(port)
 ```
 
-The base class provides portable command, file, and directory-transfer implementations. Providers may override file methods when they have a native data plane. For example, Local uses the host filesystem directly and Modal uses its filesystem API for absolute paths.
+The base class provides portable command, file, and directory-transfer implementations. Providers may override file methods when they have a native data plane. For example, Local uses the host filesystem directly, Docker uses `docker cp`, and Modal uses its filesystem API for absolute paths.
 
 ## Error Policy
 

--- a/docs/source/quickstart/installation.md
+++ b/docs/source/quickstart/installation.md
@@ -41,6 +41,14 @@ Task dependencies provide task-specific datasets, verifiers, and reward implemen
 
 Install the client package for the sandbox backend you plan to use, for example:
 
+=== "Docker"
+
+    Install [Docker](https://docs.docker.com/engine/install/) and verify that its daemon is available:
+
+    ```bash
+    docker version
+    ```
+
 === "Modal"
 
     ```bash

--- a/docs/source/quickstart/launch-sandbox.md
+++ b/docs/source/quickstart/launch-sandbox.md
@@ -36,7 +36,30 @@ Uni-Agent supports multiple sandbox backends. Choose the backend that matches yo
 
     **Local, isolated.** [Docker](https://www.docker.com/) runs agents in containers on your machine.
 
-    Integration and configuration instructions are to be filled.
+    Install Docker and make sure its daemon is running. The image must already be available locally;
+    Uni-Agent does not pull it automatically.
+
+    ```bash
+    docker pull python:3.12
+    ```
+
+    ```python
+    from uni_agent.sandbox import SandboxConfig
+
+    config = SandboxConfig(
+        provider="docker",
+        image="python:3.12",
+        sandbox_kwargs={
+            # Optional arguments inserted before the image in `docker run`.
+            "run_args": ["--network", "none"],
+        },
+    )
+    ```
+
+    The provider starts an ephemeral container, executes commands with `docker exec`,
+    transfers files with `docker cp`, and removes the container when the sandbox exits.
+    The default container command is `sleep infinity`; images without `sleep` can override
+    `entrypoint` and `command` in `sandbox_kwargs`.
 
 === "veFaaS"
 
@@ -211,6 +234,12 @@ After configuring a supported backend above, run the complete connectivity and p
 
     ```bash
     DEBUG_MODE=1 SANDBOX_PROVIDER=local python examples/quickstart/sandbox/demo.py
+    ```
+
+=== "Docker"
+
+    ```bash
+    DEBUG_MODE=1 SANDBOX_PROVIDER=docker python examples/quickstart/sandbox/demo.py
     ```
 
 === "veFaaS"

--- a/docs/source/quickstart/launch-sandbox.md
+++ b/docs/source/quickstart/launch-sandbox.md
@@ -36,12 +36,7 @@ Uni-Agent supports multiple sandbox backends. Choose the backend that matches yo
 
     **Local, isolated.** [Docker](https://www.docker.com/) runs agents in containers on your machine.
 
-    Install Docker and make sure its daemon is running. The image must already be available locally;
-    Uni-Agent does not pull it automatically.
-
-    ```bash
-    docker pull python:3.12
-    ```
+    Install Docker and make sure its daemon is running. By default, Docker pulls the image when it is not already available locally.
 
     ```python
     from uni_agent.sandbox import SandboxConfig
@@ -50,6 +45,8 @@ Uni-Agent supports multiple sandbox backends. Choose the backend that matches yo
         provider="docker",
         image="python:3.12",
         sandbox_kwargs={
+            # "missing" (default), "always", or "never".
+            "pull_policy": "missing",
             # Optional arguments inserted before the image in `docker run`.
             "run_args": ["--network", "none"],
         },
@@ -59,7 +56,8 @@ Uni-Agent supports multiple sandbox backends. Choose the backend that matches yo
     The provider starts an ephemeral container, executes commands with `docker exec`,
     transfers files with `docker cp`, and removes the container when the sandbox exits.
     The default container command is `sleep infinity`; images without `sleep` can override
-    `entrypoint` and `command` in `sandbox_kwargs`.
+    `entrypoint` and `command` in `sandbox_kwargs`. Run `docker login <registry>` first when
+    pulling from a private registry.
 
 === "veFaaS"
 

--- a/examples/quickstart/sandbox/README.md
+++ b/examples/quickstart/sandbox/README.md
@@ -12,6 +12,16 @@ The local provider requires no credentials, but runs commands directly on the ho
 DEBUG_MODE=1 SANDBOX_PROVIDER=local python examples/quickstart/sandbox/demo.py
 ```
 
+## Run with Docker
+
+Docker provides a local isolated environment. Its daemon must be running and the image must
+already exist locally:
+
+```bash
+docker pull python:3.12
+DEBUG_MODE=1 SANDBOX_PROVIDER=docker IMAGE=python:3.12 python examples/quickstart/sandbox/demo.py
+```
+
 ## Run with Modal
 
 Install and authenticate Modal first:

--- a/examples/quickstart/sandbox/README.md
+++ b/examples/quickstart/sandbox/README.md
@@ -14,11 +14,9 @@ DEBUG_MODE=1 SANDBOX_PROVIDER=local python examples/quickstart/sandbox/demo.py
 
 ## Run with Docker
 
-Docker provides a local isolated environment. Its daemon must be running and the image must
-already exist locally:
+Docker provides a local isolated environment. Its daemon must be running; the image is pulled automatically when it is not already available locally:
 
 ```bash
-docker pull python:3.12
 DEBUG_MODE=1 SANDBOX_PROVIDER=docker IMAGE=python:3.12 python examples/quickstart/sandbox/demo.py
 ```
 

--- a/tests/uni_agent/sandbox/test_docker_sandbox.py
+++ b/tests/uni_agent/sandbox/test_docker_sandbox.py
@@ -27,6 +27,7 @@ def test_registry_builds_docker_sandbox_from_config():
     assert isinstance(sandbox, DockerSandbox)
     assert sandbox.image == "example:local"
     assert sandbox.run_args == ["--network", "none"]
+    assert sandbox.pull_policy == "missing"
     assert "_exec" in DockerSandbox.__dict__
     assert "exec" not in DockerSandbox.__dict__
     assert DockerSandbox.exec is Sandbox.exec
@@ -37,6 +38,7 @@ def test_start_requires_local_image_and_builds_detached_run(monkeypatch):
         image="example:local",
         container_name="agent-test",
         run_args=["--network", "none"],
+        pull_policy="never",
     )
     calls: list[tuple[str, ...]] = []
 
@@ -68,8 +70,36 @@ def test_start_requires_local_image_and_builds_detached_run(monkeypatch):
     assert sandbox._container_name == "agent-test"
 
 
+def test_start_pulls_missing_image_through_docker_run(monkeypatch):
+    sandbox = DockerSandbox(image="registry.example.com/agent:latest", container_name="agent-test")
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run(*args: str, timeout=None):
+        calls.append(args)
+        return _ok("container-id\n")
+
+    monkeypatch.setattr(sandbox, "_run_docker", fake_run)
+    asyncio.run(sandbox.start())
+
+    assert calls == [
+        (
+            "run",
+            "--rm",
+            "-d",
+            "--name",
+            "agent-test",
+            "--pull",
+            "missing",
+            "--entrypoint",
+            "sleep",
+            "registry.example.com/agent:latest",
+            "infinity",
+        )
+    ]
+
+
 def test_start_rejects_missing_local_image(monkeypatch):
-    sandbox = DockerSandbox(image="missing:local")
+    sandbox = DockerSandbox(image="missing:local", pull_policy="never")
 
     async def fake_run(*args: str, timeout=None):
         return ExecResult(exit_code=1, stdout="", stderr="No such image")
@@ -79,6 +109,11 @@ def test_start_rejects_missing_local_image(monkeypatch):
     with pytest.raises(RuntimeError, match="not available locally"):
         asyncio.run(sandbox.start())
     assert sandbox._container_name is None
+
+
+def test_rejects_unknown_pull_policy():
+    with pytest.raises(ValueError, match="pull_policy"):
+        DockerSandbox(pull_policy="sometimes")
 
 
 def test_exec_forwards_workdir_environment_and_argv(monkeypatch):

--- a/tests/uni_agent/sandbox/test_docker_sandbox.py
+++ b/tests/uni_agent/sandbox/test_docker_sandbox.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from uni_agent.sandbox.base import ExecResult, Sandbox, SandboxConfig
+from uni_agent.sandbox.docker import DockerSandbox
+from uni_agent.sandbox.registry import SANDBOX_MODULES, build_sandbox
+
+
+def _ok(stdout: str = "") -> ExecResult:
+    return ExecResult(exit_code=0, stdout=stdout, stderr="")
+
+
+def test_registry_builds_docker_sandbox_from_config():
+    config = SandboxConfig(
+        provider="docker",
+        image="example:local",
+        sandbox_kwargs={"run_args": ["--network", "none"]},
+    )
+
+    sandbox = build_sandbox(config)
+
+    assert SANDBOX_MODULES["docker"] == "uni_agent.sandbox.docker"
+    assert isinstance(sandbox, DockerSandbox)
+    assert sandbox.image == "example:local"
+    assert sandbox.run_args == ["--network", "none"]
+    assert "_exec" in DockerSandbox.__dict__
+    assert "exec" not in DockerSandbox.__dict__
+    assert DockerSandbox.exec is Sandbox.exec
+
+
+def test_start_requires_local_image_and_builds_detached_run(monkeypatch):
+    sandbox = DockerSandbox(
+        image="example:local",
+        container_name="agent-test",
+        run_args=["--network", "none"],
+    )
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run(*args: str, timeout=None):
+        calls.append(args)
+        return _ok("sha256:image\n" if args[:2] == ("image", "inspect") else "container-id\n")
+
+    monkeypatch.setattr(sandbox, "_run_docker", fake_run)
+    asyncio.run(sandbox.start())
+
+    assert calls == [
+        ("image", "inspect", "example:local"),
+        (
+            "run",
+            "--rm",
+            "-d",
+            "--name",
+            "agent-test",
+            "--pull",
+            "never",
+            "--entrypoint",
+            "sleep",
+            "--network",
+            "none",
+            "example:local",
+            "infinity",
+        ),
+    ]
+    assert sandbox._container_name == "agent-test"
+
+
+def test_start_rejects_missing_local_image(monkeypatch):
+    sandbox = DockerSandbox(image="missing:local")
+
+    async def fake_run(*args: str, timeout=None):
+        return ExecResult(exit_code=1, stdout="", stderr="No such image")
+
+    monkeypatch.setattr(sandbox, "_run_docker", fake_run)
+
+    with pytest.raises(RuntimeError, match="not available locally"):
+        asyncio.run(sandbox.start())
+    assert sandbox._container_name is None
+
+
+def test_exec_forwards_workdir_environment_and_argv(monkeypatch):
+    sandbox = DockerSandbox(image="example:local")
+    sandbox._container_name = "agent-test"
+    calls: list[tuple[tuple[str, ...], float | None]] = []
+
+    async def fake_run(*args: str, timeout=None):
+        calls.append((args, timeout))
+        return _ok("hello\n")
+
+    monkeypatch.setattr(sandbox, "_run_docker", fake_run)
+    result = asyncio.run(
+        sandbox._exec(
+            ["python", "-c", "print('hello')"],
+            timeout=12.0,
+            workdir="/workspace",
+            env={"A": "1", "B": "two"},
+        )
+    )
+
+    assert result.stdout == "hello\n"
+    assert calls == [
+        (
+            (
+                "exec",
+                "--workdir",
+                "/workspace",
+                "--env",
+                "A=1",
+                "--env",
+                "B=two",
+                "agent-test",
+                "python",
+                "-c",
+                "print('hello')",
+            ),
+            12.0,
+        )
+    ]
+
+
+def test_stop_is_idempotent_and_checks_liveness(monkeypatch):
+    sandbox = DockerSandbox(image="example:local")
+    sandbox._container_name = "agent-test"
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run(*args: str, timeout=None):
+        calls.append(args)
+        if args[0] == "inspect":
+            return _ok("true\n")
+        return _ok()
+
+    monkeypatch.setattr(sandbox, "_run_docker", fake_run)
+
+    async def run() -> None:
+        assert await sandbox.is_alive() is True
+        await sandbox.stop()
+        await sandbox.stop()
+        assert await sandbox.is_alive() is False
+
+    asyncio.run(run())
+    assert calls == [
+        ("inspect", "--format", "{{.State.Running}}", "agent-test"),
+        ("rm", "-f", "agent-test"),
+    ]
+
+
+def test_upload_and_download_use_docker_cp(monkeypatch, tmp_path: Path):
+    sandbox = DockerSandbox(image="example:local")
+    sandbox._container_name = "agent-test"
+    source = tmp_path / "source.bin"
+    destination = tmp_path / "nested" / "destination.bin"
+    source.write_bytes(b"content")
+    docker_calls: list[tuple[str, ...]] = []
+    exec_calls: list[list[str]] = []
+
+    async def fake_run(*args: str, timeout=None):
+        docker_calls.append(args)
+        return _ok()
+
+    async def fake_exec(argv, **kwargs):
+        exec_calls.append(argv)
+        return _ok()
+
+    monkeypatch.setattr(sandbox, "_run_docker", fake_run)
+    monkeypatch.setattr(sandbox, "exec", fake_exec)
+
+    async def run() -> None:
+        await sandbox.upload_file(source, "/workspace/data/source.bin")
+        await sandbox.download_file("/workspace/data/result.bin", destination)
+
+    asyncio.run(run())
+
+    assert exec_calls == [["mkdir", "-p", "/workspace/data"]]
+    assert docker_calls == [
+        ("cp", str(source), "agent-test:/workspace/data/source.bin"),
+        ("cp", "agent-test:/workspace/data/result.bin", str(destination)),
+    ]
+    assert destination.parent.is_dir()

--- a/tests/uni_agent/sandbox/test_exec_error_policy.py
+++ b/tests/uni_agent/sandbox/test_exec_error_policy.py
@@ -146,7 +146,7 @@ def test_is_timeout_error_override_is_honored_by_exec():
 
 # --------------------------- provider wiring ---------------------------
 
-_PROVIDERS = ["local", "modal", "vefaas", "seed"]
+_PROVIDERS = ["local", "docker", "modal", "vefaas", "seed"]
 
 
 @pytest.mark.parametrize("name", _PROVIDERS)
@@ -226,6 +226,12 @@ def test_modal_is_alive_false_before_start():
     from uni_agent.sandbox.modal import ModalSandbox
 
     assert asyncio.run(ModalSandbox().is_alive()) is False
+
+
+def test_docker_is_alive_false_before_start():
+    from uni_agent.sandbox.docker import DockerSandbox
+
+    assert asyncio.run(DockerSandbox().is_alive()) is False
 
 
 def test_seed_is_alive_false_before_start():

--- a/uni_agent/sandbox/docker.py
+++ b/uni_agent/sandbox/docker.py
@@ -23,6 +23,7 @@ class DockerSandbox(Sandbox):
         docker_binary: str = "docker",
         container_name: str | None = None,
         run_args: list[str] | None = None,
+        pull_policy: str = "missing",
         entrypoint: str = "sleep",
         command: list[str] | None = None,
     ) -> None:
@@ -30,6 +31,9 @@ class DockerSandbox(Sandbox):
         self.docker_binary = docker_binary
         self.container_name = container_name
         self.run_args = list(run_args or [])
+        if pull_policy not in {"always", "missing", "never"}:
+            raise ValueError("pull_policy must be one of: 'always', 'missing', 'never'")
+        self.pull_policy = pull_policy
         self.entrypoint = entrypoint
         self.command = list(command or ["infinity"])
         self._container_name: str | None = None
@@ -69,13 +73,14 @@ class DockerSandbox(Sandbox):
         if self._container_name is not None:
             return
 
-        inspected = await self._run_docker("image", "inspect", self.image)
-        if inspected.exit_code != 0:
-            detail = inspected.stderr.strip() or inspected.stdout.strip()
-            raise RuntimeError(f"Docker image {self.image!r} is not available locally: {detail}")
+        if self.pull_policy == "never":
+            inspected = await self._run_docker("image", "inspect", self.image)
+            if inspected.exit_code != 0:
+                detail = inspected.stderr.strip() or inspected.stdout.strip()
+                raise RuntimeError(f"Docker image {self.image!r} is not available locally: {detail}")
 
         name = self.container_name or f"uni-agent-{uuid.uuid4().hex[:12]}"
-        args = ["run", "--rm", "-d", "--name", name, "--pull", "never"]
+        args = ["run", "--rm", "-d", "--name", name, "--pull", self.pull_policy]
         if self.entrypoint:
             args.extend(["--entrypoint", self.entrypoint])
         args.extend(self.run_args)

--- a/uni_agent/sandbox/docker.py
+++ b/uni_agent/sandbox/docker.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING
+
+from .base import ExecResult, Sandbox, _to_str
+from .registry import register_sandbox
+
+if TYPE_CHECKING:
+    from .base import SandboxConfig
+
+
+@register_sandbox("docker")
+class DockerSandbox(Sandbox):
+    """Run an isolated sandbox from an image available to a local Docker daemon."""
+
+    def __init__(
+        self,
+        *,
+        image: str = "python:3.12",
+        docker_binary: str = "docker",
+        container_name: str | None = None,
+        run_args: list[str] | None = None,
+        entrypoint: str = "sleep",
+        command: list[str] | None = None,
+    ) -> None:
+        self.image = image
+        self.docker_binary = docker_binary
+        self.container_name = container_name
+        self.run_args = list(run_args or [])
+        self.entrypoint = entrypoint
+        self.command = list(command or ["infinity"])
+        self._container_name: str | None = None
+
+    @classmethod
+    def from_config(cls, config: SandboxConfig) -> DockerSandbox:
+        return cls(image=config.image, **config.sandbox_kwargs)
+
+    async def _run_docker(self, *args: str, timeout: float | None = None) -> ExecResult:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                self.docker_binary,
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"Docker executable {self.docker_binary!r} was not found") from exc
+
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            await proc.communicate()
+            raise
+
+        return ExecResult(
+            exit_code=int(proc.returncode or 0),
+            stdout=_to_str(stdout),
+            stderr=_to_str(stderr),
+        )
+
+    async def start(self) -> None:
+        if self._container_name is not None:
+            return
+
+        inspected = await self._run_docker("image", "inspect", self.image)
+        if inspected.exit_code != 0:
+            detail = inspected.stderr.strip() or inspected.stdout.strip()
+            raise RuntimeError(f"Docker image {self.image!r} is not available locally: {detail}")
+
+        name = self.container_name or f"uni-agent-{uuid.uuid4().hex[:12]}"
+        args = ["run", "--rm", "-d", "--name", name, "--pull", "never"]
+        if self.entrypoint:
+            args.extend(["--entrypoint", self.entrypoint])
+        args.extend(self.run_args)
+        args.append(self.image)
+        args.extend(self.command)
+
+        started = await self._run_docker(*args)
+        if started.exit_code != 0:
+            detail = started.stderr.strip() or started.stdout.strip()
+            raise RuntimeError(f"Failed to start Docker sandbox from {self.image!r}: {detail}")
+        self._container_name = name
+
+    async def stop(self) -> None:
+        name, self._container_name = self._container_name, None
+        if name is not None:
+            await self._run_docker("rm", "-f", name)
+
+    def _require_container(self) -> str:
+        if self._container_name is None:
+            raise RuntimeError("DockerSandbox not started; call start() first")
+        return self._container_name
+
+    async def is_alive(self) -> bool:
+        if self._container_name is None:
+            return False
+        try:
+            result = await self._run_docker(
+                "inspect",
+                "--format",
+                "{{.State.Running}}",
+                self._container_name,
+                timeout=10.0,
+            )
+            return result.exit_code == 0 and result.stdout.strip() == "true"
+        except Exception:
+            return False
+
+    async def _exec(
+        self,
+        argv: list[str],
+        *,
+        timeout: float | None = None,
+        workdir: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> ExecResult:
+        args = ["exec"]
+        if workdir:
+            args.extend(["--workdir", workdir])
+        for key, value in (env or {}).items():
+            args.extend(["--env", f"{key}={value}"])
+        args.append(self._require_container())
+        args.extend(argv)
+        return await self._run_docker(*args, timeout=timeout)
+
+    async def upload_file(self, local_file: Path | str, remote_file: str) -> None:
+        container = self._require_container()
+        parent = str(PurePosixPath(remote_file).parent)
+        if parent not in {"", "."}:
+            created = await self.exec(["mkdir", "-p", parent])
+            if created.exit_code != 0:
+                raise RuntimeError(f"Failed to create Docker sandbox directory {parent!r}: {created.stderr.strip()}")
+        result = await self._run_docker("cp", str(local_file), f"{container}:{remote_file}")
+        if result.exit_code != 0:
+            raise RuntimeError(f"Failed to upload {local_file!s} to {remote_file!r}: {result.stderr.strip()}")
+
+    async def download_file(self, remote_file: str, local_file: Path | str) -> None:
+        destination = Path(local_file)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        result = await self._run_docker(
+            "cp",
+            f"{self._require_container()}:{remote_file}",
+            str(destination),
+        )
+        if result.exit_code != 0:
+            raise RuntimeError(f"Failed to download {remote_file!r}: {result.stderr.strip()}")

--- a/uni_agent/sandbox/registry.py
+++ b/uni_agent/sandbox/registry.py
@@ -17,6 +17,7 @@ SANDBOX_REGISTRY: dict[str, type[Sandbox]] = {}
 #: provider name -> module that defines (and registers) it, for lazy loading.
 SANDBOX_MODULES: dict[str, str] = {
     "local": "uni_agent.sandbox.local",
+    "docker": "uni_agent.sandbox.docker",
     "modal": "uni_agent.sandbox.modal",
     "vefaas": "uni_agent.sandbox.vefaas",
 }


### PR DESCRIPTION
## Summary

Add a Docker-backed sandbox provider for running agents in isolated local containers.

## Changes

- Add `DockerSandbox` with container lifecycle management.
- Execute commands through `docker exec`.
- Transfer files through `docker cp`.
- Support working directories and environment variables.
- Support `always`, `missing`, and `never` image pull policies.
- Register the `docker` sandbox provider.
- Add Docker configuration and quickstart documentation.
- Add lifecycle, configuration, execution, and file-transfer tests.

## Example

```yaml
sandbox:
  provider: docker
  image: python:3.12
  sandbox_kwargs:
    pull_policy: missing