### PR TITLE
[gateway] fix: remove stale generation prompt on rollback

### DIFF
--- a/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
+++ b/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
@@ -78,15 +78,21 @@ async def test_gateway_actor_forwards_last_assistant_rollback_to_session():
 
     actor = _GatewayActor(
         GatewayActorConfig(tokenizer=FakeTokenizer()),
-        SequencedBackend(["BAD", "FIXED"]),
+        SequencedBackend(["A1", "A2", "FIXED"]),
     )
     actor._server_base_url = "http://test"
     await actor.create_session("rollback-enabled")
     prompt = [{"role": "user", "content": "run"}]
+    continuation = [
+        *prompt,
+        {"role": "assistant", "content": "A1"},
+        {"role": "user", "content": "continue"},
+    ]
     await actor._handle_openai_chat_completions("rollback-enabled", {"messages": prompt})
+    await actor._handle_openai_chat_completions("rollback-enabled", {"messages": continuation})
     await actor._handle_openai_chat_completions(
         "rollback-enabled",
-        {"messages": [*prompt, {"role": "user", "content": "user_error"}]},
+        {"messages": [*continuation, {"role": "user", "content": "user_error"}]},
     )
 
     state = await actor.get_session_state("rollback-enabled")

--- a/tests/uni_agent/gateway/test_message_codec_initialization.py
+++ b/tests/uni_agent/gateway/test_message_codec_initialization.py
@@ -1,0 +1,46 @@
+import pytest
+
+
+class _StableGenerationPromptTokenizer:
+    def apply_chat_template(self, messages, *, add_generation_prompt, tokenize=True, **kwargs):
+        del messages, kwargs
+        ids = [10, 20]
+        if add_generation_prompt:
+            ids += [30, 40]
+        return ids
+
+
+class _UnstableGenerationPromptTokenizer:
+    def apply_chat_template(self, messages, *, add_generation_prompt, tokenize=True, **kwargs):
+        del messages, kwargs
+        return [10, 20] if not add_generation_prompt else [99, 30, 40]
+
+
+class _TypedContentOnlyProcessor:
+    def apply_chat_template(self, messages, *, add_generation_prompt, tokenize=True, **kwargs):
+        del kwargs
+        if any(not isinstance(message["content"], list) for message in messages):
+            raise TypeError("content must use typed parts")
+        ids = [10, 20]
+        if add_generation_prompt:
+            ids += [30, 40]
+        return ids
+
+
+def test_initialize_generation_prompt_returns_generation_suffix():
+    from uni_agent.gateway.session import codec as codec_module
+
+    assert codec_module.initialize_generation_prompt(_StableGenerationPromptTokenizer()) == [30, 40]
+
+
+def test_initialize_generation_prompt_supports_typed_content_processors():
+    from uni_agent.gateway.session import codec as codec_module
+
+    assert codec_module.initialize_generation_prompt(_TypedContentOnlyProcessor()) == [30, 40]
+
+
+def test_initialize_generation_prompt_rejects_non_prefix_template():
+    from uni_agent.gateway.session import codec as codec_module
+
+    with pytest.raises(ValueError, match="stable token suffix"):
+        codec_module.initialize_generation_prompt(_UnstableGenerationPromptTokenizer())

--- a/tests/uni_agent/gateway/test_message_codec_initialization.py
+++ b/tests/uni_agent/gateway/test_message_codec_initialization.py
@@ -1,42 +1,17 @@
 import pytest
 
 
-class _StableGenerationPromptTokenizer:
-    def apply_chat_template(self, messages, *, add_generation_prompt, tokenize=True, **kwargs):
-        del messages, kwargs
-        ids = [10, 20]
-        if add_generation_prompt:
-            ids += [30, 40]
-        return ids
-
-
 class _UnstableGenerationPromptTokenizer:
     def apply_chat_template(self, messages, *, add_generation_prompt, tokenize=True, **kwargs):
         del messages, kwargs
         return [10, 20] if not add_generation_prompt else [99, 30, 40]
 
 
-class _TypedContentOnlyProcessor:
-    def apply_chat_template(self, messages, *, add_generation_prompt, tokenize=True, **kwargs):
-        del kwargs
-        if any(not isinstance(message["content"], list) for message in messages):
-            raise TypeError("content must use typed parts")
-        ids = [10, 20]
-        if add_generation_prompt:
-            ids += [30, 40]
-        return ids
-
-
 def test_initialize_generation_prompt_returns_generation_suffix():
+    from tests.uni_agent.support import FakeTokenizer
     from uni_agent.gateway.session import codec as codec_module
 
-    assert codec_module.initialize_generation_prompt(_StableGenerationPromptTokenizer()) == [30, 40]
-
-
-def test_initialize_generation_prompt_supports_typed_content_processors():
-    from uni_agent.gateway.session import codec as codec_module
-
-    assert codec_module.initialize_generation_prompt(_TypedContentOnlyProcessor()) == [30, 40]
+    assert codec_module.initialize_generation_prompt(FakeTokenizer()) == [ord(char) for char in "assistant:"]
 
 
 def test_initialize_generation_prompt_rejects_non_prefix_template():

--- a/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
+++ b/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
@@ -2,7 +2,6 @@ import asyncio
 from types import SimpleNamespace
 
 import pytest
-import torch
 from fastapi import HTTPException
 
 from tests.uni_agent.support import (
@@ -160,20 +159,6 @@ class _ControlledParallelBackend:
         self.calls[index]["release"].set()
 
 
-class _ExpandedImageTokenProcessor(FakeProcessor):
-    """Mirror vision processors that expand one image into multiple model tokens."""
-
-    def __call__(self, **kwargs):
-        output = super().__call__(**kwargs)
-        if kwargs.get("images"):
-            expanded_ids = []
-            for token_id in output["input_ids"][0].tolist():
-                expanded_ids.extend([token_id, token_id] if token_id == self.image_token_id else [token_id])
-            output["input_ids"] = torch.tensor([expanded_ids], dtype=torch.long)
-            output["attention_mask"] = torch.ones_like(output["input_ids"])
-        return output
-
-
 def _image_message(url: str, text: str) -> dict:
     return {
         "role": "user",
@@ -291,11 +276,7 @@ async def test_multiple_chains_context_compaction_starts_new_chain():
 @pytest.mark.asyncio
 async def test_first_assistant_rewrite_splits_without_rollback():
     """Split a first-assistant rewrite because there are no trainable tokens to preserve."""
-    session = _session(
-        "rollback-token-truth",
-        sampling_params={"logprobs": True},
-        enable_last_assistant_rollback=True,
-    )
+    session = _session("rollback-token-truth", enable_last_assistant_rollback=True)
     first_messages = [{"role": "user", "content": "run mini-swe"}]
     rewrite_messages = [
         *first_messages,
@@ -310,17 +291,12 @@ async def test_first_assistant_rewrite_splits_without_rollback():
     state = session.snapshot_state()
     assert state["active_chain_ids"] == [1, 2]
     assert state["rollback_count"] == 0
-    assert state["rollback_dropped_trainable_tokens_total"] == 0
     chains_by_id = {chain.chain_id: chain for chain in session.active_chains}
-    assert [message["role"] for message in chains_by_id[1].message_history] == ["user", "assistant"]
     assert _decode_response_ids(chains_by_id[1].buffer.response_ids) == "FORMAT_ERROR"
     expected_prompt_ids = codec.encode_full(rewrite_messages)
     assert backend.calls[1]["prompt_ids"] == expected_prompt_ids
     assert chains_by_id[2].buffer.prompt_ids == expected_prompt_ids
     assert _decode_response_ids(chains_by_id[2].buffer.response_ids) == "FIXED"
-    assert chains_by_id[2].buffer.response_mask == [1] * len("FIXED")
-    assert chains_by_id[2].buffer.response_logprobs == [-0.1] * len("FIXED")
-    assert len(chains_by_id[2].buffer.response_logprobs) == len(chains_by_id[2].buffer.response_ids)
 
 
 @pytest.mark.asyncio
@@ -341,39 +317,10 @@ async def test_first_assistant_rewrite_with_assistant_tool_context_splits():
     assert [chain.chain_id for chain in session.active_chains] == [1, 2]
     chains_by_id = {chain.chain_id: chain for chain in session.active_chains}
     assert _decode_response_ids(chains_by_id[1].buffer.response_ids) == "BAD"
-    assert backend.calls[1]["prompt_ids"] == session._codec.encode_full(rewrite_messages)
-    assert chains_by_id[2].buffer.prompt_ids == session._codec.encode_full(rewrite_messages)
+    expected_prompt_ids = session._codec.encode_full(rewrite_messages)
+    assert backend.calls[1]["prompt_ids"] == expected_prompt_ids
+    assert chains_by_id[2].buffer.prompt_ids == expected_prompt_ids
     assert chains_by_id[2].buffer.response_ids == _ids("FIXED")
-    assert chains_by_id[2].buffer.response_mask == [1] * len("FIXED")
-
-
-@pytest.mark.asyncio
-async def test_first_assistant_split_does_not_materialize_suffix_beyond_total_capacity():
-    """Keep the old chain when a first-assistant split prompt exceeds capacity."""
-    first_messages = [{"role": "user", "content": "run mini-swe"}]
-    rewrite_messages = [
-        *first_messages,
-        {"role": "user", "content": "user_error: missing import"},
-    ]
-    codec = MessageCodec(FakeTokenizer())
-    total_capacity = len(codec.encode_full(rewrite_messages)) - 1
-    session = _session(
-        "rollback-total-capacity",
-        prompt_length=1,
-        response_length=total_capacity - 1,
-        enable_last_assistant_rollback=True,
-    )
-    backend = SequencedBackend(["BAD", "SHOULD_NOT_RUN"])
-
-    await _run(session, backend, first_messages)
-    outcome = await _run(session, backend, rewrite_messages)
-    trajectories = await session.finalize()
-
-    assert outcome.finish_reason == "length"
-    assert len(backend.calls) == 1
-    assert trajectories[0].response_ids == _ids("BAD")
-    assert len(trajectories[0].prompt_ids) + len(trajectories[0].response_ids) <= total_capacity
-    assert trajectories[0].extra_fields == {}
 
 
 @pytest.mark.asyncio
@@ -403,9 +350,7 @@ async def test_later_assistant_rollback_removes_only_the_response_side_gp():
     expected_context += codec.encode_incremental([second_messages[2]])[: -len(generation_prompt)]
     expected_context += codec.encode_incremental([rewrite_messages[-1]])
     assert backend.calls[2]["prompt_ids"] == expected_context
-    assert FakeTokenizer().decode(backend.calls[2]["prompt_ids"]).count("assistant:") == 2
     [chain] = session.active_chains
-    assert chain.buffer.prompt_ids == codec.encode_full(first_messages)
     assert _decode_response_ids(chain.buffer.response_ids) == ("A1user:second\nuser:replacement\nassistant:FIXED")
     assert chain.buffer.response_mask == (
         [1] * len("A1") + [0] * len("user:second\nuser:replacement\nassistant:") + [1] * len("FIXED")
@@ -635,44 +580,6 @@ async def test_later_assistant_rollback_rejects_misaligned_stored_logprobs():
 
     with pytest.raises(AssertionError, match="response_logprobs must be empty or aligned"):
         await _run(session, backend, rewrite_messages)
-
-
-@pytest.mark.asyncio
-async def test_first_assistant_rewrite_splits_multimodal_context():
-    """Split a first-rollback multimodal rewrite without dropping the old chain."""
-    session = _session(
-        "rollback-multimodal",
-        processor=_ExpandedImageTokenProcessor(),
-        vision_info_extractor=fake_vision_info_extractor,
-        enable_last_assistant_rollback=True,
-    )
-    first_messages = [_image_message("image://old.png", "inspect old")]
-    replacement_message = _image_message("image://error.png", "user_error image")
-    rewrite_messages = [*first_messages, replacement_message]
-    backend = SequencedBackend(["BAD_IMAGE", "FIXED_IMAGE"])
-    expected_prompt_ids = session._codec.encode_full(
-        rewrite_messages,
-        image_data=["image://old.png", "image://error.png"],
-    )
-
-    await _run(session, backend, first_messages)
-    await _run(session, backend, rewrite_messages)
-
-    state = session.snapshot_state()
-    assert state["active_chain_ids"] == [1, 2]
-    assert state["rollback_count"] == 0
-    assert state["rollback_dropped_trainable_tokens_total"] == 0
-    assert backend.calls[1]["image_data"] == ["image://old.png", "image://error.png"]
-    chains_by_id = {chain.chain_id: chain for chain in session.active_chains}
-    assert chains_by_id[1].image_data == ["image://old.png"]
-    assert chains_by_id[1].video_data is None
-    assert _decode_response_ids(chains_by_id[1].buffer.response_ids) == "BAD_IMAGE"
-    assert chains_by_id[2].image_data == ["image://old.png", "image://error.png"]
-    assert chains_by_id[2].video_data is None
-    assert backend.calls[1]["prompt_ids"] == expected_prompt_ids
-    assert chains_by_id[2].buffer.prompt_ids == expected_prompt_ids
-    assert chains_by_id[2].buffer.response_ids == _ids("FIXED_IMAGE")
-    assert chains_by_id[2].buffer.response_mask == [1] * len("FIXED_IMAGE")
 
 
 @pytest.mark.asyncio
@@ -1799,30 +1706,6 @@ async def test_weight_versions_stay_independent_across_split_chains():
         for trajectory in trajectories
     }
     assert spans == {"BASE": (3, 3), "FRESH": (7, 7)}
-
-
-@pytest.mark.asyncio
-async def test_weight_versions_stay_independent_across_first_assistant_split():
-    """Keep abandoned and replacement versions on their separate first-turn chains."""
-    session = _session("versions-rollback", enable_last_assistant_rollback=True)
-    first_messages = [{"role": "user", "content": "run mini-swe"}]
-    rewrite_messages = [
-        *first_messages,
-        {"role": "user", "content": "user_error: missing import"},
-    ]
-
-    await _run(session, _VersionedBackend([("FORMAT_ERROR", 5, 5)]), first_messages)
-    await _run(session, _VersionedBackend([("FIXED", 7, 7)]), rewrite_messages)
-    trajectories = await session.finalize()
-
-    spans = {
-        _decode_response_ids(trajectory.response_ids): (
-            trajectory.extra_fields["min_global_steps"],
-            trajectory.extra_fields["max_global_steps"],
-        )
-        for trajectory in trajectories
-    }
-    assert spans == {"FORMAT_ERROR": (5, 5), "FIXED": (7, 7)}
 
 
 @pytest.mark.asyncio

--- a/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
+++ b/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
@@ -367,10 +367,11 @@ async def test_later_user_rollback_deduplicates_incremental_turn_separator():
             self._turn_separator = _ids("\n")
 
         def encode_incremental(self, messages, image_data=None, video_data=None):
-            incremental_ids = super().encode_incremental(messages, image_data, video_data)
-            if incremental_ids[: len(self.turn_separator)] == self.turn_separator:
-                return incremental_ids
-            return self.turn_separator + incremental_ids
+            return self.turn_separator + self._tokenizer.apply_chat_template(
+                messages,
+                tokenize=True,
+                add_generation_prompt=True,
+            )
 
     codec = _LeadingSeparatorCodec()
     session = GatewaySession(

--- a/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
+++ b/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
@@ -5,7 +5,12 @@ import pytest
 import torch
 from fastapi import HTTPException
 
-from tests.uni_agent.support import FakeProcessor, FakeTokenizer, SequencedBackend, fake_vision_info_extractor
+from tests.uni_agent.support import (
+    FakeProcessor,
+    FakeTokenizer,
+    SequencedBackend,
+    fake_vision_info_extractor,
+)
 from uni_agent.gateway.adapters.openai import openai_to_internal
 from uni_agent.gateway.session import GatewaySession, MessageCodec, SessionHandle
 from verl.workers.rollout.replica import TokenOutput
@@ -284,8 +289,8 @@ async def test_multiple_chains_context_compaction_starts_new_chain():
 
 
 @pytest.mark.asyncio
-async def test_last_assistant_rollback_reencodes_replacement_suffix_as_masked_context():
-    """Drop an abandoned assistant and retain its replacement prompt as context."""
+async def test_first_assistant_rollback_rebuilds_full_prompt_without_stale_gp():
+    """Rebuild the first rolled-back prompt instead of retaining its stale GP."""
     session = _session(
         "rollback-token-truth",
         sampling_params={"logprobs": True},
@@ -296,10 +301,11 @@ async def test_last_assistant_rollback_reencodes_replacement_suffix_as_masked_co
         *first_messages,
         {"role": "user", "content": "user_error: missing import"},
     ]
-    expected_suffix = "user:user_error: missing import\nassistant:"
+    codec = session._codec
+    backend = SequencedBackend(["FORMAT_ERROR", "FIXED"])
 
-    await _run(session, _LogprobBackend([("FORMAT_ERROR", "full")]), first_messages)
-    await _run(session, _LogprobBackend([("FIXED", "full")]), rewrite_messages)
+    await _run(session, backend, first_messages)
+    await _run(session, backend, rewrite_messages)
 
     state = session.snapshot_state()
     assert state["active_chain_ids"] == [1]
@@ -307,10 +313,35 @@ async def test_last_assistant_rollback_reencodes_replacement_suffix_as_masked_co
     assert state["rollback_dropped_trainable_tokens_total"] == len("FORMAT_ERROR")
     [chain] = session.active_chains
     assert [message["role"] for message in chain.message_history] == ["user", "user", "assistant"]
-    assert _decode_response_ids(chain.buffer.response_ids) == expected_suffix + "FIXED"
-    assert chain.buffer.response_mask == [0] * len(expected_suffix) + [1] * len("FIXED")
-    assert chain.buffer.response_logprobs == [0.0] * len(expected_suffix) + [-0.1] * len("FIXED")
+    expected_prompt_ids = codec.encode_full(rewrite_messages)
+    assert backend.calls[1]["prompt_ids"] == expected_prompt_ids
+    assert chain.buffer.prompt_ids == expected_prompt_ids
+    assert _decode_response_ids(chain.buffer.response_ids) == "FIXED"
+    assert chain.buffer.response_mask == [1] * len("FIXED")
+    assert chain.buffer.response_logprobs == [-0.1] * len("FIXED")
     assert len(chain.buffer.response_logprobs) == len(chain.buffer.response_ids)
+
+
+@pytest.mark.asyncio
+async def test_first_assistant_rollback_reencodes_assistant_tool_context_as_prompt():
+    """Treat a first-turn assistant/tool rewrite as one fresh full prompt."""
+    session = _session("rollback-first-assistant-tool", enable_last_assistant_rollback=True)
+    first_messages = [{"role": "user", "content": "run task"}]
+    rewrite_messages = [
+        *first_messages,
+        {"role": "assistant", "content": "NEW", "tool_calls": []},
+        {"role": "tool", "content": "OBS", "tool_call_id": "call_1"},
+    ]
+    backend = SequencedBackend(["BAD", "FIXED"])
+
+    await _run(session, backend, first_messages)
+    await _run(session, backend, rewrite_messages)
+
+    [chain] = session.active_chains
+    assert backend.calls[1]["prompt_ids"] == session._codec.encode_full(rewrite_messages)
+    assert chain.buffer.prompt_ids == session._codec.encode_full(rewrite_messages)
+    assert chain.buffer.response_ids == _ids("FIXED")
+    assert chain.buffer.response_mask == [1] * len("FIXED")
 
 
 @pytest.mark.asyncio
@@ -322,12 +353,11 @@ async def test_last_assistant_rollback_does_not_materialize_suffix_beyond_total_
         {"role": "user", "content": "user_error: missing import"},
     ]
     codec = MessageCodec(FakeTokenizer())
-    prompt_length = len(codec.encode_full(first_messages))
-    suffix_length = len(codec.encode_incremental(rewrite_messages[1:]))
+    total_capacity = len(codec.encode_full(rewrite_messages)) - 1
     session = _session(
         "rollback-total-capacity",
-        prompt_length=prompt_length,
-        response_length=suffix_length - 1,
+        prompt_length=1,
+        response_length=total_capacity - 1,
         enable_last_assistant_rollback=True,
     )
     backend = SequencedBackend(["BAD", "SHOULD_NOT_RUN"])
@@ -339,8 +369,67 @@ async def test_last_assistant_rollback_does_not_materialize_suffix_beyond_total_
     assert outcome.finish_reason == "length"
     assert len(backend.calls) == 1
     assert trajectories[0].response_ids == []
-    assert len(trajectories[0].prompt_ids) + len(trajectories[0].response_ids) <= prompt_length + suffix_length - 1
+    assert len(trajectories[0].prompt_ids) + len(trajectories[0].response_ids) <= total_capacity
     assert trajectories[0].extra_fields == {"materialization_reason": "max_trajectory_length"}
+
+
+@pytest.mark.asyncio
+async def test_later_assistant_rollback_removes_only_the_response_side_gp():
+    """Preserve earlier trainable output while removing the latest stale GP."""
+    session = _session("rollback-later-gp", enable_last_assistant_rollback=True)
+    backend = SequencedBackend(["A1", "A2", "FIXED"])
+    first_messages = [{"role": "user", "content": "start"}]
+    second_messages = [
+        *first_messages,
+        {"role": "assistant", "content": "A1"},
+        {"role": "user", "content": "second"},
+    ]
+    rewrite_messages = [
+        *second_messages[:2],
+        second_messages[2],
+        {"role": "user", "content": "replacement"},
+    ]
+
+    await _run(session, backend, first_messages)
+    await _run(session, backend, second_messages)
+    await _run(session, backend, rewrite_messages)
+
+    codec = session._codec
+    generation_prompt = codec.generation_prompt
+    expected_context = codec.encode_full(first_messages) + _ids("A1")
+    expected_context += codec.encode_incremental([second_messages[2]])[: -len(generation_prompt)]
+    expected_context += codec.encode_incremental([rewrite_messages[-1]])
+    assert backend.calls[2]["prompt_ids"] == expected_context
+    assert FakeTokenizer().decode(backend.calls[2]["prompt_ids"]).count("assistant:") == 2
+    [chain] = session.active_chains
+    assert chain.buffer.prompt_ids == codec.encode_full(first_messages)
+    assert _decode_response_ids(chain.buffer.response_ids) == ("A1user:second\nuser:replacement\nassistant:FIXED")
+    assert chain.buffer.response_mask == (
+        [1] * len("A1") + [0] * len("user:second\nuser:replacement\nassistant:") + [1] * len("FIXED")
+    )
+
+
+@pytest.mark.asyncio
+async def test_later_assistant_rollback_rejects_misaligned_generation_prompt():
+    """Fail closed when a stored response-side GP no longer matches the codec."""
+    session = _session("rollback-gp-assert", enable_last_assistant_rollback=True)
+    backend = SequencedBackend(["A1", "A2", "FIXED"])
+    first_messages = [{"role": "user", "content": "start"}]
+    continuation = [
+        *first_messages,
+        {"role": "assistant", "content": "A1"},
+        {"role": "user", "content": "second"},
+    ]
+    rewrite_messages = [*continuation, {"role": "user", "content": "replacement"}]
+
+    await _run(session, backend, first_messages)
+    await _run(session, backend, continuation)
+    [chain] = session.active_chains
+    snapshot = chain.last_assistant_start
+    chain.buffer.response_ids[snapshot.response_ids_len - 1] += 1
+
+    with pytest.raises(ValueError, match="generation prompt"):
+        await _run(session, backend, rewrite_messages)
 
 
 @pytest.mark.asyncio
@@ -544,7 +633,7 @@ async def test_last_assistant_rollback_rejects_misaligned_stored_logprobs():
 
 @pytest.mark.asyncio
 async def test_last_assistant_rollback_multimodal_suffix_reencodes_expanded_media_tokens():
-    """Keep rollback media aligned when one image expands into multiple tokens."""
+    """Rebuild first-rollback media and prompt tokens as one full context."""
     session = _session(
         "rollback-multimodal",
         processor=_ExpandedImageTokenProcessor(),
@@ -555,9 +644,9 @@ async def test_last_assistant_rollback_multimodal_suffix_reencodes_expanded_medi
     replacement_message = _image_message("image://error.png", "user_error image")
     rewrite_messages = [*first_messages, replacement_message]
     backend = SequencedBackend(["BAD_IMAGE", "FIXED_IMAGE"])
-    expected_suffix_ids = session._codec.encode_incremental(
-        [replacement_message],
-        image_data=["image://error.png"],
+    expected_prompt_ids = session._codec.encode_full(
+        rewrite_messages,
+        image_data=["image://old.png", "image://error.png"],
     )
 
     await _run(session, backend, first_messages)
@@ -571,8 +660,10 @@ async def test_last_assistant_rollback_multimodal_suffix_reencodes_expanded_medi
     [chain] = session.active_chains
     assert chain.image_data == ["image://old.png", "image://error.png"]
     assert chain.video_data is None
-    assert chain.buffer.response_ids[: len(expected_suffix_ids)] == expected_suffix_ids
-    assert chain.buffer.response_mask == [0] * len(expected_suffix_ids) + [1] * len("FIXED_IMAGE")
+    assert backend.calls[1]["prompt_ids"] == expected_prompt_ids
+    assert chain.buffer.prompt_ids == expected_prompt_ids
+    assert chain.buffer.response_ids == _ids("FIXED_IMAGE")
+    assert chain.buffer.response_mask == [1] * len("FIXED_IMAGE")
 
 
 @pytest.mark.asyncio

--- a/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
+++ b/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
@@ -289,8 +289,8 @@ async def test_multiple_chains_context_compaction_starts_new_chain():
 
 
 @pytest.mark.asyncio
-async def test_first_assistant_rollback_rebuilds_full_prompt_without_stale_gp():
-    """Rebuild the first rolled-back prompt instead of retaining its stale GP."""
+async def test_first_assistant_rewrite_splits_without_rollback():
+    """Split a first-assistant rewrite because there are no trainable tokens to preserve."""
     session = _session(
         "rollback-token-truth",
         sampling_params={"logprobs": True},
@@ -308,23 +308,24 @@ async def test_first_assistant_rollback_rebuilds_full_prompt_without_stale_gp():
     await _run(session, backend, rewrite_messages)
 
     state = session.snapshot_state()
-    assert state["active_chain_ids"] == [1]
-    assert state["rollback_count"] == 1
-    assert state["rollback_dropped_trainable_tokens_total"] == len("FORMAT_ERROR")
-    [chain] = session.active_chains
-    assert [message["role"] for message in chain.message_history] == ["user", "user", "assistant"]
+    assert state["active_chain_ids"] == [1, 2]
+    assert state["rollback_count"] == 0
+    assert state["rollback_dropped_trainable_tokens_total"] == 0
+    chains_by_id = {chain.chain_id: chain for chain in session.active_chains}
+    assert [message["role"] for message in chains_by_id[1].message_history] == ["user", "assistant"]
+    assert _decode_response_ids(chains_by_id[1].buffer.response_ids) == "FORMAT_ERROR"
     expected_prompt_ids = codec.encode_full(rewrite_messages)
     assert backend.calls[1]["prompt_ids"] == expected_prompt_ids
-    assert chain.buffer.prompt_ids == expected_prompt_ids
-    assert _decode_response_ids(chain.buffer.response_ids) == "FIXED"
-    assert chain.buffer.response_mask == [1] * len("FIXED")
-    assert chain.buffer.response_logprobs == [-0.1] * len("FIXED")
-    assert len(chain.buffer.response_logprobs) == len(chain.buffer.response_ids)
+    assert chains_by_id[2].buffer.prompt_ids == expected_prompt_ids
+    assert _decode_response_ids(chains_by_id[2].buffer.response_ids) == "FIXED"
+    assert chains_by_id[2].buffer.response_mask == [1] * len("FIXED")
+    assert chains_by_id[2].buffer.response_logprobs == [-0.1] * len("FIXED")
+    assert len(chains_by_id[2].buffer.response_logprobs) == len(chains_by_id[2].buffer.response_ids)
 
 
 @pytest.mark.asyncio
-async def test_first_assistant_rollback_reencodes_assistant_tool_context_as_prompt():
-    """Treat a first-turn assistant/tool rewrite as one fresh full prompt."""
+async def test_first_assistant_rewrite_with_assistant_tool_context_splits():
+    """Split a first-turn assistant/tool rewrite as a fresh full prompt."""
     session = _session("rollback-first-assistant-tool", enable_last_assistant_rollback=True)
     first_messages = [{"role": "user", "content": "run task"}]
     rewrite_messages = [
@@ -337,16 +338,18 @@ async def test_first_assistant_rollback_reencodes_assistant_tool_context_as_prom
     await _run(session, backend, first_messages)
     await _run(session, backend, rewrite_messages)
 
-    [chain] = session.active_chains
+    assert [chain.chain_id for chain in session.active_chains] == [1, 2]
+    chains_by_id = {chain.chain_id: chain for chain in session.active_chains}
+    assert _decode_response_ids(chains_by_id[1].buffer.response_ids) == "BAD"
     assert backend.calls[1]["prompt_ids"] == session._codec.encode_full(rewrite_messages)
-    assert chain.buffer.prompt_ids == session._codec.encode_full(rewrite_messages)
-    assert chain.buffer.response_ids == _ids("FIXED")
-    assert chain.buffer.response_mask == [1] * len("FIXED")
+    assert chains_by_id[2].buffer.prompt_ids == session._codec.encode_full(rewrite_messages)
+    assert chains_by_id[2].buffer.response_ids == _ids("FIXED")
+    assert chains_by_id[2].buffer.response_mask == [1] * len("FIXED")
 
 
 @pytest.mark.asyncio
-async def test_last_assistant_rollback_does_not_materialize_suffix_beyond_total_capacity():
-    """Close the rolled-back prefix without storing an oversized replacement suffix."""
+async def test_first_assistant_split_does_not_materialize_suffix_beyond_total_capacity():
+    """Keep the old chain when a first-assistant split prompt exceeds capacity."""
     first_messages = [{"role": "user", "content": "run mini-swe"}]
     rewrite_messages = [
         *first_messages,
@@ -368,9 +371,9 @@ async def test_last_assistant_rollback_does_not_materialize_suffix_beyond_total_
 
     assert outcome.finish_reason == "length"
     assert len(backend.calls) == 1
-    assert trajectories[0].response_ids == []
+    assert trajectories[0].response_ids == _ids("BAD")
     assert len(trajectories[0].prompt_ids) + len(trajectories[0].response_ids) <= total_capacity
-    assert trajectories[0].extra_fields == {"materialization_reason": "max_trajectory_length"}
+    assert trajectories[0].extra_fields == {}
 
 
 @pytest.mark.asyncio
@@ -614,7 +617,7 @@ def test_chain_prefix_hash_match_accepts_empty_history_for_any_request():
 
 
 @pytest.mark.asyncio
-async def test_last_assistant_rollback_rejects_misaligned_stored_logprobs():
+async def test_later_assistant_rollback_rejects_misaligned_stored_logprobs():
     """Fail loudly instead of slicing a chain whose token truth is already corrupt."""
     session = _session(
         "rollback-logprob-assert",
@@ -622,18 +625,21 @@ async def test_last_assistant_rollback_rejects_misaligned_stored_logprobs():
         enable_last_assistant_rollback=True,
     )
     prompt = [{"role": "user", "content": "run"}]
-    rewrite_messages = [*prompt, {"role": "user", "content": "user_error"}]
+    continuation = [*prompt, {"role": "assistant", "content": "A1"}, {"role": "user", "content": "continue"}]
+    rewrite_messages = [*continuation, {"role": "user", "content": "user_error"}]
 
-    await _run(session, _LogprobBackend([("BAD", "full")]), prompt)
+    backend = _LogprobBackend([("A1", "full"), ("A2", "full"), ("FIXED", "full")])
+    await _run(session, backend, prompt)
+    await _run(session, backend, continuation)
     session.active_chains[0].buffer.response_logprobs.pop()
 
     with pytest.raises(AssertionError, match="response_logprobs must be empty or aligned"):
-        await _run(session, _LogprobBackend([("FIXED", "full")]), rewrite_messages)
+        await _run(session, backend, rewrite_messages)
 
 
 @pytest.mark.asyncio
-async def test_last_assistant_rollback_multimodal_suffix_reencodes_expanded_media_tokens():
-    """Rebuild first-rollback media and prompt tokens as one full context."""
+async def test_first_assistant_rewrite_splits_multimodal_context():
+    """Split a first-rollback multimodal rewrite without dropping the old chain."""
     session = _session(
         "rollback-multimodal",
         processor=_ExpandedImageTokenProcessor(),
@@ -653,17 +659,20 @@ async def test_last_assistant_rollback_multimodal_suffix_reencodes_expanded_medi
     await _run(session, backend, rewrite_messages)
 
     state = session.snapshot_state()
-    assert state["active_chain_ids"] == [1]
-    assert state["rollback_count"] == 1
-    assert state["rollback_dropped_trainable_tokens_total"] == len("BAD_IMAGE")
+    assert state["active_chain_ids"] == [1, 2]
+    assert state["rollback_count"] == 0
+    assert state["rollback_dropped_trainable_tokens_total"] == 0
     assert backend.calls[1]["image_data"] == ["image://old.png", "image://error.png"]
-    [chain] = session.active_chains
-    assert chain.image_data == ["image://old.png", "image://error.png"]
-    assert chain.video_data is None
+    chains_by_id = {chain.chain_id: chain for chain in session.active_chains}
+    assert chains_by_id[1].image_data == ["image://old.png"]
+    assert chains_by_id[1].video_data is None
+    assert _decode_response_ids(chains_by_id[1].buffer.response_ids) == "BAD_IMAGE"
+    assert chains_by_id[2].image_data == ["image://old.png", "image://error.png"]
+    assert chains_by_id[2].video_data is None
     assert backend.calls[1]["prompt_ids"] == expected_prompt_ids
-    assert chain.buffer.prompt_ids == expected_prompt_ids
-    assert chain.buffer.response_ids == _ids("FIXED_IMAGE")
-    assert chain.buffer.response_mask == [1] * len("FIXED_IMAGE")
+    assert chains_by_id[2].buffer.prompt_ids == expected_prompt_ids
+    assert chains_by_id[2].buffer.response_ids == _ids("FIXED_IMAGE")
+    assert chains_by_id[2].buffer.response_mask == [1] * len("FIXED_IMAGE")
 
 
 @pytest.mark.asyncio
@@ -1793,8 +1802,8 @@ async def test_weight_versions_stay_independent_across_split_chains():
 
 
 @pytest.mark.asyncio
-async def test_weight_versions_drop_rolled_back_generations():
-    """Exclude a rolled-back assistant's version from the surviving trajectory's span."""
+async def test_weight_versions_stay_independent_across_first_assistant_split():
+    """Keep abandoned and replacement versions on their separate first-turn chains."""
     session = _session("versions-rollback", enable_last_assistant_rollback=True)
     first_messages = [{"role": "user", "content": "run mini-swe"}]
     rewrite_messages = [
@@ -1804,11 +1813,16 @@ async def test_weight_versions_drop_rolled_back_generations():
 
     await _run(session, _VersionedBackend([("FORMAT_ERROR", 5, 5)]), first_messages)
     await _run(session, _VersionedBackend([("FIXED", 7, 7)]), rewrite_messages)
-    [trajectory] = await session.finalize()
+    trajectories = await session.finalize()
 
-    # Version 5 produced only the dropped assistant, so it must not widen the span.
-    assert trajectory.extra_fields["min_global_steps"] == 7
-    assert trajectory.extra_fields["max_global_steps"] == 7
+    spans = {
+        _decode_response_ids(trajectory.response_ids): (
+            trajectory.extra_fields["min_global_steps"],
+            trajectory.extra_fields["max_global_steps"],
+        )
+        for trajectory in trajectories
+    }
+    assert spans == {"FORMAT_ERROR": (5, 5), "FIXED": (7, 7)}
 
 
 @pytest.mark.asyncio

--- a/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
+++ b/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
@@ -358,6 +358,45 @@ async def test_later_assistant_rollback_removes_only_the_response_side_gp():
 
 
 @pytest.mark.asyncio
+async def test_later_user_rollback_deduplicates_incremental_turn_separator():
+    """Keep one turn separator when incremental encoding restores the retained boundary."""
+
+    class _LeadingSeparatorCodec(MessageCodec):
+        def __init__(self):
+            super().__init__(FakeTokenizer())
+            self._turn_separator = _ids("\n")
+
+        def encode_incremental(self, messages, image_data=None, video_data=None):
+            incremental_ids = super().encode_incremental(messages, image_data, video_data)
+            if incremental_ids[: len(self.turn_separator)] == self.turn_separator:
+                return incremental_ids
+            return self.turn_separator + incremental_ids
+
+    codec = _LeadingSeparatorCodec()
+    session = GatewaySession(
+        SessionHandle(session_id="rollback-separator"),
+        codec,
+        enable_last_assistant_rollback=True,
+    )
+    backend = SequencedBackend(["A1", "A2", "FIXED"])
+    first_messages = [{"role": "user", "content": "start"}]
+    second_messages = [
+        *first_messages,
+        {"role": "assistant", "content": "A1"},
+        {"role": "user", "content": "second"},
+    ]
+    rewrite_messages = [*second_messages, {"role": "user", "content": "replacement"}]
+
+    await _run(session, backend, first_messages)
+    await _run(session, backend, second_messages)
+    await _run(session, backend, rewrite_messages)
+
+    assert _decode_response_ids(backend.calls[2]["prompt_ids"]) == (
+        "user:start\nassistant:A1\nuser:second\nuser:replacement\nassistant:"
+    )
+
+
+@pytest.mark.asyncio
 async def test_later_assistant_rollback_rejects_misaligned_generation_prompt():
     """Fail closed when a stored response-side GP no longer matches the codec."""
     session = _session("rollback-gp-assert", enable_last_assistant_rollback=True)

--- a/uni_agent/gateway/session/codec.py
+++ b/uni_agent/gateway/session/codec.py
@@ -14,7 +14,7 @@ from uuid import uuid4
 
 from verl.utils.tokenizer import normalize_token_ids
 from verl.utils.tokenizer.chat_template import apply_chat_template as _apply_chat_template
-from verl.utils.tokenizer.chat_template import initialize_system_prompt
+from verl.utils.tokenizer.chat_template import initialize_system_prompt, initialize_turn_separator
 
 logger = logging.getLogger("gateway")
 
@@ -173,12 +173,21 @@ class MessageCodec:
             processing_class,
             **self._apply_chat_template_kwargs,
         )
+        self._turn_separator = initialize_turn_separator(
+            processing_class,
+            **self._apply_chat_template_kwargs,
+        )
         self._tool_parser_name = tool_parser_name
 
     @property
     def generation_prompt(self) -> list[int]:
         """Return the configured chat template's generation-prompt token suffix."""
         return list(self._generation_prompt)
+
+    @property
+    def turn_separator(self) -> list[int]:
+        """Return the configured chat template's inter-turn separator tokens."""
+        return list(self._turn_separator)
 
     async def _default_vision_info_extractor(
         self,

--- a/uni_agent/gateway/session/codec.py
+++ b/uni_agent/gateway/session/codec.py
@@ -145,7 +145,33 @@ class MessageCodec:
             self._processor if self._processor is not None else tokenizer,
             **self._apply_chat_template_kwargs,
         )
+        processing_class = self._processor if self._processor is not None else tokenizer
+        empty_content = [{"type": "text", "text": ""}] if self._processor is not None else ""
+        without_generation_prompt = normalize_token_ids(
+            _apply_chat_template(
+                processing_class,
+                [{"role": "user", "content": empty_content}],
+                add_generation_prompt=False,
+                **self._apply_chat_template_kwargs,
+            )
+        )
+        with_generation_prompt = normalize_token_ids(
+            _apply_chat_template(
+                processing_class,
+                [{"role": "user", "content": empty_content}],
+                add_generation_prompt=True,
+                **self._apply_chat_template_kwargs,
+            )
+        )
+        if with_generation_prompt[: len(without_generation_prompt)] != without_generation_prompt:
+            raise ValueError("Generation prompt is not a stable token suffix")
+        self._generation_prompt = with_generation_prompt[len(without_generation_prompt) :]
         self._tool_parser_name = tool_parser_name
+
+    @property
+    def generation_prompt(self) -> list[int]:
+        """Return the configured chat template's generation-prompt token suffix."""
+        return list(self._generation_prompt)
 
     async def _default_vision_info_extractor(
         self,

--- a/uni_agent/gateway/session/codec.py
+++ b/uni_agent/gateway/session/codec.py
@@ -41,6 +41,39 @@ _VLLM_TOOL_PARSER_ALIASES = {
 }
 
 
+def initialize_generation_prompt(processing_class, **apply_chat_template_kwargs) -> list[int]:
+    """Initialize the token suffix inserted by ``add_generation_prompt=True``."""
+    last_error: Exception | None = None
+    for empty_content in ("", [{"type": "text", "text": ""}]):
+        try:
+            without_generation_prompt = normalize_token_ids(
+                _apply_chat_template(
+                    processing_class,
+                    [{"role": "user", "content": empty_content}],
+                    add_generation_prompt=False,
+                    **apply_chat_template_kwargs,
+                )
+            )
+            with_generation_prompt = normalize_token_ids(
+                _apply_chat_template(
+                    processing_class,
+                    [{"role": "user", "content": empty_content}],
+                    add_generation_prompt=True,
+                    **apply_chat_template_kwargs,
+                )
+            )
+        except Exception as error:
+            last_error = error
+            continue
+
+        if with_generation_prompt[: len(without_generation_prompt)] != without_generation_prompt:
+            raise ValueError("Generation prompt is not a stable token suffix")
+        return with_generation_prompt[len(without_generation_prompt) :]
+
+    assert last_error is not None
+    raise last_error
+
+
 def _canonicalize_tool_arguments_for_comparison(arguments: Any) -> tuple[str, Any]:
     if isinstance(arguments, dict | list):
         return ("json", arguments)
@@ -146,26 +179,10 @@ class MessageCodec:
             **self._apply_chat_template_kwargs,
         )
         processing_class = self._processor if self._processor is not None else tokenizer
-        empty_content = [{"type": "text", "text": ""}] if self._processor is not None else ""
-        without_generation_prompt = normalize_token_ids(
-            _apply_chat_template(
-                processing_class,
-                [{"role": "user", "content": empty_content}],
-                add_generation_prompt=False,
-                **self._apply_chat_template_kwargs,
-            )
+        self._generation_prompt = initialize_generation_prompt(
+            processing_class,
+            **self._apply_chat_template_kwargs,
         )
-        with_generation_prompt = normalize_token_ids(
-            _apply_chat_template(
-                processing_class,
-                [{"role": "user", "content": empty_content}],
-                add_generation_prompt=True,
-                **self._apply_chat_template_kwargs,
-            )
-        )
-        if with_generation_prompt[: len(without_generation_prompt)] != without_generation_prompt:
-            raise ValueError("Generation prompt is not a stable token suffix")
-        self._generation_prompt = with_generation_prompt[len(without_generation_prompt) :]
         self._tool_parser_name = tool_parser_name
 
     @property

--- a/uni_agent/gateway/session/codec.py
+++ b/uni_agent/gateway/session/codec.py
@@ -43,35 +43,25 @@ _VLLM_TOOL_PARSER_ALIASES = {
 
 def initialize_generation_prompt(processing_class, **apply_chat_template_kwargs) -> list[int]:
     """Initialize the token suffix inserted by ``add_generation_prompt=True``."""
-    last_error: Exception | None = None
-    for empty_content in ("", [{"type": "text", "text": ""}]):
-        try:
-            without_generation_prompt = normalize_token_ids(
-                _apply_chat_template(
-                    processing_class,
-                    [{"role": "user", "content": empty_content}],
-                    add_generation_prompt=False,
-                    **apply_chat_template_kwargs,
-                )
-            )
-            with_generation_prompt = normalize_token_ids(
-                _apply_chat_template(
-                    processing_class,
-                    [{"role": "user", "content": empty_content}],
-                    add_generation_prompt=True,
-                    **apply_chat_template_kwargs,
-                )
-            )
-        except Exception as error:
-            last_error = error
-            continue
-
-        if with_generation_prompt[: len(without_generation_prompt)] != without_generation_prompt:
-            raise ValueError("Generation prompt is not a stable token suffix")
-        return with_generation_prompt[len(without_generation_prompt) :]
-
-    assert last_error is not None
-    raise last_error
+    without_generation_prompt = normalize_token_ids(
+        _apply_chat_template(
+            processing_class,
+            [{"role": "user", "content": ""}],
+            add_generation_prompt=False,
+            **apply_chat_template_kwargs,
+        )
+    )
+    with_generation_prompt = normalize_token_ids(
+        _apply_chat_template(
+            processing_class,
+            [{"role": "user", "content": ""}],
+            add_generation_prompt=True,
+            **apply_chat_template_kwargs,
+        )
+    )
+    if with_generation_prompt[: len(without_generation_prompt)] != without_generation_prompt:
+        raise ValueError("Generation prompt is not a stable token suffix")
+    return with_generation_prompt[len(without_generation_prompt) :]
 
 
 def _canonicalize_tool_arguments_for_comparison(arguments: Any) -> tuple[str, Any]:
@@ -174,11 +164,11 @@ class MessageCodec:
         self._vision_info_extractor = vision_info_extractor or self._default_vision_info_extractor
         self._vision_info_extractor_kwargs = dict(vision_info_extractor_kwargs or {})
         self._apply_chat_template_kwargs = dict(apply_chat_template_kwargs or {})
+        processing_class = self._processor if self._processor is not None else tokenizer
         self._system_prompt = initialize_system_prompt(
-            self._processor if self._processor is not None else tokenizer,
+            processing_class,
             **self._apply_chat_template_kwargs,
         )
-        processing_class = self._processor if self._processor is not None else tokenizer
         self._generation_prompt = initialize_generation_prompt(
             processing_class,
             **self._apply_chat_template_kwargs,

--- a/uni_agent/gateway/session/session.py
+++ b/uni_agent/gateway/session/session.py
@@ -415,7 +415,6 @@ class GatewaySession:
             self._assert_response_logprob_alignment(buffer)
             image_data, video_data = self._copy_chain_media(selected_chain)
             chain_id = selected_chain.chain_id
-            reencoded_full_prompt = False
             if rollback_to_last_assistant:
                 last_assistant_start = selected_chain.last_assistant_start
                 assert last_assistant_start.response_ids_len <= len(buffer.response_ids)
@@ -432,111 +431,78 @@ class GatewaySession:
                 if video_data is not None:
                     assert last_assistant_start.video_data_len <= len(video_data)
                     video_data = video_data[: last_assistant_start.video_data_len] or None
-                if last_assistant_start.response_ids_len == 0:
-                    # No response-side context predates the first assistant, so rebuild the
-                    # requested history as a fresh prompt instead of splicing its prompt GP.
-                    del buffer.response_ids[:]
-                    del buffer.response_mask[:]
-                    del buffer.response_logprobs[:]
-                    buffer.routed_experts = None
-                    incremental_messages = messages[last_assistant_start.message_history_len :]
-                    new_image_data, new_video_data = await self._codec.extract_multi_modal_data(incremental_messages)
-                    full_image_data = list(image_data or [])
-                    full_video_data = list(video_data or [])
-                    if new_image_data:
-                        full_image_data.extend(new_image_data)
-                    if new_video_data:
-                        full_video_data.extend(new_video_data)
-                    prompt_ids = self._codec.encode_full(
-                        messages,
-                        tools=tools,
-                        image_data=full_image_data or None,
-                        video_data=full_video_data or None,
-                    )
-                    capacity_exhausted = (
-                        self._trajectory_capacity is not None and len(prompt_ids) >= self._trajectory_capacity
-                    )
-                    if not capacity_exhausted:
-                        buffer = TrajectoryBuffer(prompt_ids=prompt_ids)
-                        image_data = full_image_data or None
-                        video_data = full_video_data or None
-                    reencoded_full_prompt = True
-                else:
-                    # Later rollbacks retain earlier trainable output; the snapshot was captured
-                    # after the prior incremental GP, so remove that verified suffix as well.
-                    rollback_response_ids_len = last_assistant_start.response_ids_len
-                    rollback_response_mask_len = last_assistant_start.response_mask_len
-                    rollback_response_logprobs_len = last_assistant_start.response_logprobs_len
-                    generation_prompt = self._codec.generation_prompt
-                    if generation_prompt:
-                        generation_prompt_len = len(generation_prompt)
-                        generation_prompt_start = rollback_response_ids_len - generation_prompt_len
-                        if (
-                            generation_prompt_start < 0
-                            or buffer.response_ids[generation_prompt_start:rollback_response_ids_len]
-                            != generation_prompt
+                assert last_assistant_start.response_ids_len > 0
+                # Later rollbacks retain earlier trainable output; the snapshot was captured
+                # after the prior incremental GP, so remove that verified suffix as well.
+                rollback_response_ids_len = last_assistant_start.response_ids_len
+                rollback_response_mask_len = last_assistant_start.response_mask_len
+                rollback_response_logprobs_len = last_assistant_start.response_logprobs_len
+                generation_prompt = self._codec.generation_prompt
+                if generation_prompt:
+                    generation_prompt_len = len(generation_prompt)
+                    generation_prompt_start = rollback_response_ids_len - generation_prompt_len
+                    if (
+                        generation_prompt_start < 0
+                        or buffer.response_ids[generation_prompt_start:rollback_response_ids_len] != generation_prompt
+                    ):
+                        raise ValueError("Stored response does not end its assistant prefix with the generation prompt")
+                    rollback_response_ids_len = generation_prompt_start
+                    rollback_response_mask_len -= generation_prompt_len
+                    if rollback_response_mask_len < 0 or any(
+                        buffer.response_mask[rollback_response_mask_len : last_assistant_start.response_mask_len]
+                    ):
+                        raise ValueError("Stored generation-prompt mask is not rollback-safe")
+                    if rollback_response_logprobs_len:
+                        rollback_response_logprobs_len -= generation_prompt_len
+                        if rollback_response_logprobs_len < 0 or any(
+                            buffer.response_logprobs[
+                                rollback_response_logprobs_len : last_assistant_start.response_logprobs_len
+                            ]
                         ):
-                            raise ValueError(
-                                "Stored response does not end its assistant prefix with the generation prompt"
-                            )
-                        rollback_response_ids_len = generation_prompt_start
-                        rollback_response_mask_len -= generation_prompt_len
-                        if rollback_response_mask_len < 0 or any(
-                            buffer.response_mask[rollback_response_mask_len : last_assistant_start.response_mask_len]
-                        ):
-                            raise ValueError("Stored generation-prompt mask is not rollback-safe")
-                        if rollback_response_logprobs_len:
-                            rollback_response_logprobs_len -= generation_prompt_len
-                            if rollback_response_logprobs_len < 0 or any(
-                                buffer.response_logprobs[
-                                    rollback_response_logprobs_len : last_assistant_start.response_logprobs_len
-                                ]
-                            ):
-                                raise ValueError("Stored generation-prompt logprobs are not rollback-safe")
-                    del buffer.response_ids[rollback_response_ids_len:]
-                    del buffer.response_mask[rollback_response_mask_len:]
-                    del buffer.response_logprobs[rollback_response_logprobs_len:]
-                    self._assert_response_logprob_alignment(buffer)
-                    incremental_start = last_assistant_start.message_history_len
+                            raise ValueError("Stored generation-prompt logprobs are not rollback-safe")
+                del buffer.response_ids[rollback_response_ids_len:]
+                del buffer.response_mask[rollback_response_mask_len:]
+                del buffer.response_logprobs[rollback_response_logprobs_len:]
+                self._assert_response_logprob_alignment(buffer)
+                incremental_start = last_assistant_start.message_history_len
                 rollback_applied = True
             else:
                 incremental_start = len(selected_chain.message_history)
 
-            if not reencoded_full_prompt:
-                incremental_messages = messages[incremental_start:]
-                new_image_data = None
-                new_video_data = None
-                incremental_ids = []
-                current_trajectory_length = len(buffer.prompt_ids) + len(buffer.response_ids)
-                capacity_exhausted = (
-                    self._trajectory_capacity is not None and current_trajectory_length >= self._trajectory_capacity
+            incremental_messages = messages[incremental_start:]
+            new_image_data = None
+            new_video_data = None
+            incremental_ids = []
+            current_trajectory_length = len(buffer.prompt_ids) + len(buffer.response_ids)
+            capacity_exhausted = (
+                self._trajectory_capacity is not None and current_trajectory_length >= self._trajectory_capacity
+            )
+            if incremental_messages and not capacity_exhausted:
+                new_image_data, new_video_data = await self._codec.extract_multi_modal_data(incremental_messages)
+                incremental_ids = self._codec.encode_incremental(
+                    incremental_messages,
+                    image_data=new_image_data,
+                    video_data=new_video_data,
                 )
-                if incremental_messages and not capacity_exhausted:
-                    new_image_data, new_video_data = await self._codec.extract_multi_modal_data(incremental_messages)
-                    incremental_ids = self._codec.encode_incremental(
-                        incremental_messages,
-                        image_data=new_image_data,
-                        video_data=new_video_data,
-                    )
-                    capacity_exhausted = (
-                        self._trajectory_capacity is not None
-                        and current_trajectory_length + len(incremental_ids) >= self._trajectory_capacity
-                    )
+                capacity_exhausted = (
+                    self._trajectory_capacity is not None
+                    and current_trajectory_length + len(incremental_ids) >= self._trajectory_capacity
+                )
 
-                if not capacity_exhausted:
-                    buffer.response_ids.extend(incremental_ids)
-                    buffer.response_mask.extend([0] * len(incremental_ids))
-                    if sampling_params.get("logprobs", False):
-                        buffer.response_logprobs.extend([0.0] * len(incremental_ids))
-                    self._assert_response_logprob_alignment(buffer)
-                    if new_image_data:
-                        if image_data is None:
-                            image_data = []
-                        image_data.extend(new_image_data)
-                    if new_video_data:
-                        if video_data is None:
-                            video_data = []
-                        video_data.extend(new_video_data)
+            if not capacity_exhausted:
+                buffer.response_ids.extend(incremental_ids)
+                buffer.response_mask.extend([0] * len(incremental_ids))
+                if sampling_params.get("logprobs", False):
+                    buffer.response_logprobs.extend([0.0] * len(incremental_ids))
+                self._assert_response_logprob_alignment(buffer)
+                if new_image_data:
+                    if image_data is None:
+                        image_data = []
+                    image_data.extend(new_image_data)
+                if new_video_data:
+                    if video_data is None:
+                        video_data = []
+                    video_data.extend(new_video_data)
 
         context_ids = buffer.prompt_ids + buffer.response_ids
         if capacity_exhausted:
@@ -613,6 +579,10 @@ class GatewaySession:
                 ranked_candidates.append((chain, len(chain.message_history), True))
                 continue
             if self._enable_last_assistant_rollback:
+                if assistant_start.response_ids_len == 0:
+                    # A first assistant rewrite has no trainable response tokens to preserve;
+                    # leave this candidate out so an exact or later rollback chain can still win.
+                    continue
                 if assistant_start_len > deepest_rollback_service_value:
                     deepest_rollback_candidates = [chain]
                     deepest_rollback_service_value = assistant_start_len

--- a/uni_agent/gateway/session/session.py
+++ b/uni_agent/gateway/session/session.py
@@ -462,6 +462,19 @@ class GatewaySession:
                     image_data=new_image_data,
                     video_data=new_video_data,
                 )
+                turn_separator = self._codec.turn_separator
+                if (
+                    rollback_applied
+                    and turn_separator
+                    and buffer.response_ids[-len(turn_separator) :] == turn_separator
+                    and incremental_ids[: len(turn_separator)] == turn_separator
+                ):
+                    # Rollback retains the separator before the removed GP. Keep the
+                    # incremental encoder's copy when it restores the same boundary.
+                    del buffer.response_ids[-len(turn_separator) :]
+                    del buffer.response_mask[-len(turn_separator) :]
+                    del buffer.response_logprobs[-len(turn_separator) :]
+                    current_trajectory_length -= len(turn_separator)
                 capacity_exhausted = (
                     self._trajectory_capacity is not None
                     and current_trajectory_length + len(incremental_ids) >= self._trajectory_capacity

--- a/uni_agent/gateway/session/session.py
+++ b/uni_agent/gateway/session/session.py
@@ -415,19 +415,16 @@ class GatewaySession:
             self._assert_response_logprob_alignment(buffer)
             image_data, video_data = self._copy_chain_media(selected_chain)
             chain_id = selected_chain.chain_id
+            reencoded_full_prompt = False
             if rollback_to_last_assistant:
                 last_assistant_start = selected_chain.last_assistant_start
                 assert last_assistant_start.response_ids_len <= len(buffer.response_ids)
                 assert last_assistant_start.response_mask_len <= len(buffer.response_mask)
                 assert last_assistant_start.response_logprobs_len <= len(buffer.response_logprobs)
                 rollback_dropped_trainable_tokens = sum(buffer.response_mask[last_assistant_start.response_mask_len :])
-                del buffer.response_ids[last_assistant_start.response_ids_len :]
-                del buffer.response_mask[last_assistant_start.response_mask_len :]
-                del buffer.response_logprobs[last_assistant_start.response_logprobs_len :]
                 # One generation appends exactly one mark, so the rewritten
                 # assistant is always the last one.
                 del buffer.generation_versions[-1:]
-                self._assert_response_logprob_alignment(buffer)
 
                 if image_data is not None:
                     assert last_assistant_start.image_data_len <= len(image_data)
@@ -435,45 +432,111 @@ class GatewaySession:
                 if video_data is not None:
                     assert last_assistant_start.video_data_len <= len(video_data)
                     video_data = video_data[: last_assistant_start.video_data_len] or None
-                incremental_start = last_assistant_start.message_history_len
+                if last_assistant_start.response_ids_len == 0:
+                    # No response-side context predates the first assistant, so rebuild the
+                    # requested history as a fresh prompt instead of splicing its prompt GP.
+                    del buffer.response_ids[:]
+                    del buffer.response_mask[:]
+                    del buffer.response_logprobs[:]
+                    buffer.routed_experts = None
+                    incremental_messages = messages[last_assistant_start.message_history_len :]
+                    new_image_data, new_video_data = await self._codec.extract_multi_modal_data(incremental_messages)
+                    full_image_data = list(image_data or [])
+                    full_video_data = list(video_data or [])
+                    if new_image_data:
+                        full_image_data.extend(new_image_data)
+                    if new_video_data:
+                        full_video_data.extend(new_video_data)
+                    prompt_ids = self._codec.encode_full(
+                        messages,
+                        tools=tools,
+                        image_data=full_image_data or None,
+                        video_data=full_video_data or None,
+                    )
+                    capacity_exhausted = (
+                        self._trajectory_capacity is not None and len(prompt_ids) >= self._trajectory_capacity
+                    )
+                    if not capacity_exhausted:
+                        buffer = TrajectoryBuffer(prompt_ids=prompt_ids)
+                        image_data = full_image_data or None
+                        video_data = full_video_data or None
+                    reencoded_full_prompt = True
+                else:
+                    # Later rollbacks retain earlier trainable output; the snapshot was captured
+                    # after the prior incremental GP, so remove that verified suffix as well.
+                    rollback_response_ids_len = last_assistant_start.response_ids_len
+                    rollback_response_mask_len = last_assistant_start.response_mask_len
+                    rollback_response_logprobs_len = last_assistant_start.response_logprobs_len
+                    generation_prompt = self._codec.generation_prompt
+                    if generation_prompt:
+                        generation_prompt_len = len(generation_prompt)
+                        generation_prompt_start = rollback_response_ids_len - generation_prompt_len
+                        if (
+                            generation_prompt_start < 0
+                            or buffer.response_ids[generation_prompt_start:rollback_response_ids_len]
+                            != generation_prompt
+                        ):
+                            raise ValueError(
+                                "Stored response does not end its assistant prefix with the generation prompt"
+                            )
+                        rollback_response_ids_len = generation_prompt_start
+                        rollback_response_mask_len -= generation_prompt_len
+                        if rollback_response_mask_len < 0 or any(
+                            buffer.response_mask[rollback_response_mask_len : last_assistant_start.response_mask_len]
+                        ):
+                            raise ValueError("Stored generation-prompt mask is not rollback-safe")
+                        if rollback_response_logprobs_len:
+                            rollback_response_logprobs_len -= generation_prompt_len
+                            if rollback_response_logprobs_len < 0 or any(
+                                buffer.response_logprobs[
+                                    rollback_response_logprobs_len : last_assistant_start.response_logprobs_len
+                                ]
+                            ):
+                                raise ValueError("Stored generation-prompt logprobs are not rollback-safe")
+                    del buffer.response_ids[rollback_response_ids_len:]
+                    del buffer.response_mask[rollback_response_mask_len:]
+                    del buffer.response_logprobs[rollback_response_logprobs_len:]
+                    self._assert_response_logprob_alignment(buffer)
+                    incremental_start = last_assistant_start.message_history_len
                 rollback_applied = True
             else:
                 incremental_start = len(selected_chain.message_history)
 
-            incremental_messages = messages[incremental_start:]
-            new_image_data = None
-            new_video_data = None
-            incremental_ids = []
-            current_trajectory_length = len(buffer.prompt_ids) + len(buffer.response_ids)
-            capacity_exhausted = (
-                self._trajectory_capacity is not None and current_trajectory_length >= self._trajectory_capacity
-            )
-            if incremental_messages and not capacity_exhausted:
-                new_image_data, new_video_data = await self._codec.extract_multi_modal_data(incremental_messages)
-                incremental_ids = self._codec.encode_incremental(
-                    incremental_messages,
-                    image_data=new_image_data,
-                    video_data=new_video_data,
-                )
+            if not reencoded_full_prompt:
+                incremental_messages = messages[incremental_start:]
+                new_image_data = None
+                new_video_data = None
+                incremental_ids = []
+                current_trajectory_length = len(buffer.prompt_ids) + len(buffer.response_ids)
                 capacity_exhausted = (
-                    self._trajectory_capacity is not None
-                    and current_trajectory_length + len(incremental_ids) >= self._trajectory_capacity
+                    self._trajectory_capacity is not None and current_trajectory_length >= self._trajectory_capacity
                 )
+                if incremental_messages and not capacity_exhausted:
+                    new_image_data, new_video_data = await self._codec.extract_multi_modal_data(incremental_messages)
+                    incremental_ids = self._codec.encode_incremental(
+                        incremental_messages,
+                        image_data=new_image_data,
+                        video_data=new_video_data,
+                    )
+                    capacity_exhausted = (
+                        self._trajectory_capacity is not None
+                        and current_trajectory_length + len(incremental_ids) >= self._trajectory_capacity
+                    )
 
-            if not capacity_exhausted:
-                buffer.response_ids.extend(incremental_ids)
-                buffer.response_mask.extend([0] * len(incremental_ids))
-                if sampling_params.get("logprobs", False):
-                    buffer.response_logprobs.extend([0.0] * len(incremental_ids))
-                self._assert_response_logprob_alignment(buffer)
-                if new_image_data:
-                    if image_data is None:
-                        image_data = []
-                    image_data.extend(new_image_data)
-                if new_video_data:
-                    if video_data is None:
-                        video_data = []
-                    video_data.extend(new_video_data)
+                if not capacity_exhausted:
+                    buffer.response_ids.extend(incremental_ids)
+                    buffer.response_mask.extend([0] * len(incremental_ids))
+                    if sampling_params.get("logprobs", False):
+                        buffer.response_logprobs.extend([0.0] * len(incremental_ids))
+                    self._assert_response_logprob_alignment(buffer)
+                    if new_image_data:
+                        if image_data is None:
+                            image_data = []
+                        image_data.extend(new_image_data)
+                    if new_video_data:
+                        if video_data is None:
+                            video_data = []
+                        video_data.extend(new_video_data)
 
         context_ids = buffer.prompt_ids + buffer.response_ids
         if capacity_exhausted:

--- a/uni_agent/gateway/session/session.py
+++ b/uni_agent/gateway/session/session.py
@@ -438,6 +438,8 @@ class GatewaySession:
                     != generation_prompt
                 ):
                     raise ValueError("Stored response does not end its assistant prefix with the generation prompt")
+                # Incremental encoding restores the turn separator with the replacement suffix.
+                rollback_response_len -= len(self._codec.turn_separator)
                 del buffer.response_ids[rollback_response_len:]
                 del buffer.response_mask[rollback_response_len:]
                 del buffer.response_logprobs[rollback_response_len:]
@@ -462,19 +464,6 @@ class GatewaySession:
                     image_data=new_image_data,
                     video_data=new_video_data,
                 )
-                turn_separator = self._codec.turn_separator
-                if (
-                    rollback_applied
-                    and turn_separator
-                    and buffer.response_ids[-len(turn_separator) :] == turn_separator
-                    and incremental_ids[: len(turn_separator)] == turn_separator
-                ):
-                    # Rollback retains the separator before the removed GP. Keep the
-                    # incremental encoder's copy when it restores the same boundary.
-                    del buffer.response_ids[-len(turn_separator) :]
-                    del buffer.response_mask[-len(turn_separator) :]
-                    del buffer.response_logprobs[-len(turn_separator) :]
-                    current_trajectory_length -= len(turn_separator)
                 capacity_exhausted = (
                     self._trajectory_capacity is not None
                     and current_trajectory_length + len(incremental_ids) >= self._trajectory_capacity

--- a/uni_agent/gateway/session/session.py
+++ b/uni_agent/gateway/session/session.py
@@ -580,8 +580,8 @@ class GatewaySession:
                 continue
             if self._enable_last_assistant_rollback:
                 if assistant_start.response_ids_len == 0:
-                    # A first assistant rewrite has no trainable response tokens to preserve;
-                    # leave this candidate out so an exact or later rollback chain can still win.
+                    # No response-side tokens predate this assistant, so rollback has nothing
+                    # to preserve. Omit it while still allowing an exact or later chain to win.
                     continue
                 if assistant_start_len > deepest_rollback_service_value:
                     deepest_rollback_candidates = [chain]

--- a/uni_agent/gateway/session/session.py
+++ b/uni_agent/gateway/session/session.py
@@ -67,8 +67,6 @@ class LastAssistantStart:
     """Stable chain lengths captured immediately before its latest assistant."""
 
     response_ids_len: int
-    response_mask_len: int
-    response_logprobs_len: int
     message_history_len: int
     image_data_len: int
     video_data_len: int
@@ -418,9 +416,7 @@ class GatewaySession:
             if rollback_to_last_assistant:
                 last_assistant_start = selected_chain.last_assistant_start
                 assert last_assistant_start.response_ids_len <= len(buffer.response_ids)
-                assert last_assistant_start.response_mask_len <= len(buffer.response_mask)
-                assert last_assistant_start.response_logprobs_len <= len(buffer.response_logprobs)
-                rollback_dropped_trainable_tokens = sum(buffer.response_mask[last_assistant_start.response_mask_len :])
+                rollback_dropped_trainable_tokens = sum(buffer.response_mask[last_assistant_start.response_ids_len :])
                 # One generation appends exactly one mark, so the rewritten
                 # assistant is always the last one.
                 del buffer.generation_versions[-1:]
@@ -434,35 +430,17 @@ class GatewaySession:
                 assert last_assistant_start.response_ids_len > 0
                 # Later rollbacks retain earlier trainable output; the snapshot was captured
                 # after the prior incremental GP, so remove that verified suffix as well.
-                rollback_response_ids_len = last_assistant_start.response_ids_len
-                rollback_response_mask_len = last_assistant_start.response_mask_len
-                rollback_response_logprobs_len = last_assistant_start.response_logprobs_len
                 generation_prompt = self._codec.generation_prompt
-                if generation_prompt:
-                    generation_prompt_len = len(generation_prompt)
-                    generation_prompt_start = rollback_response_ids_len - generation_prompt_len
-                    if (
-                        generation_prompt_start < 0
-                        or buffer.response_ids[generation_prompt_start:rollback_response_ids_len] != generation_prompt
-                    ):
-                        raise ValueError("Stored response does not end its assistant prefix with the generation prompt")
-                    rollback_response_ids_len = generation_prompt_start
-                    rollback_response_mask_len -= generation_prompt_len
-                    if rollback_response_mask_len < 0 or any(
-                        buffer.response_mask[rollback_response_mask_len : last_assistant_start.response_mask_len]
-                    ):
-                        raise ValueError("Stored generation-prompt mask is not rollback-safe")
-                    if rollback_response_logprobs_len:
-                        rollback_response_logprobs_len -= generation_prompt_len
-                        if rollback_response_logprobs_len < 0 or any(
-                            buffer.response_logprobs[
-                                rollback_response_logprobs_len : last_assistant_start.response_logprobs_len
-                            ]
-                        ):
-                            raise ValueError("Stored generation-prompt logprobs are not rollback-safe")
-                del buffer.response_ids[rollback_response_ids_len:]
-                del buffer.response_mask[rollback_response_mask_len:]
-                del buffer.response_logprobs[rollback_response_logprobs_len:]
+                rollback_response_len = last_assistant_start.response_ids_len - len(generation_prompt)
+                if (
+                    rollback_response_len < 0
+                    or buffer.response_ids[rollback_response_len : last_assistant_start.response_ids_len]
+                    != generation_prompt
+                ):
+                    raise ValueError("Stored response does not end its assistant prefix with the generation prompt")
+                del buffer.response_ids[rollback_response_len:]
+                del buffer.response_mask[rollback_response_len:]
+                del buffer.response_logprobs[rollback_response_len:]
                 self._assert_response_logprob_alignment(buffer)
                 incremental_start = last_assistant_start.message_history_len
                 rollback_applied = True
@@ -686,8 +664,6 @@ class GatewaySession:
     ) -> LastAssistantStart:
         return LastAssistantStart(
             response_ids_len=len(buffer.response_ids),
-            response_mask_len=len(buffer.response_mask),
-            response_logprobs_len=len(buffer.response_logprobs),
             message_history_len=message_history_len,
             image_data_len=len(image_data or []),
             video_data_len=len(video_data or []),


### PR DESCRIPTION
## Summary

Fix redundant generation-prompt tokens in Gateway assistant rewrites. First-assistant rewrites now split into a fresh chain, while later rollbacks preserve earlier trainable output and remove only the stale response-side generation prompt. PR #101 remains responsible for changing the incremental anchor implementation.

## Changes

- Add a codec-local `initialize_generation_prompt` helper that probes the configured chat-template generation-prompt token suffix and validates its stable prefix boundary.
- Reuse one `processing_class` for both system-prompt and generation-prompt initialization.
- Exclude candidates with no response-side tokens before the latest assistant from rollback selection; the request follows the existing full-encode split path and keeps the abandoned chain unchanged.
- For later rollbacks, verify and remove only the response-side GP preceding the abandoned assistant while preserving earlier trainable output.
- Trim duplicate capacity, multimodal, and weight-span matrix tests; retain focused behavioral and malformed-state coverage.

## Validation

- `PYTHONPATH="$PWD:$PWD/verl" pytest tests/uni_agent/gateway/test_message_codec_initialization.py tests/uni_agent/gateway/test_message_codec_tool_dispatch.py tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py tests/uni_agent/gateway/test_gateway_actor_on_cpu.py -q` — 113 passed, 5 warnings.
- `pre-commit run --all-files --show-diff-on-failure --color=always` — passed.
- `ledger_update: none`; the `uni-agent-evolution-ledger` skill is not available in this environment, and no remote ledger was modified.

## Compatibility

No public request or configuration API changes. `encode_full` remains unchanged and retains the trailing generation prompt. First-assistant rewrites now produce sibling trajectories instead of replacing the abandoned chain; PR #101 anchor behavior is intentionally out of scope.

## Checklist

- [x] Focused Gateway rollback/split change with tests.
- [x] No `verl/` submodule changes.
- [x] No credentials or rollout artifacts included.
