### PR TITLE
[core] fix: enforce total trajectory capacity instead of response length

### DIFF
--- a/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
+++ b/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
@@ -547,7 +547,7 @@ async def test_generate_sequences_writes_tq_schema_for_each_session(monkeypatch,
                         ],
                         dtype=np.uint8,
                     ),
-                    extra_fields={"materialization_reason": "max_response_length"},
+                    extra_fields={"materialization_reason": "max_trajectory_length"},
                 )
             ],
             "session-sample-0-rollout-1": [_trajectory(response_logprobs=[-0.3, -0.4])],
@@ -596,7 +596,7 @@ async def test_generate_sequences_writes_tq_schema_for_each_session(monkeypatch,
         "response_len": 2,
         "seq_len": 4,
         "uid": "uid-0",
-        "materialization_reason": "max_response_length",
+        "materialization_reason": "max_trajectory_length",
     }
     assert "length_truncated" not in tag
     assert "traj_exit_reason" not in tag
@@ -651,7 +651,7 @@ async def test_generate_sequences_batches_length_trajectory_before_normal_trajec
             "session-sample-0-rollout-0": [
                 _trajectory(
                     response_ids=[20],
-                    extra_fields={"materialization_reason": "max_response_length"},
+                    extra_fields={"materialization_reason": "max_trajectory_length"},
                 ),
                 _trajectory(response_ids=[21]),
             ]
@@ -667,7 +667,7 @@ async def test_generate_sequences_batches_length_trajectory_before_normal_trajec
     assert len(fake_tq.batch_puts) == 1
     batch = fake_tq.batch_puts[0]
     assert batch["keys"] == ["uid-0_0_0", "uid-0_0_1"]
-    assert batch["tags"][0]["materialization_reason"] == "max_response_length"
+    assert batch["tags"][0]["materialization_reason"] == "max_trajectory_length"
     assert "materialization_reason" not in batch["tags"][1]
     assert "materialization_reason" not in batch["fields"].keys()
     assert batch["fields"]["responses"][0].tolist() == [20]

--- a/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
+++ b/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
@@ -49,6 +49,14 @@ def test_gateway_actor_config_rejects_non_positive_response_length(response_leng
         GatewayActorConfig(tokenizer=FakeTokenizer(), response_length=response_length)
 
 
+@pytest.mark.parametrize("prompt_length", [0, -1])
+def test_gateway_actor_config_rejects_non_positive_prompt_length(prompt_length):
+    from uni_agent.gateway.config import GatewayActorConfig
+
+    with pytest.raises(ValueError, match="prompt_length must be positive"):
+        GatewayActorConfig(tokenizer=FakeTokenizer(), prompt_length=prompt_length)
+
+
 @pytest.mark.parametrize("value", ["true", 1, None])
 def test_gateway_actor_config_rejects_non_bool_last_assistant_rollback(value):
     from uni_agent.gateway.config import GatewayActorConfig
@@ -87,8 +95,8 @@ async def test_gateway_actor_forwards_last_assistant_rollback_to_session():
 
 
 @pytest.mark.asyncio
-async def test_gateway_actor_max_tokens_clamped_to_remaining_response_budget():
-    """Continuation requests clamp ``max_tokens`` to the selected chain budget."""
+async def test_gateway_actor_max_tokens_clamped_to_remaining_trajectory_capacity():
+    """Clamp ``max_tokens`` to total capacity minus the selected chain context."""
     from uni_agent.gateway.config import GatewayActorConfig
     from uni_agent.gateway.gateway import _GatewayActor
 
@@ -107,40 +115,46 @@ async def test_gateway_actor_max_tokens_clamped_to_remaining_response_budget():
         await actor.create_session("s1", sampling_params={"top_p": 0.8})
         first_messages = [{"role": "user", "content": "hi"}]
         await actor._handle_openai_chat_completions("s1", {"messages": first_messages})
-        assert backend.calls[-1]["sampling_params"]["max_tokens"] == 100
+        total_capacity = 2048 + 100
+        assert backend.calls[-1]["sampling_params"]["max_tokens"] == total_capacity - len(
+            backend.calls[-1]["prompt_ids"]
+        )
 
         await actor._handle_openai_chat_completions(
             "s1",
             {
                 "messages": [*first_messages, {"role": "assistant", "content": "A" * 60}],
-                "max_tokens": 200,
+                "max_tokens": 5000,
             },
         )
 
-        assert backend.calls[-1]["sampling_params"]["max_tokens"] == 40
+        assert backend.calls[-1]["sampling_params"]["max_tokens"] == total_capacity - len(
+            backend.calls[-1]["prompt_ids"]
+        )
         assert backend.calls[-1]["sampling_params"]["top_p"] == 0.8
     finally:
         await actor.shutdown()
 
 
 @pytest.mark.asyncio
-async def test_gateway_actor_over_budget_closes_without_backend_call():
+async def test_gateway_actor_exhausted_trajectory_closes_without_backend_call():
     from uni_agent.gateway.config import GatewayActorConfig
     from uni_agent.gateway.gateway import _GatewayActor
 
+    first_messages = [{"role": "user", "content": "hi"}]
+    prompt_length = len(FakeTokenizer().apply_chat_template(first_messages))
     backend = SequencedBackend(["A" * 60, "B"])
     actor = _GatewayActor(
         GatewayActorConfig(
             tokenizer=FakeTokenizer(),
-            prompt_length=2048,
-            response_length=50,
+            prompt_length=prompt_length,
+            response_length=60,
         ),
         backend,
     )
     await actor.start()
     try:
         await actor.create_session("s1")
-        first_messages = [{"role": "user", "content": "hi"}]
         await actor._handle_openai_chat_completions("s1", {"messages": first_messages})
 
         response = await actor._handle_openai_chat_completions(
@@ -185,17 +199,20 @@ async def test_gateway_actor_rejects_invalid_session_max_tokens_before_backend_c
 
 @pytest.mark.asyncio
 async def test_gateway_actor_continuation_budget_exhausted_materializes_length_stop():
-    """When a continuation request exceeds the selected chain response budget,
+    """When a continuation request exceeds the selected chain trajectory capacity,
     the gateway skips the backend call, closes that chain with
-    ``materialization_reason="max_response_length"``, and returns an empty
+    ``materialization_reason="max_trajectory_length"``, and returns an empty
     assistant message with ``finish_reason="length"``."""
     from uni_agent.gateway.config import GatewayActorConfig
     from uni_agent.gateway.gateway import _GatewayActor
 
+    first_messages = [{"role": "user", "content": "search"}]
+    prompt_length = len(FakeTokenizer().apply_chat_template(first_messages))
     backend = SequencedBackend(["A" * 45, "SHOULD_NOT_RUN"])
     actor = _GatewayActor(
         GatewayActorConfig(
             tokenizer=FakeTokenizer(),
+            prompt_length=prompt_length,
             response_length=50,
         ),
         backend,
@@ -203,7 +220,6 @@ async def test_gateway_actor_continuation_budget_exhausted_materializes_length_s
     await actor.start()
     try:
         await actor.create_session("s1")
-        first_messages = [{"role": "user", "content": "search"}]
         await actor._handle_openai_chat_completions("s1", {"messages": first_messages})
         backend.calls.clear()
         payload = {
@@ -226,7 +242,7 @@ async def test_gateway_actor_continuation_budget_exhausted_materializes_length_s
         trajectories = await actor.finalize_session("s1")
         assert len(trajectories) == 1
         trajectory = trajectories[0]
-        assert trajectory.extra_fields["materialization_reason"] == "max_response_length"
+        assert trajectory.extra_fields["materialization_reason"] == "max_trajectory_length"
         assert "length_truncated" not in trajectory.extra_fields
         assert "traj_exit_reason" not in trajectory.extra_fields
     finally:
@@ -1048,7 +1064,6 @@ async def test_gateway_actor_session_sampling_defaults_are_isolated_and_request_
     actor = _GatewayActor(
         GatewayActorConfig(
             tokenizer=FakeTokenizer(),
-            response_length=64,
         ),
         backend,
     )
@@ -1100,7 +1115,7 @@ async def test_gateway_actor_session_sampling_defaults_are_isolated_and_request_
             "top_k": 1,
             "presence_penalty": 0.3,
             "logprobs": True,
-            "max_tokens": 64,
+            "max_tokens": 128,
         },
         {
             "temperature": 0,

--- a/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
+++ b/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
@@ -298,6 +298,36 @@ async def test_last_assistant_rollback_reencodes_replacement_suffix_as_masked_co
 
 
 @pytest.mark.asyncio
+async def test_last_assistant_rollback_does_not_materialize_suffix_beyond_total_capacity():
+    """Close the rolled-back prefix without storing an oversized replacement suffix."""
+    first_messages = [{"role": "user", "content": "run mini-swe"}]
+    rewrite_messages = [
+        *first_messages,
+        {"role": "user", "content": "user_error: missing import"},
+    ]
+    codec = MessageCodec(FakeTokenizer())
+    prompt_length = len(codec.encode_full(first_messages))
+    suffix_length = len(codec.encode_incremental(rewrite_messages[1:]))
+    session = _session(
+        "rollback-total-capacity",
+        prompt_length=prompt_length,
+        response_length=suffix_length - 1,
+        enable_last_assistant_rollback=True,
+    )
+    backend = SequencedBackend(["BAD", "SHOULD_NOT_RUN"])
+
+    await _run(session, backend, first_messages)
+    outcome = await _run(session, backend, rewrite_messages)
+    trajectories = await session.finalize()
+
+    assert outcome.finish_reason == "length"
+    assert len(backend.calls) == 1
+    assert trajectories[0].response_ids == []
+    assert len(trajectories[0].prompt_ids) + len(trajectories[0].response_ids) <= prompt_length + suffix_length - 1
+    assert trajectories[0].extra_fields == {"materialization_reason": "max_trajectory_length"}
+
+
+@pytest.mark.asyncio
 async def test_last_assistant_rollback_splits_when_history_changes_before_boundary():
     """Split when request drift starts before the latest assistant boundary."""
     session = _session("rollback-split-before-boundary", enable_last_assistant_rollback=True)
@@ -1005,8 +1035,8 @@ async def test_multiple_chains_closes_when_continuation_fills_total_trajectory_c
 
 
 @pytest.mark.asyncio
-async def test_multiple_chains_rejects_initial_context_that_fills_total_trajectory_capacity():
-    """Reject a fresh prompt when no capacity remains for a generated token."""
+async def test_multiple_chains_returns_length_when_initial_context_fills_total_trajectory_capacity():
+    """Return a normal length stop when a fresh prompt leaves no generation room."""
     messages = [{"role": "user", "content": "initial prompt"}]
     context_length = _prompt_length(messages)
     session = _session(
@@ -1016,12 +1046,14 @@ async def test_multiple_chains_rejects_initial_context_that_fills_total_trajecto
     )
     backend = SequencedBackend(["SHOULD_NOT_RUN"])
 
-    with pytest.raises(HTTPException, match="leaves no generation room") as exc_info:
-        await _run(session, backend, messages)
+    outcome = await _run(session, backend, messages)
 
-    assert exc_info.value.status_code == 400
+    assert outcome.assistant_msg == {"role": "assistant", "content": ""}
+    assert outcome.finish_reason == "length"
+    assert outcome.completion_tokens == 0
     assert backend.steps == ["SHOULD_NOT_RUN"]
     assert session.active_chains == []
+    assert await session.finalize() == []
 
 
 @pytest.mark.asyncio
@@ -1230,8 +1262,8 @@ async def test_multiple_chains_terminal_state_rejects_late_commit(terminal_actio
 
 
 @pytest.mark.asyncio
-async def test_multiple_chains_reserved_chain_is_not_closed_by_oversized_split_request():
-    """Reject an oversized split without closing the chain reserved by another request."""
+async def test_multiple_chains_oversized_split_returns_length_without_closing_reserved_chain():
+    """Return a length stop without closing the chain reserved by another request."""
     first_messages = [{"role": "user", "content": "base"}]
     session = _session(
         "reserved-length",
@@ -1245,17 +1277,18 @@ async def test_multiple_chains_reserved_chain_is_not_closed_by_oversized_split_r
     await pending_backend.wait_for_calls(1)
 
     split_backend = SequencedBackend(["SHOULD_NOT_RUN"])
-    with pytest.raises(HTTPException, match="leaves no generation room") as exc_info:
-        await _run(
-            session,
-            split_backend,
-            [
-                {"role": "user", "content": "base"},
-                {"role": "assistant", "content": "BASE"},
-                {"role": "user", "content": "this continuation is long enough to close the chain"},
-            ],
-        )
-    assert exc_info.value.status_code == 400
+    split_outcome = await _run(
+        session,
+        split_backend,
+        [
+            {"role": "user", "content": "base"},
+            {"role": "assistant", "content": "BASE"},
+            {"role": "user", "content": "this continuation is long enough to close the chain"},
+        ],
+    )
+    assert split_outcome.assistant_msg == {"role": "assistant", "content": ""}
+    assert split_outcome.finish_reason == "length"
+    assert split_outcome.completion_tokens == 0
     assert split_backend.steps == ["SHOULD_NOT_RUN"]
     assert session.snapshot_state()["active_chain_ids"] == [1]
     assert session.snapshot_state()["num_trajectories"] == 0

--- a/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
+++ b/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
@@ -29,9 +29,14 @@ def _decode_response_ids(response_ids: list[int]) -> str:
     return FakeTokenizer().decode(response_ids)
 
 
+def _prompt_length(messages: list[dict]) -> int:
+    return len(MessageCodec(FakeTokenizer()).encode_full(messages))
+
+
 def _session(
     session_id: str,
     *,
+    prompt_length: int | None = None,
     response_length: int | None = None,
     sampling_params: dict | None = None,
     enable_last_assistant_rollback: bool = False,
@@ -47,6 +52,7 @@ def _session(
             vision_info_extractor=vision_info_extractor,
             tool_parser_name=tool_parser_name,
         ),
+        prompt_length=prompt_length,
         response_length=response_length,
         sampling_params=sampling_params,
         enable_last_assistant_rollback=enable_last_assistant_rollback,
@@ -58,6 +64,13 @@ def test_gateway_session_rejects_non_positive_response_length(response_length):
     """Reject non-positive session response budgets during construction."""
     with pytest.raises(ValueError, match="response_length must be positive"):
         _session("invalid-response-length", response_length=response_length)
+
+
+@pytest.mark.parametrize("prompt_length", [0, -1])
+def test_gateway_session_rejects_non_positive_prompt_length(prompt_length):
+    """Reject non-positive session prompt capacity during construction."""
+    with pytest.raises(ValueError, match="prompt_length must be positive"):
+        _session("invalid-prompt-length", prompt_length=prompt_length)
 
 
 def test_gateway_session_enables_last_assistant_rollback_by_default():
@@ -807,11 +820,15 @@ async def test_multiple_chains_new_chain_backend_failure_does_not_leave_partial_
 
 @pytest.mark.asyncio
 async def test_multiple_chains_length_exhaustion_closes_selected_chain_and_orders_it_last():
-    """Close and order the selected chain when its response budget is exhausted."""
-    session = _session("length-close", response_length=len("MAIN1") + 1)
-    backend = SequencedBackend(["MAIN1", "SUB"])
+    """Close and order the selected chain when its trajectory capacity is exhausted."""
     main_first = [HELPFUL_SYS, {"role": "user", "content": "main"}]
     subagent = [SUBAGENT_SYS, {"role": "user", "content": "sub"}]
+    session = _session(
+        "length-close",
+        prompt_length=max(_prompt_length(main_first), _prompt_length(subagent)),
+        response_length=len("MAIN1") + 1,
+    )
+    backend = SequencedBackend(["MAIN1", "SUB"])
     main_too_long = [
         HELPFUL_SYS,
         {"role": "user", "content": "main"},
@@ -829,15 +846,19 @@ async def test_multiple_chains_length_exhaustion_closes_selected_chain_and_order
     assert len(trajectories) == 2
     assert _decode_response_ids(trajectories[0].response_ids) == "SUB"
     assert _decode_response_ids(trajectories[1].response_ids) == "MAIN1"
-    assert trajectories[1].extra_fields["materialization_reason"] == "max_response_length"
+    assert trajectories[1].extra_fields["materialization_reason"] == "max_trajectory_length"
 
 
 @pytest.mark.asyncio
 async def test_multiple_chains_exactly_exhausted_chain_closes_without_backend_call():
     """Close an exhausted chain even when the repeated request has no incremental tail."""
-    session = _session("chain-budget-exhausted", response_length=len("NORMAL"))
-    backend = SequencedBackend(["NORMAL", "SHOULD_NOT_RUN"])
     first_messages = [{"role": "user", "content": "fill the response budget"}]
+    session = _session(
+        "chain-budget-exhausted",
+        prompt_length=_prompt_length(first_messages),
+        response_length=len("NORMAL"),
+    )
+    backend = SequencedBackend(["NORMAL", "SHOULD_NOT_RUN"])
     repeated_history = [
         *first_messages,
         {"role": "assistant", "content": "NORMAL"},
@@ -851,15 +872,19 @@ async def test_multiple_chains_exactly_exhausted_chain_closes_without_backend_ca
     assert len(backend.calls) == 1
     assert backend.steps == ["SHOULD_NOT_RUN"]
     assert len(trajectories) == 1
-    assert trajectories[0].extra_fields["materialization_reason"] == "max_response_length"
+    assert trajectories[0].extra_fields["materialization_reason"] == "max_trajectory_length"
 
 
 @pytest.mark.asyncio
 async def test_multiple_chains_length_exhaustion_orders_before_later_fresh_chain():
     """Order a closed length trajectory before a later normal trajectory."""
-    session = _session("length-before-fresh", response_length=len("FULL"))
-    backend = SequencedBackend(["FULL", "NEW"])
     first_messages = [{"role": "user", "content": "fill the response budget"}]
+    session = _session(
+        "length-before-fresh",
+        prompt_length=_prompt_length(first_messages),
+        response_length=len("FULL"),
+    )
+    backend = SequencedBackend(["FULL", "NEW"])
     repeated_history = [
         *first_messages,
         {"role": "assistant", "content": "FULL"},
@@ -874,13 +899,13 @@ async def test_multiple_chains_length_exhaustion_orders_before_later_fresh_chain
     assert len(backend.calls) == 2
     assert backend.steps == []
     assert [_decode_response_ids(trajectory.response_ids) for trajectory in trajectories] == ["FULL", "NEW"]
-    assert trajectories[0].extra_fields == {"materialization_reason": "max_response_length"}
+    assert trajectories[0].extra_fields == {"materialization_reason": "max_trajectory_length"}
     assert trajectories[1].extra_fields == {}
 
 
 @pytest.mark.asyncio
 async def test_multiple_chains_exactly_exhausted_chain_skips_new_media_extraction():
-    """Do not parse unused incremental media after the response budget is full."""
+    """Do not parse unused incremental media after trajectory capacity is full."""
     extractor_calls = 0
 
     async def forbidden_extractor(*args, **kwargs):
@@ -888,14 +913,15 @@ async def test_multiple_chains_exactly_exhausted_chain_skips_new_media_extractio
         extractor_calls += 1
         raise AssertionError("media extractor must not run for an exhausted chain")
 
+    first_messages = [{"role": "user", "content": "fill the response budget"}]
     session = _session(
         "exhausted-skips-media",
+        prompt_length=_prompt_length(first_messages),
         response_length=len("FULL"),
         processor=FakeProcessor(),
         vision_info_extractor=forbidden_extractor,
     )
     backend = SequencedBackend(["FULL", "SHOULD_NOT_RUN"])
-    first_messages = [{"role": "user", "content": "fill the response budget"}]
     continuation = [
         *first_messages,
         {"role": "assistant", "content": "FULL"},
@@ -911,18 +937,91 @@ async def test_multiple_chains_exactly_exhausted_chain_skips_new_media_extractio
     assert len(backend.calls) == 1
     assert backend.steps == ["SHOULD_NOT_RUN"]
     assert trajectories[0].multi_modal_data is None
-    assert trajectories[0].extra_fields == {"materialization_reason": "max_response_length"}
+    assert trajectories[0].extra_fields == {"materialization_reason": "max_trajectory_length"}
 
 
 @pytest.mark.asyncio
-async def test_multiple_chains_sets_remaining_budget_when_request_omits_max_tokens():
-    """Use the remaining session budget when max_tokens is omitted."""
-    session = _session("default-max-tokens-budget", response_length=10)
+async def test_multiple_chains_does_not_enforce_response_length_without_prompt_length():
+    """Do not treat response_length alone as a response-only token budget."""
+    session = _session("response-length-only", response_length=10)
     backend = SequencedBackend(["A"])
 
     await _run(session, backend, [{"role": "user", "content": "use session budget"}])
 
-    assert backend.calls[0]["sampling_params"]["max_tokens"] == 10
+    assert "max_tokens" not in backend.calls[0]["sampling_params"]
+
+
+@pytest.mark.asyncio
+async def test_multiple_chains_uses_total_trajectory_capacity_instead_of_response_only_budget():
+    """Allow response tokens to use unused prompt capacity across turns."""
+    session = _session(
+        "total-capacity-allows-continuation",
+        prompt_length=256,
+        response_length=len("FIRST"),
+    )
+    backend = SequencedBackend(["FIRST", "SECOND"])
+    first_messages = [{"role": "user", "content": "first"}]
+    continuation = [
+        *first_messages,
+        {"role": "assistant", "content": "FIRST"},
+        {"role": "user", "content": "continue"},
+    ]
+
+    await _run(session, backend, first_messages)
+    outcome = await _run(session, backend, continuation)
+    trajectories = await session.finalize()
+
+    assert outcome.finish_reason == "stop"
+    assert len(backend.calls) == 2
+    assert _decode_response_ids(trajectories[0].response_ids).endswith("SECOND")
+
+
+@pytest.mark.asyncio
+async def test_multiple_chains_closes_when_continuation_fills_total_trajectory_capacity():
+    """Count prompt, generated, and continuation-context tokens against one capacity."""
+    first_messages = [{"role": "user", "content": "first"}]
+    continuation_messages = [
+        {"role": "assistant", "content": "FIRST"},
+        {"role": "user", "content": "continue"},
+    ]
+    codec = MessageCodec(FakeTokenizer())
+    prompt_length = len(codec.encode_full(first_messages))
+    incremental_length = len(codec.encode_incremental(continuation_messages[-1:]))
+    session = _session(
+        "total-capacity-exhausted",
+        prompt_length=prompt_length,
+        response_length=len("FIRST") + incremental_length,
+    )
+    backend = SequencedBackend(["FIRST", "SHOULD_NOT_RUN"])
+
+    await _run(session, backend, first_messages)
+    outcome = await _run(session, backend, [*first_messages, *continuation_messages])
+    trajectories = await session.finalize()
+
+    assert outcome.finish_reason == "length"
+    assert len(backend.calls) == 1
+    assert backend.steps == ["SHOULD_NOT_RUN"]
+    assert trajectories[0].extra_fields == {"materialization_reason": "max_trajectory_length"}
+
+
+@pytest.mark.asyncio
+async def test_multiple_chains_rejects_initial_context_that_fills_total_trajectory_capacity():
+    """Reject a fresh prompt when no capacity remains for a generated token."""
+    messages = [{"role": "user", "content": "initial prompt"}]
+    context_length = _prompt_length(messages)
+    session = _session(
+        "initial-context-exhausted",
+        prompt_length=context_length - 1,
+        response_length=1,
+    )
+    backend = SequencedBackend(["SHOULD_NOT_RUN"])
+
+    with pytest.raises(HTTPException, match="leaves no generation room") as exc_info:
+        await _run(session, backend, messages)
+
+    assert exc_info.value.status_code == 400
+    assert backend.steps == ["SHOULD_NOT_RUN"]
+    assert session.active_chains == []
 
 
 @pytest.mark.asyncio
@@ -1029,13 +1128,6 @@ async def test_multiple_chains_length_exhaustion_does_not_materialize_unsent_med
     media_kind, message_factory, extractor, sent_url, unsent_url, backend_field, trajectory_key
 ):
     """Exclude unsent media when length exhaustion skips backend generation."""
-    session = _session(
-        f"length-unsent-{media_kind}",
-        response_length=len("FIRST") + 1,
-        processor=FakeProcessor(),
-        vision_info_extractor=extractor,
-    )
-    backend = SequencedBackend(["FIRST", "SHOULD_NOT_RUN"])
     first_messages = [message_factory(sent_url, "describe first")]
     exhausted_messages = [
         *first_messages,
@@ -1043,6 +1135,21 @@ async def test_multiple_chains_length_exhaustion_does_not_materialize_unsent_med
         message_factory(unsent_url, "new media that exhausts length"),
     ]
     expected_sent = [sent_url] if media_kind == "image" else [(sent_url, {"url": sent_url})]
+    prompt_length = len(
+        MessageCodec(FakeTokenizer(), processor=FakeProcessor()).encode_full(
+            first_messages,
+            image_data=expected_sent if media_kind == "image" else None,
+            video_data=expected_sent if media_kind == "video" else None,
+        )
+    )
+    session = _session(
+        f"length-unsent-{media_kind}",
+        prompt_length=prompt_length,
+        response_length=len("FIRST") + 1,
+        processor=FakeProcessor(),
+        vision_info_extractor=extractor,
+    )
+    backend = SequencedBackend(["FIRST", "SHOULD_NOT_RUN"])
 
     await _run(session, backend, first_messages)
     outcome = await _run(session, backend, exhausted_messages)
@@ -1054,15 +1161,19 @@ async def test_multiple_chains_length_exhaustion_does_not_materialize_unsent_med
     assert backend.calls[0][backend_field] == expected_sent
     assert len(trajectories) == 1
     assert trajectories[0].multi_modal_data == {trajectory_key: expected_sent}
-    assert trajectories[0].extra_fields["materialization_reason"] == "max_response_length"
+    assert trajectories[0].extra_fields["materialization_reason"] == "max_trajectory_length"
 
 
 @pytest.mark.asyncio
 async def test_multiple_chains_abort_clears_length_materialized_trajectories():
     """Clear length-materialized trajectories when the session is aborted."""
-    session = _session("abort-clears-materialized", response_length=len("FIRST") + 1)
-    backend = SequencedBackend(["FIRST", "SHOULD_NOT_RUN"])
     first_messages = [{"role": "user", "content": "first turn"}]
+    session = _session(
+        "abort-clears-materialized",
+        prompt_length=_prompt_length(first_messages),
+        response_length=len("FIRST") + 1,
+    )
+    backend = SequencedBackend(["FIRST", "SHOULD_NOT_RUN"])
     exhausted_messages = [
         *first_messages,
         {"role": "assistant", "content": "FIRST"},
@@ -1119,41 +1230,45 @@ async def test_multiple_chains_terminal_state_rejects_late_commit(terminal_actio
 
 
 @pytest.mark.asyncio
-async def test_multiple_chains_reserved_chain_is_not_closed_by_concurrent_length_request():
-    """Split rather than length-close a matching chain reserved by another request."""
-    session = _session("reserved-length", response_length=len("BASE") + 1)
-    await _run(session, SequencedBackend(["BASE"]), [{"role": "user", "content": "base"}])
+async def test_multiple_chains_reserved_chain_is_not_closed_by_oversized_split_request():
+    """Reject an oversized split without closing the chain reserved by another request."""
+    first_messages = [{"role": "user", "content": "base"}]
+    session = _session(
+        "reserved-length",
+        prompt_length=_prompt_length(first_messages),
+        response_length=len("BASE") + 1,
+    )
+    await _run(session, SequencedBackend(["BASE"]), first_messages)
     pending_backend = _ControlledParallelBackend(["CONT"])
     pending_messages = list(session.active_chains[0].message_history)
     pending_task = asyncio.create_task(_run(session, pending_backend, pending_messages))
     await pending_backend.wait_for_calls(1)
 
-    split_outcome = await _run(
-        session,
-        SequencedBackend(["FRESH"]),
-        [
-            {"role": "user", "content": "base"},
-            {"role": "assistant", "content": "BASE"},
-            {"role": "user", "content": "this continuation is long enough to close the chain"},
-        ],
-    )
-    assert split_outcome.finish_reason == "stop"
-    assert session.snapshot_state()["active_chain_ids"] == [1, 2]
+    split_backend = SequencedBackend(["SHOULD_NOT_RUN"])
+    with pytest.raises(HTTPException, match="leaves no generation room") as exc_info:
+        await _run(
+            session,
+            split_backend,
+            [
+                {"role": "user", "content": "base"},
+                {"role": "assistant", "content": "BASE"},
+                {"role": "user", "content": "this continuation is long enough to close the chain"},
+            ],
+        )
+    assert exc_info.value.status_code == 400
+    assert split_backend.steps == ["SHOULD_NOT_RUN"]
+    assert session.snapshot_state()["active_chain_ids"] == [1]
     assert session.snapshot_state()["num_trajectories"] == 0
-    split_chain = next(chain for chain in session.active_chains if chain.chain_id == 2)
-    assert split_chain.buffer.response_ids == _ids("FRESH")
-    assert split_chain.buffer.response_mask == [1] * len("FRESH")
 
     pending_backend.release_call(0)
     await pending_task
-    assert session.snapshot_state()["active_chain_ids"] == [1, 2]
+    assert session.snapshot_state()["active_chain_ids"] == [1]
 
     trajectories = await session.finalize()
     decoded = [_decode_response_ids(trajectory.response_ids) for trajectory in trajectories]
-    assert len(trajectories) == 2
+    assert len(trajectories) == 1
     assert all("materialization_reason" not in trajectory.extra_fields for trajectory in trajectories)
-    assert any(text.endswith("CONT") for text in decoded)
-    assert "FRESH" in decoded
+    assert decoded[0].endswith("CONT")
 
 
 @pytest.mark.asyncio

--- a/uni_agent/gateway/config.py
+++ b/uni_agent/gateway/config.py
@@ -26,8 +26,9 @@ class GatewayActorConfig:
             provider adapters when merging payload sampling params.
         vision_info_extractor: Optional async extractor for image/video inputs.
         vision_info_extractor_kwargs: Static kwargs forwarded to the extractor.
-        prompt_length: Optional prompt-token budget stored on gateway sessions.
-        response_length: Optional response-token budget stored on gateway sessions.
+        prompt_length: Optional prompt component of the total trajectory capacity.
+        response_length: Optional response component of the total trajectory capacity.
+            The gateway enforces their sum when both values are set.
         enable_last_assistant_rollback: Whether latest-assistant rewrites may
             rollback and reuse an existing chain. Enabled by default.
     """
@@ -49,5 +50,7 @@ class GatewayActorConfig:
                 "enable_last_assistant_rollback must be a bool, "
                 f"got {type(self.enable_last_assistant_rollback).__name__}"
             )
+        if self.prompt_length is not None and self.prompt_length <= 0:
+            raise ValueError(f"prompt_length must be positive when set, got {self.prompt_length}")
         if self.response_length is not None and self.response_length <= 0:
             raise ValueError(f"response_length must be positive when set, got {self.response_length}")

--- a/uni_agent/gateway/session/session.py
+++ b/uni_agent/gateway/session/session.py
@@ -109,8 +109,8 @@ class EncodedData:
             materialization.
         video_data: Video inputs carried into backend generation and trajectory
             materialization.
-        length_exhausted_trajectory: Materialized trajectory for a total-capacity
-            early return, or ``None`` on the normal path.
+        capacity_exhausted: Whether preparation determined that no generation
+            can fit within the total trajectory capacity.
         chain_id: Selected active chain id, or ``None`` when commit should append
             a new chain.
         incoming_message_prefix_hashes: Stable prefix hashes for the normalized
@@ -130,7 +130,7 @@ class EncodedData:
     tools: list[dict[str, Any]] | None
     image_data: list[Any] | None
     video_data: list[Any] | None
-    length_exhausted_trajectory: Trajectory | None
+    capacity_exhausted: bool
     chain_id: int | None
     incoming_message_prefix_hashes: list[str] = field(default_factory=list)
     last_assistant_start: LastAssistantStart | None = None
@@ -235,9 +235,10 @@ class GatewaySession:
                 # Prepare can touch codec and multimodal extractor state, so only
                 # backend generation runs outside the session lock.
                 encoded = await self._prepare_generation_inputs(request)
-                if encoded.length_exhausted_trajectory is not None:
+                if encoded.capacity_exhausted:
                     empty_msg = {"role": "assistant", "content": ""}
-                    self._close_length_exhausted_chain(encoded)
+                    if encoded.chain_id is not None:
+                        self._close_length_exhausted_chain(encoded)
                     self._touch()
                     return GenerationOutcome(
                         assistant_msg=empty_msg,
@@ -378,14 +379,14 @@ class GatewaySession:
         tools = request["tools"]
         sampling_params = dict(request["sampling_params"])
         incoming_message_prefix_hashes = self._extend_message_prefix_hashes([], messages)
-        selected_chain = self._select_chain(
+        selection = self._select_chain(
             tools=tools,
             incoming_message_prefix_hashes=incoming_message_prefix_hashes,
         )
         rollback_applied = False
         rollback_dropped_trainable_tokens = 0
 
-        if selected_chain is None:
+        if selection is None:
             image_data, video_data = await self._codec.extract_multi_modal_data(messages)
             prompt_ids = self._codec.encode_full(
                 messages,
@@ -393,25 +394,15 @@ class GatewaySession:
                 image_data=image_data,
                 video_data=video_data,
             )
-            if self._trajectory_capacity is not None and len(prompt_ids) >= self._trajectory_capacity:
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        f"request context length {len(prompt_ids)} leaves no generation room "
-                        f"within trajectory capacity {self._trajectory_capacity}"
-                    ),
-                )
             buffer = TrajectoryBuffer(prompt_ids=prompt_ids)
             chain_id = None
+            capacity_exhausted = self._trajectory_capacity is not None and len(prompt_ids) >= self._trajectory_capacity
         else:
+            selected_chain, rollback_to_last_assistant = selection
             buffer = self._copy_trajectory_buffer(selected_chain.buffer)
             self._assert_response_logprob_alignment(buffer)
             image_data, video_data = self._copy_chain_media(selected_chain)
             chain_id = selected_chain.chain_id
-            rollback_to_last_assistant = not self._is_chain_prefix_hash_match(
-                chain=selected_chain,
-                incoming_message_prefix_hashes=incoming_message_prefix_hashes,
-            )
             if rollback_to_last_assistant:
                 last_assistant_start = selected_chain.last_assistant_start
                 assert last_assistant_start.response_ids_len <= len(buffer.response_ids)
@@ -423,107 +414,38 @@ class GatewaySession:
                 del buffer.response_logprobs[last_assistant_start.response_logprobs_len :]
                 self._assert_response_logprob_alignment(buffer)
 
-                stored_image_data = list(selected_chain.image_data or [])
-                stored_video_data = list(selected_chain.video_data or [])
-                assert last_assistant_start.image_data_len <= len(stored_image_data)
-                assert last_assistant_start.video_data_len <= len(stored_video_data)
-                image_data = stored_image_data[: last_assistant_start.image_data_len] or None
-                video_data = stored_video_data[: last_assistant_start.video_data_len] or None
-                suffix_messages = messages[last_assistant_start.message_history_len :]
-                suffix_ids: list[int] = []
-                new_image_data = None
-                new_video_data = None
-                if suffix_messages:
-                    new_image_data, new_video_data = await self._codec.extract_multi_modal_data(suffix_messages)
-                    suffix_ids = self._codec.encode_incremental(
-                        suffix_messages,
-                        image_data=new_image_data,
-                        video_data=new_video_data,
-                    )
-
-                buffer.response_ids.extend(suffix_ids)
-                buffer.response_mask.extend([0] * len(suffix_ids))
-                if sampling_params.get("logprobs", False):
-                    buffer.response_logprobs.extend([0.0] * len(suffix_ids))
-                self._assert_response_logprob_alignment(buffer)
-                if new_image_data:
-                    if image_data is None:
-                        image_data = []
-                    image_data.extend(new_image_data)
-                if new_video_data:
-                    if video_data is None:
-                        video_data = []
-                    video_data.extend(new_video_data)
+                if image_data is not None:
+                    assert last_assistant_start.image_data_len <= len(image_data)
+                    image_data = image_data[: last_assistant_start.image_data_len] or None
+                if video_data is not None:
+                    assert last_assistant_start.video_data_len <= len(video_data)
+                    video_data = video_data[: last_assistant_start.video_data_len] or None
+                incremental_start = last_assistant_start.message_history_len
                 rollback_applied = True
-
-                if (
-                    self._trajectory_capacity is not None
-                    and len(buffer.prompt_ids) + len(buffer.response_ids) >= self._trajectory_capacity
-                ):
-                    context_ids = buffer.prompt_ids + buffer.response_ids
-                    working_chain = replace(
-                        selected_chain,
-                        message_history=list(messages),
-                        message_tip_hash=incoming_message_prefix_hashes[-1],
-                        buffer=buffer,
-                        image_data=self._copy_media_list(image_data),
-                        video_data=self._copy_media_list(video_data),
-                    )
-                    return EncodedData(
-                        buffer=buffer,
-                        context_ids=context_ids,
-                        sampling_params={},
-                        messages=list(messages),
-                        tools=tools,
-                        image_data=image_data,
-                        video_data=video_data,
-                        length_exhausted_trajectory=self._build_materialized_trajectory(
-                            chain=working_chain,
-                            extra_fields={"materialization_reason": "max_trajectory_length"},
-                        ),
-                        chain_id=selected_chain.chain_id,
-                        incoming_message_prefix_hashes=list(incoming_message_prefix_hashes),
-                        rollback_applied=True,
-                        rollback_dropped_trainable_tokens=rollback_dropped_trainable_tokens,
-                    )
             else:
-                incremental_messages = messages[len(selected_chain.message_history) :]
-                new_image_data = None
-                new_video_data = None
-                incremental_ids = []
-                current_trajectory_length = len(buffer.prompt_ids) + len(buffer.response_ids)
-                already_exhausted = (
-                    self._trajectory_capacity is not None and current_trajectory_length >= self._trajectory_capacity
-                )
-                if incremental_messages and not already_exhausted:
-                    new_image_data, new_video_data = await self._codec.extract_multi_modal_data(incremental_messages)
-                    incremental_ids = self._codec.encode_incremental(
-                        incremental_messages,
-                        image_data=new_image_data,
-                        video_data=new_video_data,
-                    )
+                incremental_start = len(selected_chain.message_history)
 
-                if already_exhausted or (
+            incremental_messages = messages[incremental_start:]
+            new_image_data = None
+            new_video_data = None
+            incremental_ids = []
+            current_trajectory_length = len(buffer.prompt_ids) + len(buffer.response_ids)
+            capacity_exhausted = (
+                self._trajectory_capacity is not None and current_trajectory_length >= self._trajectory_capacity
+            )
+            if incremental_messages and not capacity_exhausted:
+                new_image_data, new_video_data = await self._codec.extract_multi_modal_data(incremental_messages)
+                incremental_ids = self._codec.encode_incremental(
+                    incremental_messages,
+                    image_data=new_image_data,
+                    video_data=new_video_data,
+                )
+                capacity_exhausted = (
                     self._trajectory_capacity is not None
                     and current_trajectory_length + len(incremental_ids) >= self._trajectory_capacity
-                ):
-                    context_ids = buffer.prompt_ids + buffer.response_ids
-                    return EncodedData(
-                        buffer=buffer,
-                        context_ids=context_ids,
-                        sampling_params={},
-                        messages=list(messages),
-                        tools=tools,
-                        image_data=image_data,
-                        video_data=video_data,
-                        length_exhausted_trajectory=self._build_materialized_trajectory(
-                            chain=selected_chain,
-                            extra_fields={"materialization_reason": "max_trajectory_length"},
-                        ),
-                        chain_id=selected_chain.chain_id,
-                        incoming_message_prefix_hashes=list(incoming_message_prefix_hashes),
-                    )
+                )
 
+            if not capacity_exhausted:
                 buffer.response_ids.extend(incremental_ids)
                 buffer.response_mask.extend([0] * len(incremental_ids))
                 if sampling_params.get("logprobs", False):
@@ -539,6 +461,22 @@ class GatewaySession:
                     video_data.extend(new_video_data)
 
         context_ids = buffer.prompt_ids + buffer.response_ids
+        if capacity_exhausted:
+            return EncodedData(
+                buffer=buffer,
+                context_ids=context_ids,
+                sampling_params={},
+                messages=list(messages),
+                tools=tools,
+                image_data=image_data,
+                video_data=video_data,
+                capacity_exhausted=True,
+                chain_id=chain_id,
+                incoming_message_prefix_hashes=list(incoming_message_prefix_hashes),
+                rollback_applied=rollback_applied,
+                rollback_dropped_trainable_tokens=rollback_dropped_trainable_tokens,
+            )
+
         remaining_trajectory_capacity = (
             self._trajectory_capacity - len(context_ids) if self._trajectory_capacity is not None else None
         )
@@ -562,7 +500,7 @@ class GatewaySession:
             tools=tools,
             image_data=image_data,
             video_data=video_data,
-            length_exhausted_trajectory=None,
+            capacity_exhausted=False,
             chain_id=chain_id,
             incoming_message_prefix_hashes=list(incoming_message_prefix_hashes),
             last_assistant_start=last_assistant_start,
@@ -575,7 +513,7 @@ class GatewaySession:
         *,
         tools: list[dict[str, Any]] | None,
         incoming_message_prefix_hashes: list[str],
-    ) -> ChainState | None:
+    ) -> tuple[ChainState, bool] | None:
         ranked_candidates = []
         deepest_rollback_candidates = []
         deepest_rollback_service_value = -1
@@ -613,7 +551,7 @@ class GatewaySession:
             return None
         if not ranked_candidates:
             return None
-        return max(
+        selected_chain, _, exact_prefix_match = max(
             ranked_candidates,
             key=lambda candidate: (
                 candidate[1],
@@ -621,7 +559,8 @@ class GatewaySession:
                 candidate[0].updated_seq,
                 candidate[0].chain_id,
             ),
-        )[0]
+        )
+        return selected_chain, not exact_prefix_match
 
     def _is_chain_prefix_hash_match(
         self,
@@ -755,13 +694,27 @@ class GatewaySession:
         )
 
     def _close_length_exhausted_chain(self, encoded: EncodedData) -> None:
-        if encoded.chain_id is None or encoded.length_exhausted_trajectory is None:
-            raise RuntimeError("length-exhausted chain metadata is missing")
+        if encoded.chain_id is None:
+            raise RuntimeError("length-exhausted chain id is missing")
         chain_index, chain = self._find_active_chain(encoded.chain_id)
+        chain_to_materialize = chain
+        if encoded.rollback_applied:
+            message_history_len = chain.last_assistant_start.message_history_len
+            chain_to_materialize = replace(
+                chain,
+                message_history=list(encoded.messages[:message_history_len]),
+                message_tip_hash=encoded.incoming_message_prefix_hashes[message_history_len - 1],
+                buffer=encoded.buffer,
+                image_data=self._copy_media_list(encoded.image_data),
+                video_data=self._copy_media_list(encoded.video_data),
+            )
         order_seq = self._next_order_seq()
         self.materialized_chains.append(
             MaterializedChain(
-                trajectory=encoded.length_exhausted_trajectory,
+                trajectory=self._build_materialized_trajectory(
+                    chain=chain_to_materialize,
+                    extra_fields={"materialization_reason": "max_trajectory_length"},
+                ),
                 order_seq=order_seq,
             )
         )

--- a/uni_agent/gateway/session/session.py
+++ b/uni_agent/gateway/session/session.py
@@ -109,7 +109,7 @@ class EncodedData:
             materialization.
         video_data: Video inputs carried into backend generation and trajectory
             materialization.
-        length_exhausted_trajectory: Materialized trajectory for a length-budget
+        length_exhausted_trajectory: Materialized trajectory for a total-capacity
             early return, or ``None`` on the normal path.
         chain_id: Selected active chain id, or ``None`` when commit should append
             a new chain.
@@ -179,15 +179,18 @@ class GatewaySession:
         enable_last_assistant_rollback: bool = True,
     ):
         """Create an active session bound to a handle and model codec."""
+        if prompt_length is not None and prompt_length <= 0:
+            raise ValueError(f"prompt_length must be positive when set, got {prompt_length}")
         if response_length is not None and response_length <= 0:
             raise ValueError(f"response_length must be positive when set, got {response_length}")
 
         self.handle = handle
         self._codec = codec
         # Provider adapters merge these trusted defaults before calling the
-        # session; the response budget is enforced here during preparation.
-        self._prompt_length = prompt_length
-        self._response_length = response_length
+        # session; the total trajectory capacity is enforced during preparation.
+        self._trajectory_capacity = (
+            prompt_length + response_length if prompt_length is not None and response_length is not None else None
+        )
         self._sampling_params = dict(sampling_params or {})
         self._enable_last_assistant_rollback = enable_last_assistant_rollback
         self.active_chains: list[ChainState] = []
@@ -390,6 +393,14 @@ class GatewaySession:
                 image_data=image_data,
                 video_data=video_data,
             )
+            if self._trajectory_capacity is not None and len(prompt_ids) >= self._trajectory_capacity:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"request context length {len(prompt_ids)} leaves no generation room "
+                        f"within trajectory capacity {self._trajectory_capacity}"
+                    ),
+                )
             buffer = TrajectoryBuffer(prompt_ids=prompt_ids)
             chain_id = None
         else:
@@ -445,7 +456,10 @@ class GatewaySession:
                     video_data.extend(new_video_data)
                 rollback_applied = True
 
-                if self._response_length is not None and len(buffer.response_mask) >= self._response_length:
+                if (
+                    self._trajectory_capacity is not None
+                    and len(buffer.prompt_ids) + len(buffer.response_ids) >= self._trajectory_capacity
+                ):
                     context_ids = buffer.prompt_ids + buffer.response_ids
                     working_chain = replace(
                         selected_chain,
@@ -465,7 +479,7 @@ class GatewaySession:
                         video_data=video_data,
                         length_exhausted_trajectory=self._build_materialized_trajectory(
                             chain=working_chain,
-                            extra_fields={"materialization_reason": "max_response_length"},
+                            extra_fields={"materialization_reason": "max_trajectory_length"},
                         ),
                         chain_id=selected_chain.chain_id,
                         incoming_message_prefix_hashes=list(incoming_message_prefix_hashes),
@@ -477,8 +491,9 @@ class GatewaySession:
                 new_image_data = None
                 new_video_data = None
                 incremental_ids = []
+                current_trajectory_length = len(buffer.prompt_ids) + len(buffer.response_ids)
                 already_exhausted = (
-                    self._response_length is not None and len(buffer.response_mask) >= self._response_length
+                    self._trajectory_capacity is not None and current_trajectory_length >= self._trajectory_capacity
                 )
                 if incremental_messages and not already_exhausted:
                     new_image_data, new_video_data = await self._codec.extract_multi_modal_data(incremental_messages)
@@ -489,8 +504,8 @@ class GatewaySession:
                     )
 
                 if already_exhausted or (
-                    self._response_length is not None
-                    and len(buffer.response_mask) + len(incremental_ids) >= self._response_length
+                    self._trajectory_capacity is not None
+                    and current_trajectory_length + len(incremental_ids) >= self._trajectory_capacity
                 ):
                     context_ids = buffer.prompt_ids + buffer.response_ids
                     return EncodedData(
@@ -503,7 +518,7 @@ class GatewaySession:
                         video_data=video_data,
                         length_exhausted_trajectory=self._build_materialized_trajectory(
                             chain=selected_chain,
-                            extra_fields={"materialization_reason": "max_response_length"},
+                            extra_fields={"materialization_reason": "max_trajectory_length"},
                         ),
                         chain_id=selected_chain.chain_id,
                         incoming_message_prefix_hashes=list(incoming_message_prefix_hashes),
@@ -524,13 +539,13 @@ class GatewaySession:
                     video_data.extend(new_video_data)
 
         context_ids = buffer.prompt_ids + buffer.response_ids
-        remaining_response_budget = (
-            self._response_length - len(buffer.response_mask) if self._response_length is not None else None
+        remaining_trajectory_capacity = (
+            self._trajectory_capacity - len(context_ids) if self._trajectory_capacity is not None else None
         )
-        if remaining_response_budget is not None:
+        if remaining_trajectory_capacity is not None:
             sampling_params["max_tokens"] = min(
-                sampling_params.get("max_tokens", remaining_response_budget),
-                remaining_response_budget,
+                sampling_params.get("max_tokens", remaining_trajectory_capacity),
+                remaining_trajectory_capacity,
             )
         last_assistant_start = self._snapshot_last_assistant_start(
             buffer=buffer,


### PR DESCRIPTION
### What does this PR do?

This PR changes Gateway session length enforcement from a response-only budget to the configured total trajectory capacity (`prompt_length + response_length`) when both values are set. It also unifies normal continuation and last-assistant rollback input preparation, including incremental message/media handling.

### Checklist Before Starting

- [x] Searched related work: #66 and #88 cover the multi-chain and rollback state model used by this change.
- [x] PR title follows `[{modules}] {type}: {description}`.

### Test

- Targeted CPU tests for Gateway session, Gateway actor, and Framework trajectory writing: `124 passed`.
- `pre-commit run --all-files --show-diff-on-failure --color=always`: passed.
- Manual Claude Code rollout validation: 8 samples x 4 sessions, 50 turns; 32/32 sessions produced trajectories, 32/32 evaluation/alignment checks passed, and no traceback, assertion, OOM, or session failure was observed. Seven sessions received `reward_score=1.0`.
- The rollout was run before rebasing onto the latest `upstream/main`, with the same functional commits under review. The only test-only overlay supplied the post-#83 reward/runner API migration from upstream #91; session/framework/task reward code came from the candidate under test.

### API and Usage Example

No new public API. Existing `prompt_length` and `response_length` configuration values are combined into one total trajectory capacity when both are configured. A response-only `response_length` remains accepted but no longer acts as a standalone response-token cap.

### Design & Code Changes

- Clamp backend `max_tokens` to the remaining total trajectory capacity.
- Materialize an active chain with `materialization_reason="max_trajectory_length"` when continuation context would leave no generation room.
- Reject a fresh prompt that already leaves no room for a generated token, instead of sending a non-positive `max_tokens` value to the backend.
- Return rollback intent from chain selection so rollback does not repeat prefix matching.
- Use one incremental encoding path for ordinary continuation and rollback replacement suffixes, while preserving chain-local media and response-mask semantics.
- Validate configured prompt and response capacity components as positive values.

### Checklist Before Submitting

- [x] Read the Contribute Guide.
- [x] Ran full-repository pre-commit checks.
- [x] Added or updated behavioral tests for total capacity, fresh over-capacity prompts, rollback suffixes, and materialization metadata.
- [x] Confirmed the PR title format.
- [x] Replaced all template placeholders with concrete content.
