### PR TITLE
[core] fix: stop fabricating rollout log probabilities

### DIFF
--- a/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
+++ b/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
@@ -697,9 +697,8 @@ async def test_generate_sequences_marks_prompt_failure_when_all_sessions_fail(fa
 
 
 @pytest.mark.asyncio
-async def test_generate_sequences_zero_fills_missing_trainer_fields(fake_tq):
-    """Without reward workers or backend logprobs, trainer-selected optional
-    fields are still emitted as zeros."""
+async def test_generate_sequences_omits_missing_rollout_log_probs(fake_tq):
+    """Missing backend logprobs are omitted while reward scores remain zero-filled."""
     runtime = _FakeGatewayManager({"session-sample-0-rollout-0": [_trajectory(response_logprobs=None)]})
 
     framework = await _build_framework_with_agent_runners(
@@ -713,7 +712,7 @@ async def test_generate_sequences_zero_fills_missing_trainer_fields(fake_tq):
 
     fields = fake_tq.batch_puts[0]["fields"]
     assert fields["rm_scores"][0].tolist() == [0.0, 0.0]
-    assert fields["rollout_log_probs"][0].tolist() == [0.0, 0.0]
+    assert "rollout_log_probs" not in fields
 
 
 @pytest.mark.asyncio

--- a/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
+++ b/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
@@ -98,14 +98,13 @@ async def test_gateway_actor_max_tokens_clamped_to_remaining_response_budget():
             tokenizer=FakeTokenizer(),
             prompt_length=2048,
             response_length=100,
-            base_sampling_params={"top_p": 0.8},
             allowed_request_sampling_param_keys={"max_tokens"},
         ),
         backend,
     )
     await actor.start()
     try:
-        await actor.create_session("s1")
+        await actor.create_session("s1", sampling_params={"top_p": 0.8})
         first_messages = [{"role": "user", "content": "hi"}]
         await actor._handle_openai_chat_completions("s1", {"messages": first_messages})
         assert backend.calls[-1]["sampling_params"]["max_tokens"] == 100
@@ -980,7 +979,7 @@ async def test_gateway_actor_context_change_splits_trajectory(ray_runtime, sessi
                     "SAFE",
                     expected_sampling_params={"temperature": 0.25, "top_p": 0.8, "max_tokens": 128},
                 ),
-                "base_sampling_params": {"temperature": 0.1, "top_p": 0.8, "max_tokens": 64},
+                "session_sampling_params": {"temperature": 0.1, "top_p": 0.8, "max_tokens": 64},
                 "allowed_request_sampling_param_keys": {"temperature", "max_tokens"},
             },
             "session-envelope-boundary",
@@ -991,14 +990,14 @@ async def test_gateway_actor_context_change_splits_trajectory(ray_runtime, sessi
                 "tools": [{"type": "function", "function": {"name": "search", "parameters": {"type": "object"}}}],
             },
         ),
-        # Non-whitelisted key (top_p) in request is ignored; base_sampling_params used as-is.
+        # Non-whitelisted key (top_p) in request is ignored; session sampling params are used as-is.
         (
             {
                 "backend": RejectRequestEnvelopeBackend(
                     "SAFE",
                     expected_sampling_params={"temperature": 0.1, "top_p": 0.9},
                 ),
-                "base_sampling_params": {"temperature": 0.1, "top_p": 0.9},
+                "session_sampling_params": {"temperature": 0.1, "top_p": 0.9},
                 "allowed_request_sampling_param_keys": {"temperature"},
             },
             "session-non-whitelist",
@@ -1009,16 +1008,19 @@ async def test_gateway_actor_context_change_splits_trajectory(ray_runtime, sessi
 async def test_gateway_actor_allowlist_filters_sampling_params(ray_runtime, backend_kwargs, session_id, request_extra):
     """The sampling-param allowlist filters request keys: non-whitelisted keys
     (e.g. ``presence_penalty``) are stripped, and envelope fields (model,
-    tools, messages) never leak into sampling params. Base sampling params
+    tools, messages) never leak into sampling params. Session sampling params
     supply defaults when the request omits a key."""
     from uni_agent.gateway.config import GatewayActorConfig
     from uni_agent.gateway.gateway import GatewayActor
 
     backend = backend_kwargs["backend"]
-    config_kwargs = {key: value for key, value in backend_kwargs.items() if key != "backend"}
+    session_sampling_params = backend_kwargs["session_sampling_params"]
+    config_kwargs = {
+        key: value for key, value in backend_kwargs.items() if key not in {"backend", "session_sampling_params"}
+    }
     actor = GatewayActor.remote(GatewayActorConfig(tokenizer=FakeTokenizer(), **config_kwargs), backend)
     ray.get(actor.start.remote())
-    session = ray.get(actor.create_session.remote(session_id))
+    session = ray.get(actor.create_session.remote(session_id, sampling_params=session_sampling_params))
 
     async with httpx.AsyncClient(timeout=5.0, trust_env=False) as client:
         response = await client.post(
@@ -1038,7 +1040,7 @@ async def test_gateway_actor_allowlist_filters_sampling_params(ray_runtime, back
 @pytest.mark.asyncio
 @pytest.mark.parametrize("provider", ["openai", "anthropic"])
 async def test_gateway_actor_session_sampling_defaults_are_isolated_and_request_overridable(provider):
-    """Both provider handlers apply base, session, then request sampling params."""
+    """Both provider handlers apply session defaults, then request sampling params."""
     from uni_agent.gateway.config import GatewayActorConfig
     from uni_agent.gateway.gateway import _GatewayActor
 
@@ -1046,25 +1048,31 @@ async def test_gateway_actor_session_sampling_defaults_are_isolated_and_request_
     actor = _GatewayActor(
         GatewayActorConfig(
             tokenizer=FakeTokenizer(),
-            base_sampling_params={
-                "temperature": 0.1,
-                "top_p": 0.2,
-                "top_k": 1,
-                "presence_penalty": 0.3,
-            },
             response_length=64,
         ),
         backend,
     )
     await actor.start()
-    train_sampling_params = {"temperature": 0.4, "top_p": 0.5, "logprobs": True}
+    train_sampling_params = {
+        "temperature": 0.4,
+        "top_p": 0.5,
+        "top_k": 1,
+        "presence_penalty": 0.3,
+        "logprobs": True,
+    }
     handler = actor._handle_openai_chat_completions if provider == "openai" else actor._handle_anthropic_messages
     try:
         await actor.create_session("train-session", sampling_params=train_sampling_params)
         train_sampling_params["temperature"] = 9.0
         await actor.create_session(
             "val-session",
-            sampling_params={"temperature": 0, "top_p": 0.9, "top_k": -1, "logprobs": False},
+            sampling_params={
+                "temperature": 0,
+                "top_p": 0.9,
+                "top_k": -1,
+                "presence_penalty": 0.3,
+                "logprobs": False,
+            },
         )
 
         await handler(

--- a/uni_agent/framework/framework.py
+++ b/uni_agent/framework/framework.py
@@ -890,8 +890,6 @@ class OpenAICompatibleAgentFramework(AgentFramework):
         }
         if trajectory.response_logprobs is not None:
             field["rollout_log_probs"] = torch.tensor(trajectory.response_logprobs, dtype=torch.float32)
-        else:
-            field["rollout_log_probs"] = torch.zeros_like(responses, dtype=torch.float32)
         if trajectory.routed_experts is not None:
             aligned_experts = _align_routed_experts(trajectory.routed_experts, input_ids.size(0))
             if aligned_experts is not None:

--- a/uni_agent/gateway/config.py
+++ b/uni_agent/gateway/config.py
@@ -22,7 +22,6 @@ class GatewayActorConfig:
         processor: Optional multimodal processor used for vision requests.
         tool_parser_name: Optional VERL tool parser name for decoding tool calls.
         apply_chat_template_kwargs: Default kwargs passed to chat-template rendering.
-        base_sampling_params: Sampling params applied before per-request overrides.
         allowed_request_sampling_param_keys: Request sampling keys accepted by the
             provider adapters when merging payload sampling params.
         vision_info_extractor: Optional async extractor for image/video inputs.
@@ -37,7 +36,6 @@ class GatewayActorConfig:
     processor: Any | None = None
     tool_parser_name: str | None = None
     apply_chat_template_kwargs: dict[str, Any] | None = None
-    base_sampling_params: dict[str, Any] | None = None
     allowed_request_sampling_param_keys: set[str] | frozenset[str] | None = None
     vision_info_extractor: Callable | None = None
     vision_info_extractor_kwargs: dict[str, Any] | None = None

--- a/uni_agent/gateway/gateway.py
+++ b/uni_agent/gateway/gateway.py
@@ -72,7 +72,6 @@ class _GatewayActor:
             tool_parser_name=config.tool_parser_name,
             apply_chat_template_kwargs=config.apply_chat_template_kwargs,
         )
-        self._base_sampling_params = dict(config.base_sampling_params or {})
         self._allowed_request_sampling_param_keys = (
             DEFAULT_ALLOWED_REQUEST_SAMPLING_KEYS
             if config.allowed_request_sampling_param_keys is None
@@ -172,7 +171,7 @@ class _GatewayActor:
         try:
             internal = openai_to_internal(
                 payload,
-                base_sampling_params={**self._base_sampling_params, **session.sampling_params},
+                base_sampling_params=dict(session.sampling_params),
                 allowed_sampling_keys=self._allowed_request_sampling_param_keys,
             )
             _validate_sampling_params(internal["sampling_params"])
@@ -198,7 +197,7 @@ class _GatewayActor:
         try:
             internal = anthropic_to_internal(
                 payload,
-                base_sampling_params={**self._base_sampling_params, **session.sampling_params},
+                base_sampling_params=dict(session.sampling_params),
                 allowed_sampling_keys=self._allowed_request_sampling_param_keys,
             )
             _validate_sampling_params(internal["sampling_params"])


### PR DESCRIPTION
### What does this PR do?

Stop emitting fabricated zero rollout log probabilities when a trajectory does not provide them. VERL uses the presence of `rollout_log_probs` to enable rollout-logprob paths, so synthetic zeros can silently contaminate bypass or off-policy importance-sampling behavior.

This PR also removes the dead gateway-level `base_sampling_params` config layer. Session sampling parameters are already the runtime source of defaults, and merging an always-empty base dictionary is a no-op.


### Checklist Before Starting

- [x] Searched for similar PRs and issues; relevant links are listed above.
- [x] Formatted the PR title as `[core] fix: stop fabricating rollout log probabilities`.

### Test

```bash
python -m pytest \
  tests/uni_agent/gateway/test_gateway_actor_on_cpu.py \
  tests/uni_agent/framework/test_generate_sequences_on_cpu.py -q
# 61 passed, 4 warnings

pre-commit run --all-files --show-diff-on-failure --color=always
# ruff, ruff format, mypy, and compile-all passed
```

No recipe rollout was run; this focused core change is covered by the affected CPU unit tests.

### API and Usage Example

`GatewayActorConfig.base_sampling_params` is removed. Put sampling defaults on each session instead:

```python
config = GatewayActorConfig(tokenizer=tokenizer)
await gateway.create_session(
    "session-id",
    sampling_params={"temperature": 0.7, "top_p": 0.9},
)
```

### Design & Code Changes

- Emit `rollout_log_probs` only when `trajectory.response_logprobs` is present, matching the adjacent conditional `routed_experts` emission pattern.
- Remove `GatewayActorConfig.base_sampling_params` and `_GatewayActor._base_sampling_params`.
- Pass a copy of `session.sampling_params` directly to the OpenAI and Anthropic adapters; their existing `base_sampling_params` argument names remain unchanged.
- Update Gateway tests to provide defaults through `create_session(..., sampling_params=...)`.
- Update the framework regression test to assert that missing rollout log probabilities omit the key while reward scores remain zero-filled.

### Checklist Before Submitting

- [x] Read the [Contribute Guide](../CONTRIBUTING.md).
- [x] Ran `pre-commit run --all-files --show-diff-on-failure --color=always`.
- [x] Confirmed no repository docs or examples reference the removed field; included the migration example above.
- [x] Updated the affected CPU tests.
- [x] Confirmed the PR title matches the required format.
- [x] Replaced all template placeholder text with real content.
