### PR TITLE
[examples] fix: support task-shaped SWE-rebench in Claude Code training

### DIFF
--- a/examples/blackbox_recipes/claude_code/claude_code_runner.py
+++ b/examples/blackbox_recipes/claude_code/claude_code_runner.py
@@ -31,6 +31,13 @@ logger = logging.getLogger(__name__)
 DEFAULT_TOOL_IMAGE = "swr.cn-east-3.myhuaweicloud.com/openyuanrong/claude-code-tool:latest"
 TOOL_TARGET = "/opt/claude-code"
 DEFAULT_GATEWAY_PROXY_PORT = 38197
+_SWE_REBENCH_GIT_CLEAN_HISTORY = " && ".join(
+    [
+        "git tag -d $(git tag -l) || true",
+        "git reflog expire --expire=now --all || true",
+        "git gc --prune=now || true",
+    ]
+)
 
 
 def extract_upstream(gateway_url: str) -> str:
@@ -113,25 +120,29 @@ def _decode_metadata_list(value) -> list[str]:
     return [str(value)]
 
 
-def _get_task_config(tools_kwargs: dict | None) -> dict:
-    tools_kwargs = tools_kwargs or {}
-    task_config = tools_kwargs.get("task", {})
-    return dict(task_config) if isinstance(task_config, Mapping) else {}
-
-
-def _get_reward_metadata(tools_kwargs: dict | None) -> dict:
-    tools_kwargs = tools_kwargs or {}
-    reward_metadata = ((tools_kwargs.get("reward") or {}).get("metadata") or {})
-    if isinstance(reward_metadata, Mapping) and reward_metadata:
-        return dict(reward_metadata)
-    task_metadata = _get_task_config(tools_kwargs).get("metadata", {})
-    return dict(task_metadata) if isinstance(task_metadata, Mapping) else {}
-
-
 def build_claude_task(raw_prompt, tools_kwargs: dict | None = None) -> str:
-    tools_kwargs = tools_kwargs or {}
+    if tools_kwargs is None:
+        tools_kwargs = {}
+    elif not isinstance(tools_kwargs, Mapping):
+        raise TypeError(f"tools_kwargs must be a mapping, got {type(tools_kwargs).__name__}")
+
+    if "task" in tools_kwargs:
+        task_config = tools_kwargs["task"]
+        if not isinstance(task_config, Mapping):
+            raise TypeError(f"tools_kwargs.task must be a mapping, got {type(task_config).__name__}")
+        metadata = task_config.get("metadata", {})
+        metadata_path = "tools_kwargs.task.metadata"
+    else:
+        reward_config = tools_kwargs.get("reward", {})
+        if not isinstance(reward_config, Mapping):
+            raise TypeError(f"tools_kwargs.reward must be a mapping, got {type(reward_config).__name__}")
+        metadata = reward_config.get("metadata", {})
+        metadata_path = "tools_kwargs.reward.metadata"
+
+    if not isinstance(metadata, Mapping):
+        raise TypeError(f"{metadata_path} must be a mapping, got {type(metadata).__name__}")
+
     task = extract_task(raw_prompt)
-    metadata = _get_reward_metadata(tools_kwargs)
     issue = metadata.get("problem_statement") or _extract_issue_text(task)
     tests = _decode_metadata_list(metadata.get("FAIL_TO_PASS"))
     if not tests:
@@ -263,18 +274,31 @@ async def claude_code_runner(
         3. Evaluate reward in the same sandbox
         4. Post reward_info for the framework reward path
     """
-    tools_kwargs = tools_kwargs or {}
+    if tools_kwargs is None:
+        tools_kwargs = {}
+    elif not isinstance(tools_kwargs, Mapping):
+        raise TypeError(f"tools_kwargs must be a mapping, got {type(tools_kwargs).__name__}")
     logger.info("claude_code_runner called, sample_index=%d", sample_index)
 
     task = build_claude_task(raw_prompt, tools_kwargs)
-    env_config = tools_kwargs.get("env", {})
-    if not env_config:
-        env_config = _get_task_config(tools_kwargs).get("sandbox", {})
+    if "task" in tools_kwargs:
+        task_config = tools_kwargs["task"]
+        if not isinstance(task_config, Mapping):
+            raise TypeError(f"tools_kwargs.task must be a mapping, got {type(task_config).__name__}")
+        task_name = task_config.get("name")
+        env_config = task_config.get("sandbox", {})
+        env_path = "tools_kwargs.task.sandbox"
+    else:
+        task_name = None
+        env_config = tools_kwargs.get("env", {})
+        env_path = "tools_kwargs.env"
+
+    if not isinstance(env_config, Mapping):
+        raise TypeError(f"{env_path} must be a mapping, got {type(env_config).__name__}")
+
     image = extract_image(env_config)
     if not image:
-        raise ValueError(
-            f"No Docker image found in tools_kwargs.env or tools_kwargs.task.sandbox for sample {sample_index}"
-        )
+        raise ValueError(f"No Docker image found in {env_path} for sample {sample_index}")
 
     gateway_url = session.base_url
     if not gateway_url:
@@ -288,6 +312,10 @@ async def claude_code_runner(
     )
 
     try:
+        if task_name == "swe_rebench":
+            # Match SWEREBenchTask.run(): remove future history before the agent reads the repo.
+            await sandbox.exec_shell(_SWE_REBENCH_GIT_CLEAN_HISTORY, workdir="/testbed")
+
         post_setup_cmd = env_config.get("post_setup_cmd", "")
         if post_setup_cmd:
             setup_result = await sandbox.exec_shell(post_setup_cmd, timeout=120)

--- a/examples/blackbox_recipes/claude_code/claude_code_runner.py
+++ b/examples/blackbox_recipes/claude_code/claude_code_runner.py
@@ -15,6 +15,7 @@ import logging
 import os
 import shlex
 import time
+from collections.abc import Mapping
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -112,10 +113,25 @@ def _decode_metadata_list(value) -> list[str]:
     return [str(value)]
 
 
+def _get_task_config(tools_kwargs: dict | None) -> dict:
+    tools_kwargs = tools_kwargs or {}
+    task_config = tools_kwargs.get("task", {})
+    return dict(task_config) if isinstance(task_config, Mapping) else {}
+
+
+def _get_reward_metadata(tools_kwargs: dict | None) -> dict:
+    tools_kwargs = tools_kwargs or {}
+    reward_metadata = ((tools_kwargs.get("reward") or {}).get("metadata") or {})
+    if isinstance(reward_metadata, Mapping) and reward_metadata:
+        return dict(reward_metadata)
+    task_metadata = _get_task_config(tools_kwargs).get("metadata", {})
+    return dict(task_metadata) if isinstance(task_metadata, Mapping) else {}
+
+
 def build_claude_task(raw_prompt, tools_kwargs: dict | None = None) -> str:
     tools_kwargs = tools_kwargs or {}
     task = extract_task(raw_prompt)
-    metadata = (tools_kwargs.get("reward") or {}).get("metadata") or {}
+    metadata = _get_reward_metadata(tools_kwargs)
     issue = metadata.get("problem_statement") or _extract_issue_text(task)
     tests = _decode_metadata_list(metadata.get("FAIL_TO_PASS"))
     if not tests:
@@ -252,9 +268,13 @@ async def claude_code_runner(
 
     task = build_claude_task(raw_prompt, tools_kwargs)
     env_config = tools_kwargs.get("env", {})
+    if not env_config:
+        env_config = _get_task_config(tools_kwargs).get("sandbox", {})
     image = extract_image(env_config)
     if not image:
-        raise ValueError(f"No Docker image found in tools_kwargs.env for sample {sample_index}")
+        raise ValueError(
+            f"No Docker image found in tools_kwargs.env or tools_kwargs.task.sandbox for sample {sample_index}"
+        )
 
     gateway_url = session.base_url
     if not gateway_url:

--- a/examples/blackbox_recipes/claude_code/dataset.py
+++ b/examples/blackbox_recipes/claude_code/dataset.py
@@ -30,14 +30,32 @@ class SWEBenchDataset(RLHFDataset):
     def __getitem__(self, item):
         row_dict = super().__getitem__(item)
         extra_info = row_dict.get("extra_info", {})
-        tools_kwargs = extra_info.get("tools_kwargs", {})
-        reward_config = tools_kwargs.get("reward", {})
-        task_config = tools_kwargs.get("task", {})
-        task_config = task_config if isinstance(task_config, Mapping) else {}
-        task_metadata = task_config.get("metadata", {}) if isinstance(task_config.get("metadata", {}), Mapping) else {}
+        if not isinstance(extra_info, Mapping):
+            raise TypeError(f"extra_info must be a mapping, got {type(extra_info).__name__}")
 
-        data_source = row_dict.get("data_source") or reward_config.get("name") or task_config.get("name") or "unknown"
-        row_dict["data_source"] = data_source
-        row_dict.setdefault("reward_model", {"ground_truth": reward_config.get("metadata") or task_metadata})
+        tools_kwargs = extra_info.get("tools_kwargs", {})
+        if not isinstance(tools_kwargs, Mapping):
+            raise TypeError(f"extra_info.tools_kwargs must be a mapping, got {type(tools_kwargs).__name__}")
+
+        if "task" in tools_kwargs:
+            task_config = tools_kwargs["task"]
+            if not isinstance(task_config, Mapping):
+                raise TypeError(f"tools_kwargs.task must be a mapping, got {type(task_config).__name__}")
+            evaluator_name = task_config.get("name")
+            reward_metadata = task_config.get("metadata", {})
+            metadata_path = "tools_kwargs.task.metadata"
+        else:
+            reward_config = tools_kwargs.get("reward", {})
+            if not isinstance(reward_config, Mapping):
+                raise TypeError(f"tools_kwargs.reward must be a mapping, got {type(reward_config).__name__}")
+            evaluator_name = reward_config.get("name")
+            reward_metadata = reward_config.get("metadata", {})
+            metadata_path = "tools_kwargs.reward.metadata"
+
+        if not isinstance(reward_metadata, Mapping):
+            raise TypeError(f"{metadata_path} must be a mapping, got {type(reward_metadata).__name__}")
+
+        row_dict["data_source"] = row_dict.get("data_source") or evaluator_name or "unknown"
+        row_dict.setdefault("reward_model", {"ground_truth": reward_metadata})
 
         return row_dict

--- a/examples/blackbox_recipes/claude_code/dataset.py
+++ b/examples/blackbox_recipes/claude_code/dataset.py
@@ -1,8 +1,10 @@
-"""SWEBench-specific dataset that injects verl-standard reward fields.
+"""SWE-bench-like dataset that injects verl-standard reward fields.
 
 Self-contained for the claude-code recipe; mirrors the mini-swe-agent dataset
 so claude_code/ does not depend on mini_swe_agent/.
 """
+
+from collections.abc import Mapping
 
 from verl.utils.dataset.rl_dataset import RLHFDataset
 
@@ -30,8 +32,12 @@ class SWEBenchDataset(RLHFDataset):
         extra_info = row_dict.get("extra_info", {})
         tools_kwargs = extra_info.get("tools_kwargs", {})
         reward_config = tools_kwargs.get("reward", {})
+        task_config = tools_kwargs.get("task", {})
+        task_config = task_config if isinstance(task_config, Mapping) else {}
+        task_metadata = task_config.get("metadata", {}) if isinstance(task_config.get("metadata", {}), Mapping) else {}
 
-        row_dict.setdefault("data_source", reward_config.get("name", "unknown"))
-        row_dict.setdefault("reward_model", {"ground_truth": {}})
+        data_source = row_dict.get("data_source") or reward_config.get("name") or task_config.get("name") or "unknown"
+        row_dict["data_source"] = data_source
+        row_dict.setdefault("reward_model", {"ground_truth": reward_config.get("metadata") or task_metadata})
 
         return row_dict

--- a/examples/blackbox_recipes/claude_code/reward.py
+++ b/examples/blackbox_recipes/claude_code/reward.py
@@ -18,37 +18,33 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-_SWE_BENCH_ALIASES = {
-    "swe_bench",
-    "swebench",
-    "princeton-nlp/swe-bench_verified",
-}
-_SWE_REBENCH_ALIASES = {
-    "swe_rebench",
-    "swerebench",
-    "nebius/swe-rebench",
-}
-
-
-def _normalize_data_source(data_source: str) -> str:
-    normalized = data_source.strip().lower()
-    if normalized in _SWE_BENCH_ALIASES:
-        return "swe_bench"
-    elif normalized in _SWE_REBENCH_ALIASES:
-        return "swe_rebench"
-    else:
-        return normalized
-
 
 def build_reward_context(tools_kwargs: dict) -> tuple[dict[str, Any], int]:
     """Extract reward metadata and eval_timeout from per-sample tools_kwargs."""
-    reward_config = tools_kwargs.get("reward", {})
-    task_config = tools_kwargs.get("task", {})
-    task_config = task_config if isinstance(task_config, Mapping) else {}
-    task_metadata = task_config.get("metadata", {}) if isinstance(task_config.get("metadata", {}), Mapping) else {}
+    if not isinstance(tools_kwargs, Mapping):
+        raise TypeError(f"tools_kwargs must be a mapping, got {type(tools_kwargs).__name__}")
+
+    if "task" in tools_kwargs:
+        task_config = tools_kwargs["task"]
+        if not isinstance(task_config, Mapping):
+            raise TypeError(f"tools_kwargs.task must be a mapping, got {type(task_config).__name__}")
+        evaluator_name = task_config.get("name")
+        reward_metadata = task_config.get("metadata", {})
+        metadata_path = "tools_kwargs.task.metadata"
+    else:
+        reward_config = tools_kwargs.get("reward", {})
+        if not isinstance(reward_config, Mapping):
+            raise TypeError(f"tools_kwargs.reward must be a mapping, got {type(reward_config).__name__}")
+        evaluator_name = reward_config.get("name")
+        reward_metadata = reward_config.get("metadata", {})
+        metadata_path = "tools_kwargs.reward.metadata"
+
+    if not isinstance(reward_metadata, Mapping):
+        raise TypeError(f"{metadata_path} must be a mapping, got {type(reward_metadata).__name__}")
+
     metadata = {
-        "data_source": reward_config.get("name") or task_config.get("name") or "unknown",
-        "reward_model": reward_config.get("metadata") or task_metadata,
+        "evaluator": evaluator_name or "unknown",
+        "reward_model": reward_metadata,
     }
     eval_timeout = int(os.environ.get("SWE_AGENT_EVAL_TIMEOUT", "600"))
     return metadata, eval_timeout
@@ -72,20 +68,17 @@ async def evaluate_in_env(
     Returns (score, eval_result) where score is 1.0/0.0 and
     eval_result contains details (eval_completed, resolved, etc.).
     """
-    data_source = metadata.get("data_source", "unknown")
-    reward_model = metadata.get("reward_model", {}) or {}
+    evaluator = metadata.get("evaluator", "unknown")
+    reward_model = metadata.get("reward_model", {})
     if not isinstance(reward_model, Mapping):
-        reward_model = {}
+        raise TypeError(f"reward metadata must be a mapping, got {type(reward_model).__name__}")
 
-    normalized_data_source = _normalize_data_source(str(data_source))
-    if normalized_data_source == "swe_bench":
+    if evaluator == "swe_bench":
         from uni_agent.tasks.swe_bench.reward import compute_reward
-    elif normalized_data_source == "swe_rebench":
+    elif evaluator == "swe_rebench":
         from uni_agent.tasks.swe_rebench.reward import compute_reward
     else:
-        raise ValueError(
-            f"Unsupported reward data source: {data_source}. Supported: swe_bench, swe_rebench"
-        )
+        raise ValueError(f"Unsupported reward evaluator: {evaluator}. Supported: swe_bench, swe_rebench")
 
     spec_metadata = reward_model.get("ground_truth", reward_model)
     result = await compute_reward(spec_metadata, env, eval_timeout=eval_timeout)

--- a/examples/blackbox_recipes/claude_code/reward.py
+++ b/examples/blackbox_recipes/claude_code/reward.py
@@ -13,17 +13,42 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Mapping
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+_SWE_BENCH_ALIASES = {
+    "swe_bench",
+    "swebench",
+    "princeton-nlp/swe-bench_verified",
+}
+_SWE_REBENCH_ALIASES = {
+    "swe_rebench",
+    "swerebench",
+    "nebius/swe-rebench",
+}
+
+
+def _normalize_data_source(data_source: str) -> str:
+    normalized = data_source.strip().lower()
+    if normalized in _SWE_BENCH_ALIASES:
+        return "swe_bench"
+    elif normalized in _SWE_REBENCH_ALIASES:
+        return "swe_rebench"
+    else:
+        return normalized
 
 
 def build_reward_context(tools_kwargs: dict) -> tuple[dict[str, Any], int]:
     """Extract reward metadata and eval_timeout from per-sample tools_kwargs."""
     reward_config = tools_kwargs.get("reward", {})
+    task_config = tools_kwargs.get("task", {})
+    task_config = task_config if isinstance(task_config, Mapping) else {}
+    task_metadata = task_config.get("metadata", {}) if isinstance(task_config.get("metadata", {}), Mapping) else {}
     metadata = {
-        "data_source": reward_config.get("name", "unknown"),
-        "reward_model": reward_config.get("metadata", {}),
+        "data_source": reward_config.get("name") or task_config.get("name") or "unknown",
+        "reward_model": reward_config.get("metadata") or task_metadata,
     }
     eval_timeout = int(os.environ.get("SWE_AGENT_EVAL_TIMEOUT", "600"))
     return metadata, eval_timeout
@@ -48,12 +73,19 @@ async def evaluate_in_env(
     eval_result contains details (eval_completed, resolved, etc.).
     """
     data_source = metadata.get("data_source", "unknown")
-    reward_model = metadata.get("reward_model", {})
+    reward_model = metadata.get("reward_model", {}) or {}
+    if not isinstance(reward_model, Mapping):
+        reward_model = {}
 
-    if data_source != "swe_bench":
-        raise ValueError(f"Unsupported reward data source: {data_source}")
-
-    from uni_agent.tasks.swe_bench.reward import compute_reward
+    normalized_data_source = _normalize_data_source(str(data_source))
+    if normalized_data_source == "swe_bench":
+        from uni_agent.tasks.swe_bench.reward import compute_reward
+    elif normalized_data_source == "swe_rebench":
+        from uni_agent.tasks.swe_rebench.reward import compute_reward
+    else:
+        raise ValueError(
+            f"Unsupported reward data source: {data_source}. Supported: swe_bench, swe_rebench"
+        )
 
     spec_metadata = reward_model.get("ground_truth", reward_model)
     result = await compute_reward(spec_metadata, env, eval_timeout=eval_timeout)


### PR DESCRIPTION
## Summary

Fix the Claude Code blackbox training recipe so that it can consume the
task-shaped SWE-rebench dataset already produced and selected by current
Uni-Agent main.

The current Claude Code training script defaults to
`swe_rebench_filtered.parquet`, while the recipe still reads the legacy
`tools_kwargs.reward` / `tools_kwargs.env` shape and rejects every reward
data source other than `swe_bench`.

The canonical SWE-rebench preprocessor stores the task name, metadata, and
sandbox image under `extra_info.tools_kwargs.task`. As a result, the
default training configuration and the recipe data contract are currently
inconsistent.

## Changes

- Teach the Claude Code dataset adapter to read task name and metadata from
  `tools_kwargs.task`, while preserving the legacy `tools_kwargs.reward`
  format.
- Teach the runner to read task metadata and sandbox configuration from
  `tools_kwargs.task`.
- Route SWE-rebench evaluation to the existing
  `uni_agent.tasks.swe_rebench.reward.compute_reward` implementation.
- Preserve the existing SWE-bench evaluator and fail explicitly for unknown
  task types.

## Owning layer

This is an examples-layer compatibility fix.

Reward policy remains owned by the Task layer. The Claude Code recipe only
selects the existing task-level evaluator, following the same adapter
pattern already used for SWE-bench by #91.

## Why this is needed

Current main contains all three of the following:

1. `run_train.sh` defaults to `swe_rebench_filtered.parquet`.
2. `uni_agent.tasks.swe_rebench.preprocess` emits
   `tools_kwargs.task`.
3. The Claude Code recipe only consumes `tools_kwargs.reward` and rejects
   `swe_rebench`.

Therefore, a dataset generated by the canonical preprocessor cannot be
consumed by the default Claude Code training configuration.

Removing the unsupported-source check would not be sufficient: the recipe
must also extract the task metadata and dispatch to the correct existing
reward evaluator.
<img width="1032" height="316" alt="PixPin_2026-07-29_18-32-24" src="https://github.com/user-attachments/assets/03c3a49e-18b5-4346-8b47-a1d164a55e7d" />


## Compatibility

No public API or dataset migration is required.

Legacy rows using `tools_kwargs.reward` and `tools_kwargs.env` continue to
work. Current task-shaped rows are added as a fallback. Existing SWE-bench
evaluation remains unchanged, and unknown task types continue to fail
closed.