### PR TITLE
[WIP][examples] fix: use shell to run cmd in sandbox

### DIFF
--- a/examples/blackbox_recipes/claude_code/claude_code_runner.py
+++ b/examples/blackbox_recipes/claude_code/claude_code_runner.py
@@ -45,7 +45,10 @@ class SandboxEnvForReward:
     async def communicate(self, input: str, timeout=600, check="ignore", error_msg="Command failed") -> str:
         result = await self._sandbox.run(input, timeout=int(timeout))
         if check == "raise" and result.exit_code != 0:
-            raise RuntimeError(f"{error_msg}: {result.stdout[:200]}")
+            raise RuntimeError(
+                f"{error_msg} (exit_code={result.exit_code}): "
+                f"stdout={result.stdout[:200]} stderr={result.stderr[:200]}"
+            )
         return result.stdout
 
     async def write_file(self, path: str | Path, content: str) -> None:

--- a/examples/blackbox_recipes/sandbox_client.py
+++ b/examples/blackbox_recipes/sandbox_client.py
@@ -213,21 +213,23 @@ class SandboxClient:
 
         raise RuntimeError(f"Failed to create sandbox after {max_retries} retries") from last_error
 
-    async def run(self, cmd: str, *, timeout: int = 600) -> CommandResult:
-        """Execute *cmd* inside the sandbox via ``sandbox.commands.run``."""
+    async def run(
+        self, cmd: str, *, timeout: int = 600,
+        cwd: str | None = None, envs: dict[str, str] | None = None
+    ) -> CommandResult:
+        """Run *cmd* in a one-shot shell; stderr is merged into stdout."""
+        shell = None
         try:
-            result = await asyncio.to_thread(
-                self._sandbox.commands.run,
-                cmd,
-                timeout=timeout,
-            )
-            return CommandResult(
-                stdout=getattr(result, "stdout", ""),
-                stderr=getattr(result, "stderr", ""),
-                exit_code=getattr(result, "exit_code", -1),
-            )
+            shell = await self._sandbox.shells.create(cwd=cwd, envs=envs)
+            return await shell.run(cmd, timeout=timeout)
         except Exception as e:
             return CommandResult(stdout="", stderr=str(e), exit_code=-1)
+        finally:
+            if shell is not None:
+                try:
+                    await shell.kill()
+                except Exception:
+                    pass
 
     async def cleanup(self) -> None:
         """Kill the sandbox if still running."""


### PR DESCRIPTION
### What does this PR do?

During reward calculation, multiple commands are executed. The set -x option is used to echo each executed command to the output; however, by default, these traces are written to stderr. This results in execution outputs being split across stdout and stderr. To ensure correct parsing, all outputs — both command traces and their results — should be merged sequentially as expected.

This PR utilizes shell.run() over command.run() to execute commands in the openYuanrong sandbox, ensuring outputs are returned both sequentially and atomically.

### Checklist Before Starting

- [ ] Search for similar PRs or issues and paste at least one relevant link here: ...
- [x] Format the PR title as `[{modules}] {type}: {description}` (checked by CI)
  - `{modules}` may include `core`, `interaction`, `model`, `env`, `tools`, `deployment`, `reward`, `dashboard`, `docs`, `examples`, `data`, `train`, `ci`, `build`, `deps`, `misc`
  - If this PR involves multiple modules, separate them with `,` like `[interaction, tools, docs]`
  - `{type}` must be one of `feat`, `fix`, `refactor`, `chore`, `test`
  - If this PR breaks an API, config contract, workflow, or other compatibility boundary, add `[BREAKING]` to the beginning of the title
  - For a stacked PR series, you may prepend a progress marker such as `[1/N]`
  - Example: `[BREAKING][deployment, docs] feat: simplify runtime env configuration`

### Test

manuel test is done in remote sandbox system

### API and Usage Example

This PR does not change API. It changes the implemention of command execution

### Design & Code Changes

This PR utilizes shell.run() over command.run() to execute commands in the openYuanrong sandbox, ensuring outputs are returned both sequentially and atomically.

examples/blackbox_recipes/claude_code/claude_code_runner.py
async def run utilizes shell.run() over command.run() 

### Checklist Before Submitting

- [x] Read the [Contribute Guide](../CONTRIBUTING.md)
- [x] Run `pre-commit install && pre-commit run --all-files --show-diff-on-failure --color=always`
- [x] Add or update docs/examples for user-facing changes
- [x] Add tests or explain why tests are not practical
- [x] Confirm the PR title matches the required format
- [x] Confirm the placeholder text in this template has been replaced with real content
