### PR TITLE
[examples, docs] feat: add NPU RL training recipe for Qwen3-Coder-30B

### DIFF
--- a/docs/source/quickstart/npu-training.md
+++ b/docs/source/quickstart/npu-training.md
@@ -1,0 +1,70 @@
+# Run Training on NPU
+
+Uni-Agent runs the same Agent workflow on Ascend NPUs. The recipe uses VeOmni as the training engine for better NPU support.
+
+This guide trains `Qwen3-Coder-30B-A3B-Instruct` with the white-box `ReAct Agent`.
+
+## Prerequisites
+
+- An Ascend NPU environment with `torch_npu` and `vllm_ascend`. See the [verl Ascend Tutorial](https://github.com/verl-project/verl/blob/main/docs/ascend_tutorial/README.md) for image builds and installation.
+- [VeOmni](https://github.com/ByteDance-Seed/VeOmni), which provides the training engine this recipe runs on:
+
+    ```bash
+    pip3 install --no-deps "git+https://github.com/ByteDance-Seed/VeOmni.git@main"
+    ```
+
+- Datasets, Task Config, and Ray Runtime Environment prepared as described in [Run Agent RL Training](rl-training.md). 
+
+## Launch Training
+
+Set the shared data and runtime root, then launch from the repository root:
+
+```bash
+RAY_DATA_HOME=/path/to/data \
+NNODES=16 \
+NGPUS_PER_NODE=16 \
+USP_SIZE=16 \
+EXPERT_SIZE=8 \
+GEN_TP=4 \
+CONCURRENCY=1024 \
+TRAIN_PROMPT_BSZ=64 \
+N_RESP_PER_PROMPT=16 \
+PPO_MINI_BATCH_SIZE=16 \
+TASK_CONFIG=examples/quickstart/training/task_config_react.yaml \
+EXP_NAME=react_qwen3_coder_30b_npu_gspo \
+ADV_ESTIMATOR=grpo \
+LOSS_MODE=gspo \
+ROLLOUT_IS=token \
+TEST_FREQ=-1 \
+bash examples/quickstart/training/train_npu_qwen3_moe.sh
+```
+
+The default layout is:
+
+```text
+<RAY_DATA_HOME>/
+├── models/Qwen3-Coder-30B-A3B-Instruct/
+├── data/uni_agent/
+│   ├── swe_rebench_filtered_1150.parquet
+│   ├── swe_bench_verified.parquet
+│   └── runtime_env.yaml
+├── ckpts/
+└── logs/
+```
+
+Override `MODEL_PATH`, `TRAIN_FILE`, `TEST_FILE`, `RUNTIME_ENV`, or `TASK_CONFIG` when your layout differs.
+
+The recipe sets `trainer.device=npu`, runs the actor with `model_engine=veomni` (full-shard FSDP with `USP_SIZE` Ulysses and `EXPERT_SIZE` expert parallelism), and selects the NPU kernel backends `moe_implementation=fused_npu`, `rms_norm_implementation=npu`, and `rotary_pos_emb_implementation=npu`. 
+
+## Monitor the Run
+
+Checkpoints and per-session Agent logs are written under:
+
+```text
+<RAY_DATA_HOME>/ckpts/Uni-Agent-Qwen3-Coder-30B-veomni-npu-colocate/<EXP_NAME>/
+<RAY_DATA_HOME>/logs/Uni-Agent-Qwen3-Coder-30B-veomni-npu-colocate/<EXP_NAME>/
+```
+
+## Results
+
+_To be added._

--- a/examples/quickstart/training/train_npu_qwen3_moe.sh
+++ b/examples/quickstart/training/train_npu_qwen3_moe.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+NNODES=${NNODES:-16}
+NGPUS_PER_NODE=${NGPUS_PER_NODE:-16}
+
+project_name=${PROJECT_NAME:-"Uni-Agent-Qwen3-Coder-30B-veomni-npu-colocate"}
+exp_name=${EXP_NAME:-"$(date +%Y%m%d%H%M)_exp"}
+
+RAY_DATA_HOME=${RAY_DATA_HOME:-"${HOME}/verl"}
+MODEL_PATH=${MODEL_PATH:-"${RAY_DATA_HOME}/models/Qwen3-Coder-30B-A3B-Instruct"}
+CKPTS_DIR=${CKPTS_DIR:-"${RAY_DATA_HOME}/ckpts/${project_name}/${exp_name}"}
+AGENT_LOG_DIR=${AGENT_LOG_DIR:-"${RAY_DATA_HOME}/logs/${project_name}/${exp_name}"}
+TRAIN_FILE=${TRAIN_FILE:-"${RAY_DATA_HOME}/data/uni_agent/swe_rebench_filtered_1150.parquet"}
+TEST_FILE=${TEST_FILE:-"${RAY_DATA_HOME}/data/uni_agent/swe_bench_verified.parquet"}
+RUNTIME_ENV=${RUNTIME_ENV:-"${RAY_DATA_HOME}/data/uni_agent/runtime_env.yaml"}
+
+TASK_CONFIG=${TASK_CONFIG:-"examples/quickstart/training/task_config_react.yaml"}
+TOOL_PARSER=${TOOL_PARSER:-"qwen3_coder"}
+GATEWAY_COUNT=${GATEWAY_COUNT:-8}
+CONCURRENCY=${CONCURRENCY:-1024}
+SERVED_MODEL_NAME=${SERVED_MODEL_NAME:-"$(basename "${MODEL_PATH}")"}
+
+rollout_mode=${ROLLOUT_MODE:-"async"}
+rollout_name=${ROLLOUT_NAME:-"vllm"}
+
+# Algorithm parameters.
+adv_estimator=${ADV_ESTIMATOR:-grpo}
+use_kl_in_reward=${USE_KL_IN_REWARD:-False}
+kl_coef=${KL_COEF:-0.0}
+use_kl_loss=${USE_KL_LOSS:-False}
+kl_loss_coef=${KL_LOSS_COEF:-0.0}
+clip_ratio_low=${CLIP_RATIO_LOW:-4e-4}
+clip_ratio_high=${CLIP_RATIO_HIGH:-4e-4}
+loss_agg_mode=${LOSS_AGG_MODE:-"token-mean"}
+loss_mode=${LOSS_MODE:-gspo}
+
+# Response length parameters
+max_prompt_length=${MAX_PROMPT_LENGTH:-$((1024 * 8))}
+max_response_length=${MAX_RESPONSE_LENGTH:-$((1024 * 128))}
+enable_overlong_buffer=${ENABLE_OVERLONG_BUFFER:-False}
+overlong_buffer_len=${OVERLONG_BUFFER_LEN:-$((1024 * 4))}
+overlong_penalty_factor=${OVERLONG_PENALTY_FACTOR:-1.0}
+
+# Algorithm
+temperature=${TEMPERATURE:-1.0}
+top_p=${TOP_P:-1.0}
+top_k=${TOP_K:--1}
+val_temperature=${VAL_TEMPERATURE:-1.0}
+val_top_p=${VAL_TOP_P:-0.95}
+val_top_k=${VAL_TOP_K:--1}
+
+# VeOmni and rollout parallelism.
+use_remove_padding=${USE_REMOVE_PADDING:-True}
+use_dynamic_bsz=${USE_DYNAMIC_BSZ:-True}
+offload=${OFFLOAD:-True}
+usp_size=${USP_SIZE:-16}
+expert_size=${EXPERT_SIZE:-8}
+gen_tp=${GEN_TP:-4}
+infer_dp=${INFER_DP:-1}
+infer_ep=${INFER_EP:-1}
+actor_ppo_max_token_len=$(((max_prompt_length + max_response_length) / usp_size))
+infer_ppo_max_token_len=$(((max_prompt_length + max_response_length) / usp_size))
+
+# V1 colocate_async batching.
+train_prompt_bsz=${TRAIN_PROMPT_BSZ:-64}
+n_resp_per_prompt=${N_RESP_PER_PROMPT:-16}
+train_prompt_mini_bsz=${PPO_MINI_BATCH_SIZE:-16}
+num_warmup_batches=${NUM_WARMUP_BATCHES:-1}
+test_freq=${TEST_FREQ:--1}
+
+# Decoupled PPO and rollout correction.
+bypass_mode=${BYPASS_MODE:-False}
+rollout_is=${ROLLOUT_IS:-token}
+rollout_is_threshold=${ROLLOUT_IS_THRESHOLD:-2.0}
+rollout_is_batch_normalize=${ROLLOUT_IS_BATCH_NORMALIZE:-False}
+rollout_rs=${ROLLOUT_RS:-null}
+rollout_rs_threshold=${ROLLOUT_RS_THRESHOLD:-"0.999_1.001"}
+
+# Router Replay remains opt-in for the NPU recipe.
+router_replay_mode=${ROUTER_REPLAY_MODE:-disabled}
+gpu_memory_utilization=${ROLLOUT_GPU_MEM_UTIL:-0.75}
+
+ray job submit --no-wait --runtime-env "$RUNTIME_ENV" \
+    -- python3 -m verl.trainer.main_ppo \
+    trainer.use_v1=True \
+    trainer.v1.trainer_mode=colocate_async \
+    trainer.v1.colocate_async.num_warmup_batches=${num_warmup_batches} \
+    transfer_queue.enable=True \
+    data.train_files="${TRAIN_FILE}" \
+    data.val_files="${TEST_FILE}" \
+    data.prompt_key=prompt \
+    data.filter_overlong_prompts=True \
+    data.truncation=error \
+    data.max_prompt_length=${max_prompt_length} \
+    data.max_response_length=${max_response_length} \
+    data.train_batch_size=${train_prompt_bsz} \
+    data.return_raw_chat=True \
+    actor_rollout_ref.rollout.n=${n_resp_per_prompt} \
+    actor_rollout_ref.actor.policy_loss.loss_mode=${loss_mode} \
+    algorithm.adv_estimator=${adv_estimator} \
+    algorithm.use_kl_in_reward=${use_kl_in_reward} \
+    algorithm.kl_ctrl.kl_coef=${kl_coef} \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.model.use_remove_padding=${use_remove_padding} \
+    actor_rollout_ref.actor.use_kl_loss=${use_kl_loss} \
+    actor_rollout_ref.actor.kl_loss_coef=${kl_loss_coef} \
+    actor_rollout_ref.actor.clip_ratio_low=${clip_ratio_low} \
+    actor_rollout_ref.actor.clip_ratio_high=${clip_ratio_high} \
+    actor_rollout_ref.actor.clip_ratio_c=10.0 \
+    actor_rollout_ref.actor.use_dynamic_bsz=${use_dynamic_bsz} \
+    actor_rollout_ref.actor.ppo_mini_batch_size=${train_prompt_mini_bsz} \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${actor_ppo_max_token_len} \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.optim.weight_decay=0.1 \
+    model_engine=veomni \
+    actor_rollout_ref.actor.veomni.param_offload=True \
+    actor_rollout_ref.actor.veomni.optimizer_offload=${offload} \
+    actor_rollout_ref.actor.veomni.enable_full_shard=True \
+    actor_rollout_ref.actor.veomni.ulysses_parallel_size=${usp_size} \
+    actor_rollout_ref.actor.veomni.expert_parallel_size=${expert_size} \
+    actor_rollout_ref.actor.veomni.moe_implementation=fused_npu \
+    actor_rollout_ref.actor.veomni.attn_implementation=flash_attention_2 \
+    actor_rollout_ref.actor.veomni.rms_norm_implementation=npu \
+    actor_rollout_ref.actor.veomni.rotary_pos_emb_implementation=npu \
+    actor_rollout_ref.actor.veomni.swiglu_mlp_implementation=eager \
+    actor_rollout_ref.actor.veomni.router_replay.mode=${router_replay_mode} \
+    algorithm.rollout_correction.bypass_mode=${bypass_mode} \
+    algorithm.rollout_correction.rollout_is=${rollout_is} \
+    algorithm.rollout_correction.rollout_is_threshold=${rollout_is_threshold} \
+    algorithm.rollout_correction.rollout_is_batch_normalize=${rollout_is_batch_normalize} \
+    algorithm.rollout_correction.rollout_rs=${rollout_rs} \
+    algorithm.rollout_correction.rollout_rs_threshold="${rollout_rs_threshold}" \
+    actor_rollout_ref.actor.entropy_coeff=0 \
+    actor_rollout_ref.actor.loss_agg_mode=${loss_agg_mode} \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=${infer_ppo_max_token_len} \
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=${use_dynamic_bsz} \
+    actor_rollout_ref.rollout.multi_turn.enable=True \
+    actor_rollout_ref.rollout.multi_turn.max_parallel_calls=1 \
+    ++actor_rollout_ref.rollout.multi_turn.format=${TOOL_PARSER} \
+    actor_rollout_ref.rollout.agent.num_workers=8 \
+    ++actor_rollout_ref.rollout.agent.agent_loop_manager_class=uni_agent.framework.entry.AgentFrameworkRolloutAdapter \
+    ++actor_rollout_ref.rollout.custom.agent_framework.gateway_count=${GATEWAY_COUNT} \
+    ++actor_rollout_ref.rollout.custom.agent_framework.log_dir=${AGENT_LOG_DIR} \
+    ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_fqn=uni_agent.framework.task_runner.run_task \
+    ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.dispatch_mode=ray_task \
+    ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.max_concurrent_sessions=${CONCURRENCY} \
+    ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_kwargs.task_config_path=${TASK_CONFIG} \
+    ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_kwargs.model_name=${SERVED_MODEL_NAME} \
+    ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_kwargs.report_reward=True \
+    ++actor_rollout_ref.rollout.custom.agent_framework.use_reward_loop_worker=False \
+    actor_rollout_ref.rollout.gpu_memory_utilization=${gpu_memory_utilization} \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=${gen_tp} \
+    actor_rollout_ref.rollout.data_parallel_size=${infer_dp} \
+    actor_rollout_ref.rollout.expert_parallel_size=${infer_ep} \
+    actor_rollout_ref.rollout.prompt_length=${max_prompt_length} \
+    actor_rollout_ref.rollout.response_length=${max_response_length} \
+    actor_rollout_ref.rollout.enable_chunked_prefill=True \
+    actor_rollout_ref.rollout.max_num_batched_tokens=$((max_prompt_length + max_response_length)) \
+    actor_rollout_ref.rollout.max_model_len=$((max_prompt_length + max_response_length)) \
+    actor_rollout_ref.rollout.temperature=${temperature} \
+    actor_rollout_ref.rollout.top_p=${top_p} \
+    actor_rollout_ref.rollout.top_k=${top_k} \
+    actor_rollout_ref.rollout.val_kwargs.temperature=${val_temperature} \
+    actor_rollout_ref.rollout.val_kwargs.top_p=${val_top_p} \
+    actor_rollout_ref.rollout.val_kwargs.top_k=${val_top_k} \
+    actor_rollout_ref.rollout.val_kwargs.do_sample=True \
+    actor_rollout_ref.rollout.val_kwargs.n=1 \
+    actor_rollout_ref.rollout.name=${rollout_name} \
+    actor_rollout_ref.rollout.mode=${rollout_mode} \
+    actor_rollout_ref.rollout.calculate_log_probs=True \
+    actor_rollout_ref.rollout.checkpoint_engine.update_weights_bucket_megabytes=4096 \
+    actor_rollout_ref.hybrid_engine=True \
+    actor_rollout_ref.nccl_timeout=9600 \
+    actor_rollout_ref.rollout.enforce_eager=False \
+    actor_rollout_ref.rollout.free_cache_engine=True \
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=${infer_ppo_max_token_len} \
+    reward.reward_manager.name=dapo \
+    +reward.reward_kwargs.overlong_buffer_cfg.enable=${enable_overlong_buffer} \
+    +reward.reward_kwargs.overlong_buffer_cfg.len=${overlong_buffer_len} \
+    +reward.reward_kwargs.overlong_buffer_cfg.penalty_factor=${overlong_penalty_factor} \
+    +reward.reward_kwargs.overlong_buffer_cfg.log=False \
+    +reward.reward_kwargs.max_resp_len=${max_response_length} \
+    trainer.critic_warmup=0 \
+    trainer.logger=['console','wandb'] \
+    trainer.project_name="${project_name}" \
+    trainer.experiment_name="${exp_name}" \
+    trainer.val_before_train=False \
+    trainer.device=npu \
+    trainer.save_freq=10 \
+    trainer.total_epochs=10 \
+    trainer.resume_mode=auto \
+    trainer.log_val_generations=10 \
+    trainer.default_local_dir="${CKPTS_DIR}" \
+    trainer.nnodes=${NNODES} \
+    trainer.n_gpus_per_node=${NGPUS_PER_NODE} \
+    trainer.test_freq=${test_freq} \
+    "$@"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - Launch a Sandbox: quickstart/launch-sandbox.md
       - Run Agent Inference: quickstart/agent-inference.md
       - Run Agent RL Training: quickstart/rl-training.md
+      - Run Training on NPU: quickstart/npu-training.md
   - Concepts:
       - Overview: concepts/index.md
       - Sandbox: concepts/sandbox.md


### PR DESCRIPTION
## Summary

Add the NPU training recipe. The recipe runs the actor on the VeOmni engine instead of Megatron and keeps the Task, Agent, Tool, Sandbox, Gateway, and Framework layers unchanged.

## Changes

### NPU recipe
- Adds `examples/quickstart/training/train_npu_qwen3_moe.sh` for `Qwen3-Coder-30B-A3B-Instruct` on SWE-reBench.
- Actor: `model_engine=veomni`, `trainer.device=npu`, full-shard FSDP with Ulysses 16 and expert parallelism 8, param/optimizer offload.
- NPU kernels: `moe_implementation=fused_npu`, `rms_norm_implementation=npu`, `rotary_pos_emb_implementation=npu`, `attn_implementation=flash_attention_2`.
- Rollout: async vLLM Ascend, `GEN_TP=4`, 128K response length, V1 `colocate_async` with transfer queue.

### Documentation
- Adds `docs/source/quickstart/npu-training.md`.

## Validation

- End-to-end NPU training result: To be added.
- `mkdocs build --strict`: passed.
- `pre-commit run --all-files --show-diff-on-failure`: passed.

## Compatibility

Prerequisite for running the recipe: the `verl` submodule must contain verl-project/verl#6993. 
