### PR TITLE
[gateway, framework] fix: propagate gateway-reported weight versions to trajectories

### DIFF
--- a/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
+++ b/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
@@ -607,6 +607,8 @@ async def test_generate_sequences_writes_tq_schema_for_each_session(monkeypatch,
     assert "length_truncated" not in tag
     assert "traj_exit_reason" not in tag
     assert "materialization_reason" not in fields
+    # No gateway-reported weight version, so both fall back to the dataloader step.
+    assert (tag["min_global_steps"], tag["max_global_steps"]) == (7, 7)
     assert fields["input_ids"].is_nested
     assert fields["response_mask"].is_nested
     assert fields["position_ids"].is_nested

--- a/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
+++ b/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
@@ -105,6 +105,22 @@ class _LogprobBackend:
         return TokenOutput(token_ids=token_ids, log_probs=log_probs, stop_reason="completed")
 
 
+class _VersionedBackend:
+    def __init__(self, steps):
+        # steps: list of (text, min_global_steps, max_global_steps)
+        self.steps = list(steps)
+
+    async def generate(self, request_id, *, prompt_ids, sampling_params, image_data=None, video_data=None):
+        text, min_steps, max_steps = self.steps.pop(0)
+        token_ids = _ids(text)
+        return TokenOutput(
+            token_ids=token_ids,
+            log_probs=[-0.1] * len(token_ids),
+            stop_reason="completed",
+            extra_fields={"min_global_steps": min_steps, "max_global_steps": max_steps},
+        )
+
+
 class _ControlledParallelBackend:
     def __init__(self, steps):
         self.steps = list(steps)
@@ -1642,3 +1658,74 @@ async def test_multiple_chains_invalid_continuation_logprobs_release_chain_for_r
     assert "SECOND" not in _decode_response_ids(trajectory.response_ids)
     assert trajectory.response_logprobs is not None
     assert len(trajectory.response_logprobs) == len(trajectory.response_ids)
+
+
+@pytest.mark.asyncio
+async def test_weight_versions_span_every_generation_in_a_chain():
+    """Report the full weight-version span a multi-turn chain was generated across."""
+    session = _session("versions-multi-turn")
+    first_messages = [{"role": "user", "content": "first turn"}]
+    continuation = [
+        *first_messages,
+        {"role": "assistant", "content": "FIRST"},
+        {"role": "user", "content": "follow up"},
+    ]
+
+    # Second generation resumed across versions 4-5 (partial rollout).
+    await _run(session, _VersionedBackend([("FIRST", 3, 3)]), first_messages)
+    await _run(session, _VersionedBackend([("SECOND", 4, 5)]), continuation)
+    [trajectory] = await session.finalize()
+
+    assert trajectory.extra_fields["min_global_steps"] == 3
+    assert trajectory.extra_fields["max_global_steps"] == 5
+
+
+@pytest.mark.asyncio
+async def test_weight_versions_stay_independent_across_split_chains():
+    """Keep each chain's version span separate when a request splits a new chain."""
+    session = _session("versions-split")
+    first_messages = [{"role": "user", "content": "base"}]
+
+    await _run(session, _VersionedBackend([("BASE", 3, 3)]), first_messages)
+    await _run(session, _VersionedBackend([("FRESH", 7, 7)]), first_messages)
+    assert session.snapshot_state()["active_chain_ids"] == [1, 2]
+    trajectories = await session.finalize()
+
+    spans = {
+        _decode_response_ids(trajectory.response_ids): (
+            trajectory.extra_fields["min_global_steps"],
+            trajectory.extra_fields["max_global_steps"],
+        )
+        for trajectory in trajectories
+    }
+    assert spans == {"BASE": (3, 3), "FRESH": (7, 7)}
+
+
+@pytest.mark.asyncio
+async def test_weight_versions_drop_rolled_back_generations():
+    """Exclude a rolled-back assistant's version from the surviving trajectory's span."""
+    session = _session("versions-rollback", enable_last_assistant_rollback=True)
+    first_messages = [{"role": "user", "content": "run mini-swe"}]
+    rewrite_messages = [
+        *first_messages,
+        {"role": "user", "content": "user_error: missing import"},
+    ]
+
+    await _run(session, _VersionedBackend([("FORMAT_ERROR", 5, 5)]), first_messages)
+    await _run(session, _VersionedBackend([("FIXED", 7, 7)]), rewrite_messages)
+    [trajectory] = await session.finalize()
+
+    # Version 5 produced only the dropped assistant, so it must not widen the span.
+    assert trajectory.extra_fields["min_global_steps"] == 7
+    assert trajectory.extra_fields["max_global_steps"] == 7
+
+
+@pytest.mark.asyncio
+async def test_weight_versions_absent_when_backend_omits_them():
+    """Omit the version keys rather than materializing None for version-less backends."""
+    session = _session("versions-absent")
+
+    await _run(session, SequencedBackend(["ONLY"]), [{"role": "user", "content": "base"}])
+    [trajectory] = await session.finalize()
+
+    assert trajectory.extra_fields == {}

--- a/uni_agent/framework/framework.py
+++ b/uni_agent/framework/framework.py
@@ -980,6 +980,9 @@ class OpenAICompatibleAgentFramework(AgentFramework):
         prompt_len = prompts.size(0)
         response_len = responses.size(0)
 
+        # The gateway reports the weight versions a trajectory spanned. Fall back to
+        # the dataloader step only when absent (backends that report no version):
+        # the trainer casts these tags with dtype=int, so None must not reach it.
         min_global_steps = trajectory.extra_fields.get("min_global_steps", global_steps)
         max_global_steps = trajectory.extra_fields.get("max_global_steps", global_steps)
         tag = {

--- a/uni_agent/gateway/session/session.py
+++ b/uni_agent/gateway/session/session.py
@@ -47,6 +47,11 @@ class TrajectoryBuffer:
             spanning ``prompt + response``. The backend re-prefills the full
             context each turn, so this is replaced (not accumulated) and the final
             value covers the whole sequence (mirrors verl's tool_agent_loop).
+        generation_versions: One ``(min_global_steps, max_global_steps)`` mark
+            per generation, in generation order. Rollback drops the last mark
+            with the tokens it describes, so a dropped assistant no longer
+            widens the trajectory's version span. Marks carry ``None`` when the
+            backend reports no version.
     """
 
     prompt_ids: list[int]
@@ -54,6 +59,7 @@ class TrajectoryBuffer:
     response_mask: list[int] = field(default_factory=list)
     response_logprobs: list[float] = field(default_factory=list)
     routed_experts: Any | None = None
+    generation_versions: list[tuple[int | None, int | None]] = field(default_factory=list)
 
 
 @dataclass
@@ -264,6 +270,12 @@ class GatewaySession:
                 raise HTTPException(status_code=500, detail=f"{e.__class__.__name__}: {e}") from e
 
             response_ids = list(output.token_ids)
+            encoded.buffer.generation_versions.append(
+                (
+                    output.extra_fields.get("min_global_steps"),
+                    output.extra_fields.get("max_global_steps"),
+                )
+            )
             encoded.buffer.response_ids.extend(response_ids)
             encoded.buffer.response_mask.extend([1] * len(response_ids))
             if encoded.sampling_params.get("logprobs", False):
@@ -412,6 +424,9 @@ class GatewaySession:
                 del buffer.response_ids[last_assistant_start.response_ids_len :]
                 del buffer.response_mask[last_assistant_start.response_mask_len :]
                 del buffer.response_logprobs[last_assistant_start.response_logprobs_len :]
+                # One generation appends exactly one mark, so the rewritten
+                # assistant is always the last one.
+                del buffer.generation_versions[-1:]
                 self._assert_response_logprob_alignment(buffer)
 
                 if image_data is not None:
@@ -608,6 +623,7 @@ class GatewaySession:
             response_mask=list(buffer.response_mask),
             response_logprobs=list(buffer.response_logprobs),
             routed_experts=buffer.routed_experts,
+            generation_versions=list(buffer.generation_versions),
         )
 
     def _copy_chain_media(self, chain: ChainState) -> tuple[list[Any] | None, list[Any] | None]:
@@ -760,6 +776,16 @@ class GatewaySession:
         response_logprobs = None
         if chain.buffer.response_logprobs:
             response_logprobs = list(chain.buffer.response_logprobs)
+        # Fold the surviving marks into the trajectory-level version span the trainer
+        # reads for staleness metrics. Omit the keys when no backend reported a
+        # version so the framework falls back instead of tagging None.
+        marks = [mark for mark in chain.buffer.generation_versions if mark[0] is not None]
+        trajectory_extra_fields: dict[str, Any] = {}
+        if marks:
+            trajectory_extra_fields["min_global_steps"] = min(mark[0] for mark in marks)
+            trajectory_extra_fields["max_global_steps"] = max(mark[1] for mark in marks)
+        if extra_fields:
+            trajectory_extra_fields.update(extra_fields)
         return Trajectory(
             prompt_ids=list(chain.buffer.prompt_ids),
             response_ids=list(chain.buffer.response_ids),
@@ -772,7 +798,7 @@ class GatewaySession:
                 chain.image_data,
                 chain.video_data,
             ),
-            extra_fields=dict(extra_fields) if extra_fields else {},
+            extra_fields=trajectory_extra_fields,
         )
 
     def _count_chat_turns(self, message_history: list[dict[str, Any]]) -> int:

--- a/uni_agent/gateway/session/types.py
+++ b/uni_agent/gateway/session/types.py
@@ -60,7 +60,8 @@ class Trajectory:
         routed_experts: Optional expert-routing data captured by the backend.
         multi_modal_data: Optional image/video data associated with the prompt.
         extra_fields: Gateway-owned extension fields, such as trajectory
-            materialization metadata consumed by training adapters.
+            materialization metadata consumed by training adapters and the
+            ``min_global_steps``/``max_global_steps`` weight-version span.
     """
 
     prompt_ids: list[int]


### PR DESCRIPTION
## Summary

Gateway never propagated backend-reported weight versions (`min_global_steps` / `max_global_steps`) to the training side, causing off-policy staleness metrics to report constant values regardless of actual lag.

`GatewaySession.run_generation` discarded `output.extra_fields`, so `framework.py` always fell back to using the dataloader step, resulting in `trajectory_spans ≡ 1` and `trajectory_staleness ≡ -1`. This is a silent observability defect: no errors, no sample loss, no training corruption—only metrics humans use to tune `max_off_policy_threshold` / `staleness_threshold` are wrong.

Trigger: `agent_loop_manager_class=AgentFrameworkRolloutAdapter` + async/partial rollout. Synchronous on-policy training masks the symptom (real values happen to equal dataloader step).

Present since Gateway anchor `862314f` (PR #25).

## Changes

- **`uni_agent/gateway/session/session.py`**: `TrajectoryBuffer` gains `generation_versions: list[tuple[int | None, int | None]]`. Each `run_generation` appends one `(min, max)` mark; `_build_materialized_trajectory` folds them into `trajectory.extra_fields["min_global_steps"]` / `["max_global_steps"]`. Last-assistant rollback (PR #88) deletes the rewritten generation's mark with `del [-1:]` to prevent stale versions from inflating the span. Backend-reported `None` is filtered out so `framework.py` fallback semantics stay intact.
- **`uni_agent/framework/framework.py`**: Comment explaining why fallback to dataloader step is mandatory (`trainer_base.py` uses `dtype=int`, cannot handle `None`).
- **`uni_agent/gateway/session/types.py`**: Docstring update for `Trajectory.extra_fields`.

Key invariant: one `run_generation` appends exactly one mark, so rollback of the last assistant drops exactly the last mark. This keeps the trajectory-level span synchronized with surviving tokens.

## Validation

**Tests** (4 new + 1 augmented):

- `tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py`: new `_VersionedBackend` fake + 4 cases
  - `test_weight_versions_span_every_generation_in_a_chain` — multi-turn (3,3) → (4,5) folds to [3,5]
  - `test_weight_versions_stay_independent_across_split_chains` — split chains keep separate spans
  - `test_weight_versions_drop_rolled_back_generations` — (5,5) rolled back, regenerated (7,7) → min must be 7
  - `test_weight_versions_absent_when_backend_omits_them` — `extra_fields == {}` when backend reports no version
- `tests/uni_agent/framework/test_generate_sequences_on_cpu.py`:
  - Augmented existing `test_generate_sequences_writes_tq_schema_for_each_session` with fallback assertion

**Results**:

- Gateway session + gateway actor + framework suites: `121 passed`
- `pre-commit run --all-files`: `4/4 Passed` (ruff, ruff format, mypy, compile)
## Compatibility

None. Adds optional keys to `trajectory.extra_fields` that already have fallback consumers. Existing trajectories without these keys continue to work (framework falls back to dataloader step as before).

Cherry-pick friendly: only depends on `TokenOutput.extra_fields` and trainer tag contract. Target versions without last-assistant rollback can omit the `del buffer.generation_versions[-1:]` block.