### PR TITLE
[examples] fix: align Claude Code sandbox proxy port

### DIFF
--- a/examples/blackbox_recipes/claude_code/README.md
+++ b/examples/blackbox_recipes/claude_code/README.md
@@ -116,6 +116,7 @@ agent_runner_fqn: examples.blackbox_recipes.claude_code.claude_code_runner.claud
 | `SWE_AGENT_EVAL_TIMEOUT` | `600` | Reward evaluation timeout (seconds) |
 | `SWE_AGENT_RUN_TIMEOUT` | `7200` | Max wall time for the claude process in the sandbox |
 | `CLAUDE_CODE_TOOL_IMAGE` | `swr.cn-east-3.myhuaweicloud.com/openyuanrong/claude-code-tool:latest` | Sidecar tool image |
+| `CLAUDE_CODE_PROXY_PORT` | `38197` | Sandbox-local reverse tunnel port shared by OpenYuanrong and `ANTHROPIC_BASE_URL` |
 | `CONDA_ENV` | `testbed` | Conda env activated inside the sandbox before running claude |
 
 `AGENT_MAX_TURNS` is the only knob that bounds the agent. The trainer's

--- a/examples/blackbox_recipes/claude_code/claude_code_runner.py
+++ b/examples/blackbox_recipes/claude_code/claude_code_runner.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_TOOL_IMAGE = "swr.cn-east-3.myhuaweicloud.com/openyuanrong/claude-code-tool:latest"
 TOOL_TARGET = "/opt/claude-code"
+DEFAULT_GATEWAY_PROXY_PORT = 38197
 
 
 def extract_upstream(gateway_url: str) -> str:
@@ -39,7 +40,7 @@ def extract_upstream(gateway_url: str) -> str:
 
 def rewrite_gateway_url(
     gateway_url: str,
-    proxy_port: int = 38197,
+    proxy_port: int = DEFAULT_GATEWAY_PROXY_PORT,
     *,
     strip_v1: bool = False,
 ) -> str:
@@ -209,6 +210,7 @@ async def _create_claude_sandbox(
     image: str,
     sidecar_image: str,
     gateway_url: str,
+    proxy_port: int,
 ) -> Sandbox:
     upstream = extract_upstream(gateway_url) if gateway_url else None
     config = SandboxConfig(
@@ -217,6 +219,7 @@ async def _create_claude_sandbox(
         sandbox_kwargs={
             "mounts": [{"target": TOOL_TARGET, "image_url": sidecar_image}],
             "upstream": upstream,
+            "proxy_port": proxy_port,
         },
     )
     sandbox = build_sandbox(config)
@@ -233,6 +236,7 @@ async def claude_code_runner(
     tool_image: str = DEFAULT_TOOL_IMAGE,
     run_timeout: int = 7200,
     conda_env: str = "testbed",
+    proxy_port: int = DEFAULT_GATEWAY_PROXY_PORT,
     **kwargs,
 ) -> None:
     """Run Claude Code inside a sandbox with sidecar tool mount.
@@ -260,6 +264,7 @@ async def claude_code_runner(
         image=image,
         sidecar_image=tool_image,
         gateway_url=gateway_url,
+        proxy_port=proxy_port,
     )
 
     try:
@@ -273,7 +278,7 @@ async def claude_code_runner(
                     setup_result.stdout + setup_result.stderr,
                 )
 
-        claude_base_url = rewrite_gateway_url(gateway_url, strip_v1=True)
+        claude_base_url = rewrite_gateway_url(gateway_url, proxy_port=proxy_port, strip_v1=True)
         max_turns = int(os.environ.get("AGENT_MAX_TURNS", "100"))
         agent_cmd = build_claude_command(
             task=task,

--- a/examples/blackbox_recipes/claude_code/config/claude_code_megatron_v1.yaml
+++ b/examples/blackbox_recipes/claude_code/config/claude_code_megatron_v1.yaml
@@ -66,6 +66,7 @@ actor_rollout_ref:
               tool_image: swr.cn-east-3.myhuaweicloud.com/openyuanrong/claude-code-tool:latest
               run_timeout: 3600
               conda_env: testbed
+              proxy_port: 38197
 
   actor:
     use_dynamic_bsz: true

--- a/examples/blackbox_recipes/claude_code/run_train.sh
+++ b/examples/blackbox_recipes/claude_code/run_train.sh
@@ -92,6 +92,7 @@ AGENT_MAX_TURNS="${AGENT_MAX_TURNS:-100}"
 if [[ "${RUNNER}" == "claude_code" ]]; then
     AGENT_RUNNER_FQN="examples.blackbox_recipes.claude_code.claude_code_runner.claude_code_runner"
     CLAUDE_CODE_TOOL_IMAGE="${CLAUDE_CODE_TOOL_IMAGE:-swr.cn-east-3.myhuaweicloud.com/openyuanrong/claude-code-tool:latest}"
+    CLAUDE_CODE_PROXY_PORT="${CLAUDE_CODE_PROXY_PORT:-38197}"
 else
     echo "Unknown RUNNER=${RUNNER}; this recipe currently supports claude_code only" >&2
     exit 1
@@ -110,6 +111,7 @@ RUNNER_ARGS=(
     "actor_rollout_ref.rollout.custom.agent_framework.agent_runners.claude_code.runner_kwargs.tool_image=${CLAUDE_CODE_TOOL_IMAGE}"
     "actor_rollout_ref.rollout.custom.agent_framework.agent_runners.claude_code.runner_kwargs.run_timeout=${SWE_AGENT_RUN_TIMEOUT}"
     "actor_rollout_ref.rollout.custom.agent_framework.agent_runners.claude_code.runner_kwargs.conda_env=${CONDA_ENV}"
+    "actor_rollout_ref.rollout.custom.agent_framework.agent_runners.claude_code.runner_kwargs.proxy_port=${CLAUDE_CODE_PROXY_PORT}"
 )
 
 # ── OpenYuanrong (remote sandbox) ───────────────────────────────────────
@@ -149,6 +151,7 @@ echo "Val data:    ${VAL_DATA}"
 echo "Engine:      ${ENGINE} (gen_tp=${GEN_TP}, train_tp=${TRAIN_TP})"
 echo "Runner:      ${RUNNER}"
 echo "Tool image:  ${CLAUDE_CODE_TOOL_IMAGE}"
+echo "Proxy port:  ${CLAUDE_CODE_PROXY_PORT}"
 echo "Turns:       agent_max_turns=${AGENT_MAX_TURNS}"
 echo "Batch:       n=${N}, mini_bsz=${PPO_MINI_BATCH_SIZE}"
 echo "Sequence:    prompt=${PROMPT_LENGTH}, response=${RESPONSE_LENGTH}"


### PR DESCRIPTION
## Summary

Restore the Claude Code reverse-tunnel port wiring that was lost when the
recipe migrated from the standalone `SandboxClient` to the shared
`SandboxConfig` abstraction in #95.

The Gateway correctly listens on a dynamically allocated host port and exposes
that address through `SessionHandle.base_url`. The Claude Code runner extracts
that address as the tunnel `upstream`, but currently does not pass the
sandbox-local `proxy_port` to OpenYuanrong. At the same time, it points
`ANTHROPIC_BASE_URL` at `127.0.0.1:38197`, so the client and the sandbox tunnel
do not share an explicit port configuration and Claude Code can fail with
`ConnectionRefused`.

This change keeps the Gateway host port dynamic and uses one runner-level
`proxy_port` value for both the OpenYuanrong tunnel and Claude Code's local
base URL.
<img width="1897" height="265" alt="PixPin_2026-07-30_16-19-32" src="https://github.com/user-attachments/assets/06c4f9a1-557a-42ff-acdb-9c6efc5e40b5" />


## Changes

- Add `proxy_port` to the Claude Code runner kwargs with the existing `38197`
  default.
- Pass the same value to `SandboxConfig.sandbox_kwargs` and
  `rewrite_gateway_url()`.
- Declare the key in `claude_code_megatron_v1.yaml` so Hydra overrides remain
  strict.
- Expose `CLAUDE_CODE_PROXY_PORT` in `run_train.sh` and document it.

Owning layer: **Examples**. The shared Gateway and OpenYuanrong sandbox layers
already provide the required dynamic-port and `proxy_port` behavior.

## Validation

- Before the fix, an A3 Claude Code training run started the Gateway on a
  dynamic port but all four sessions ended with
  `API Error: Unable to connect to API (ConnectionRefused)` and produced empty
  trajectories.
- With equivalent `runner_kwargs.proxy_port=38197` wiring, a subsequent run
  completed 4/4 rollout sessions with zero failed sessions. Later failures
  moved to model context-length validation, confirming requests reached the
  Gateway.
- A reduced smoke run completed rollout, `training/global_step:1`, and
  checkpoint saving.

No new test file is included in this focused example fix. The reverse tunnel
requires the external OpenYuanrong service, so the validation above uses the
end-to-end A3 run. Focused syntax/config checks should be listed here after the
final cleanup commit is created.

## Compatibility

No migration is required. `38197` restores the pre-#95 default. The Gateway
continues to use dynamically allocated host ports, and existing datasets,
trajectories, checkpoints, and public Gateway APIs are unchanged.
```