### PR TITLE
[tasks] feat: support swe bench multiligual

### DIFF
--- a/tests/uni_agent/sandbox/test_exec_error_policy.py
+++ b/tests/uni_agent/sandbox/test_exec_error_policy.py
@@ -95,10 +95,10 @@ def test_timeout_wins_over_liveness_even_when_dead():
     assert res.exit_code == -1
 
 
-def test_exec_shell_wraps_in_bash_lc():
+def test_exec_shell_wraps_in_non_login_bash():
     sb = _FakeSandbox(result=ExecResult(exit_code=0, stdout="", stderr=""))
     asyncio.run(sb.exec_shell("echo hi", timeout=3, workdir="/tmp"))
-    assert sb.calls[0]["argv"] == ["bash", "-lc", "echo hi"]
+    assert sb.calls[0]["argv"] == ["bash", "-c", "echo hi"]
     assert sb.calls[0]["timeout"] == 3
     assert sb.calls[0]["workdir"] == "/tmp"
 

--- a/uni_agent/sandbox/base.py
+++ b/uni_agent/sandbox/base.py
@@ -151,7 +151,7 @@ class Sandbox(abc.ABC):
 
     Providers implement :meth:`start`, :meth:`stop` and the :meth:`_exec`
     primitive; the public :meth:`exec` wraps ``_exec`` with a shared error
-    policy, and the ``bash -lc`` helper and exec-based file transfer build on
+    policy, and the non-login ``bash -c`` helper and exec-based file transfer build on
     top. :meth:`expose_port` is optional (raises until a provider implements it).
     """
 
@@ -299,8 +299,8 @@ class Sandbox(abc.ABC):
         workdir: str | None = None,
         env: dict[str, str] | None = None,
     ) -> ExecResult:
-        """Convenience: run ``script`` through ``bash -lc``."""
-        return await self.exec(["bash", "-lc", script], timeout=timeout, workdir=workdir, env=env)
+        """Convenience: run ``script`` through a non-login ``bash -c`` shell."""
+        return await self.exec(["bash", "-c", script], timeout=timeout, workdir=workdir, env=env)
 
     async def expose_port(self, port: int) -> str:
         """Return a host-reachable URL/addr for an in-sandbox ``port``.

--- a/uni_agent/tasks/registry.py
+++ b/uni_agent/tasks/registry.py
@@ -21,6 +21,7 @@ TASK_REGISTRY: dict[str, type[Task]] = {}
 #: name -> module that defines (and registers) the task, for lazy loading.
 TASK_MODULES: dict[str, str] = {
     "swe_bench": "uni_agent.tasks.swe_bench.task",
+    "swe_bench_multilingual": "uni_agent.tasks.swe_bench_multilingual.task",
     "swe_rebench": "uni_agent.tasks.swe_rebench.task",
 }
 

--- a/uni_agent/tasks/swe_bench_multilingual/__init__.py
+++ b/uni_agent/tasks/swe_bench_multilingual/__init__.py
@@ -1,0 +1,1 @@
+"""SWE-bench Multilingual task package."""

--- a/uni_agent/tasks/swe_bench_multilingual/preprocess.py
+++ b/uni_agent/tasks/swe_bench_multilingual/preprocess.py
@@ -1,0 +1,167 @@
+# ruff: noqa: E501
+"""Preprocess SWE-bench Multilingual into the new-framework SWE task format.
+
+The generated rows are provider-agnostic: they carry the canonical public
+``swebench/sweb.eval.x86_64.<id>`` image reference and leave provider-specific
+image mapping and resource configuration to the sandbox at run time.
+
+Example::
+
+    python -m uni_agent.tasks.swe_bench_multilingual.preprocess \
+        --local-save-dir ~/data/swe_agent
+"""
+
+import argparse
+import os
+
+from datasets import load_dataset
+from swebench.harness.constants import MAP_REPO_TO_EXT
+
+
+def get_image_name(instance_id: str) -> str:
+    """Return the canonical image ref, mirroring swebench's instance image key."""
+    return f"swebench/sweb.eval.x86_64.{instance_id.lower().replace('__', '_1776_')}"
+
+
+# Map swebench's file-extension code to a human-readable language for the prompt.
+EXT_TO_LANGUAGE = {
+    "c": "C",
+    "go": "Go",
+    "java": "Java",
+    "js": "JavaScript",
+    "php": "PHP",
+    "rb": "Ruby",
+    "rs": "Rust",
+}
+
+
+SYSTEM_PROMPT = """
+You are a helpful assistant that can interact with a computer to solve tasks.
+""".strip()
+
+USER_PROMPT = """
+<uploaded_files>
+/testbed
+</uploaded_files>
+I have uploaded a code repository in the /testbed directory (primary language: {language}). You can explore and modify files using the available tools. Consider the following issue description:
+
+<issue_description>
+{problem_statement}
+</issue_description>
+
+Can you help me implement the necessary changes to the repository to fix the <issue_description>?
+I have already taken care of all changes to any of the test files described in the <issue_description>. This means you DON'T have to modify the testing logic or any of the tests in any way!
+Also the development environment is already set up for you (i.e., all dependencies are already installed and the project is already built), so you don't need to install other packages.
+Your task is to make the minimal changes to non-test files in the /testbed directory to ensure the <issue_description> is satisfied.
+
+Follow these steps to resolve the issue:
+1. First, explore the codebase to locate and understand the code relevant to the <issue_description>.
+- Use efficient search commands to identify key files and functions.
+- Build your understanding of how the code works, the expected behaviors and edge cases, and the potential root causes for the given issue.
+
+2. Assess whether you can reproduce the issue:
+- Create a small script (e.g. at '/testbed/reproduce_issue.*') that demonstrates the error, using the repository's own language/runtime.
+- Execute this script to confirm the error behavior before fixing it.
+- Your reproduction script should also assert the expected behavior for the fixed code.
+
+3. Analyze the root cause:
+- Identify the underlying problem based on your code exploration and reproduction results.
+- Reason about multiple potential approaches and pick the most elegant and effective one, considering correctness, generality, and side effects.
+
+4. Implement your solution:
+- Make targeted changes to the necessary files following idiomatic code patterns once you determine the root cause.
+
+5. Verify your solution:
+- Rerun your reproduction script to confirm the error is fixed, iterating until successful.
+
+6. Run unit tests:
+- Find and run the relevant unit tests using the project's own test runner to ensure your solution is correct and does not cause regressions.
+- DO NOT MODIFY any of the existing unit tests. You can add new edge test cases in a separate file if needed BUT DO NOT MODIFY THE EXISTING TESTS.
+
+7. Test edge cases:
+- Identify potential edge cases that might challenge your solution, create additional tests in a separate file, and verify robustness.
+
+8. Submit your solution:
+- Once you have verified your solution, submit it using the `submit` tool.
+
+A successful resolution means:
+- The specific error/issue described no longer occurs
+- Your changes maintain compatibility with existing functionality
+- Edge cases are properly handled
+""".strip()
+
+
+def build_swe_bench_multilingual(max_instances: int | None = None):
+    def process(example):
+        repo = example["repo"]
+        instance_id = example["instance_id"]
+        language = EXT_TO_LANGUAGE.get(MAP_REPO_TO_EXT[repo], "the project's")
+
+        metadata = {
+            "instance_id": instance_id,
+            "repo": repo,
+            "version": str(example["version"]),
+            "base_commit": example["base_commit"],
+            "patch": example["patch"],
+            "test_patch": example["test_patch"],
+            "problem_statement": example["problem_statement"],
+            "FAIL_TO_PASS": example["FAIL_TO_PASS"],
+            "PASS_TO_PASS": example["PASS_TO_PASS"],
+        }
+        prompt = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": USER_PROMPT.format(
+                    language=language,
+                    problem_statement=example["problem_statement"],
+                ),
+            },
+        ]
+
+        task_config = {
+            "name": "swe_bench_multilingual",
+            "sandbox": {"image": get_image_name(instance_id)},
+            "prompt": prompt,
+            "metadata": metadata,
+        }
+
+        return {
+            "data_source": "SWE-bench/SWE-bench_Multilingual",
+            "prompt": prompt,
+            "extra_info": {
+                "tools_kwargs": {"task": task_config},
+            },
+        }
+
+    data_source = "SWE-bench/SWE-bench_Multilingual"
+    print(f"Loading the {data_source} dataset from huggingface...", flush=True)
+    dataset = load_dataset(data_source, split="test")
+    print(f"Loaded {len(dataset)} raw instances", flush=True)
+
+    if max_instances is not None and max_instances >= 0:
+        dataset = dataset.select(range(min(max_instances, len(dataset))))
+        print(f"Capped to {len(dataset)} instances", flush=True)
+
+    dataset = dataset.map(process, remove_columns=dataset.column_names)
+    return dataset
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--local-save-dir", default="~/data/swe_agent")
+    parser.add_argument(
+        "--max-instances",
+        type=int,
+        default=None,
+        help="Optional cap on the number of instances kept (smoke testing).",
+    )
+    args = parser.parse_args()
+
+    save_dir = os.path.expanduser(args.local_save_dir)
+    os.makedirs(save_dir, exist_ok=True)
+
+    dataset = build_swe_bench_multilingual(max_instances=args.max_instances)
+    out_path = f"{save_dir}/swe_bench_multilingual.parquet"
+    dataset.to_parquet(out_path)
+    print(f"Wrote {len(dataset)} instances to {out_path}", flush=True)

--- a/uni_agent/tasks/swe_bench_multilingual/reward.py
+++ b/uni_agent/tasks/swe_bench_multilingual/reward.py
@@ -1,0 +1,186 @@
+"""SWE-bench Multilingual evaluation and reward computation.
+
+The benchmark spans C, Go, Java, JavaScript, PHP, Ruby, and Rust repositories.
+Its published images contain the language-specific dependencies and may also
+contain uncommitted build-time edits. Evaluation therefore resets only the test
+files, preserving both those edits and the agent's solution.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+
+from swebench.harness.constants import (
+    END_TEST_OUTPUT,
+    FAIL_ONLY_REPOS,
+    MAP_REPO_TO_EXT,
+    MAP_REPO_VERSION_TO_SPECS,
+    START_TEST_OUTPUT,
+    EvalType,
+    ResolvedStatus,
+)
+from swebench.harness.grading import get_eval_tests_report, get_resolution_status
+from swebench.harness.log_parsers import MAP_REPO_TO_PARSER
+from swebench.harness.test_spec.javascript import get_download_img_commands
+from swebench.harness.test_spec.test_spec import make_test_spec
+from swebench.harness.utils import get_modified_files
+
+logger = logging.getLogger(__name__)
+
+# Heredoc delimiter used by the upstream harness to inline the test patch.
+HEREDOC_DELIMITER = "EOF_114329324912"
+
+
+def _as_commands(value) -> list[str]:
+    """Normalize a harness command field to a list of shell commands."""
+    if not value:
+        return []
+    if isinstance(value, str):
+        return [value]
+    return list(value)
+
+
+def _make_eval_script_list(metadata: dict) -> list[str]:
+    """Build the official multilingual test flow without resetting the solution."""
+    repo = metadata["repo"]
+    version = str(metadata["version"])
+    repo_directory = "/testbed"
+    base_commit = metadata["base_commit"]
+    test_patch = metadata["test_patch"]
+    specs = MAP_REPO_VERSION_TO_SPECS[repo][version]
+
+    test_files = get_modified_files(test_patch)
+    if test_files:
+        reset_tests_command = f"git checkout {base_commit} {' '.join(test_files)}"
+    else:
+        reset_tests_command = "echo 'skip reset'"
+
+    apply_test_patch_command = (
+        f"git apply --verbose --reject - <<'{HEREDOC_DELIMITER}'\n{test_patch}\n{HEREDOC_DELIMITER}"
+    )
+    build_commands = _as_commands(specs.get("build"))
+    test_commands = _as_commands(specs["test_cmd"])
+
+    eval_commands = [
+        "chmod 1777 /tmp 2>/dev/null || true",
+        f"cd {repo_directory}",
+        f"git config --global --add safe.directory {repo_directory}",
+        f"cd {repo_directory}",
+        reset_tests_command,
+        apply_test_patch_command,
+        *build_commands,
+        f": '{START_TEST_OUTPUT}'",
+        *test_commands,
+        f": '{END_TEST_OUTPUT}'",
+        reset_tests_command,
+    ]
+
+    # JavaScript instances may carry image fixtures downloaded immediately
+    # before applying the test patch.
+    if MAP_REPO_TO_EXT[repo] == "js":
+        patch_index = eval_commands.index(apply_test_patch_command)
+        eval_commands[patch_index:patch_index] = get_download_img_commands(metadata)
+
+    return eval_commands
+
+
+def _build_eval_script(metadata: dict) -> str:
+    """Assemble the eval script without ``set -e`` so cleanup always runs."""
+    return "\n".join(["#!/bin/bash", "set -uxo pipefail", *_make_eval_script_list(metadata)]) + "\n"
+
+
+def _grade(test_spec, output: str) -> dict:
+    """Parse test output and grade FAIL_TO_PASS/PASS_TO_PASS with swebench."""
+    report = {
+        "resolved": False,
+        "found_eval_status": False,
+        "test_status": None,
+    }
+
+    parser = MAP_REPO_TO_PARSER[test_spec.repo]
+    if START_TEST_OUTPUT in output and END_TEST_OUTPUT in output:
+        test_output = output.split(START_TEST_OUTPUT, 1)[1].split(END_TEST_OUTPUT, 1)[0]
+    else:
+        test_output = output
+
+    status_map = parser(test_output, test_spec)
+    # Some runners emit relevant output outside the markers, commonly on stderr.
+    if not status_map and test_output != output:
+        status_map = parser(output, test_spec)
+    if not status_map:
+        logger.warning(
+            "SWE-bench Multilingual parser matched no tests for %s; output tail:\n%s",
+            test_spec.instance_id,
+            output[-3000:],
+        )
+        return report
+
+    report["found_eval_status"] = True
+    eval_ref = {
+        "instance_id": test_spec.instance_id,
+        "FAIL_TO_PASS": test_spec.FAIL_TO_PASS,
+        "PASS_TO_PASS": test_spec.PASS_TO_PASS,
+    }
+    eval_type = EvalType.FAIL_ONLY if test_spec.repo in FAIL_ONLY_REPOS else EvalType.PASS_AND_FAIL
+    test_status = get_eval_tests_report(status_map, eval_ref, eval_type=eval_type)
+    report["test_status"] = test_status
+    report["resolved"] = get_resolution_status(test_status) == ResolvedStatus.FULL.value
+
+    if not report["resolved"]:
+        logger.warning(
+            "SWE-bench Multilingual unresolved for %s: FAIL_TO_PASS failures=%s; "
+            "PASS_TO_PASS failures=%s",
+            test_spec.instance_id,
+            test_status["FAIL_TO_PASS"]["failure"][:25],
+            test_status["PASS_TO_PASS"]["failure"][:25],
+        )
+
+    return report
+
+
+async def compute_reward(metadata: dict, sandbox, eval_timeout: float = 1800.0) -> dict:
+    """Run the official multilingual evaluation flow inside ``sandbox``."""
+    result = {
+        "eval_completed": False,
+        "eval_execution_time": None,
+        "eval_report": None,
+        "resolved": False,
+    }
+
+    test_spec = make_test_spec(metadata)
+    eval_script_path = f"/tmp/sbm_eval_{uuid.uuid4().hex}.sh"
+    await sandbox.write_file(eval_script_path, _build_eval_script(metadata))
+
+    logger.info(
+        "running SWE-bench Multilingual eval for %s (repo=%s, language=%s, timeout=%.0fs)",
+        test_spec.instance_id,
+        test_spec.repo,
+        getattr(test_spec, "language", "?"),
+        eval_timeout,
+    )
+    execution_t0 = time.perf_counter()
+
+    # Piping through cat gives the language-specific runners a non-TTY output
+    # stream, matching the official harness's docker-exec behavior.
+    response = await sandbox.exec_shell(
+        f"set -o pipefail; bash {eval_script_path} 2>&1 | cat",
+        workdir="/testbed",
+        timeout=eval_timeout,
+    )
+    execution_time = time.perf_counter() - execution_t0
+    output = response.stdout
+    if response.stderr:
+        output = f"{output}\n{response.stderr}"
+
+    result["eval_completed"] = response.exit_code == 0
+    result["eval_execution_time"] = execution_time
+    logger.info("multilingual eval finished in %.1fs (exit_code=%s)", execution_time, response.exit_code)
+
+    eval_report = _grade(test_spec, output)
+    result["eval_report"] = eval_report
+    result["resolved"] = eval_report["resolved"]
+    logger.info("reward for %s: resolved=%s", test_spec.instance_id, result["resolved"])
+
+    return result

--- a/uni_agent/tasks/swe_bench_multilingual/reward.py
+++ b/uni_agent/tasks/swe_bench_multilingual/reward.py
@@ -130,8 +130,7 @@ def _grade(test_spec, output: str) -> dict:
 
     if not report["resolved"]:
         logger.warning(
-            "SWE-bench Multilingual unresolved for %s: FAIL_TO_PASS failures=%s; "
-            "PASS_TO_PASS failures=%s",
+            "SWE-bench Multilingual unresolved for %s: FAIL_TO_PASS failures=%s; PASS_TO_PASS failures=%s",
             test_spec.instance_id,
             test_status["FAIL_TO_PASS"]["failure"][:25],
             test_status["PASS_TO_PASS"]["failure"][:25],

--- a/uni_agent/tasks/swe_bench_multilingual/task.py
+++ b/uni_agent/tasks/swe_bench_multilingual/task.py
@@ -30,7 +30,7 @@ class SWEBenchMultilingualTaskConfig(TaskConfig):
         description="Oracle mode: skip the agent and score the dataset's gold patch directly.",
     )
     eval_timeout: float = Field(
-        default=1800.0,
+        default=600.0,
         gt=0,
         description="Maximum number of seconds allowed for multilingual evaluation.",
     )

--- a/uni_agent/tasks/swe_bench_multilingual/task.py
+++ b/uni_agent/tasks/swe_bench_multilingual/task.py
@@ -1,0 +1,95 @@
+"""SWE-bench Multilingual task lifecycle."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from pydantic import Field
+
+from ..base import Task, TaskConfig, TaskResult
+from ..registry import register_task
+
+logger = logging.getLogger(__name__)
+
+# Remove tags and unreachable future history without touching the working tree:
+# multilingual images may contain required, uncommitted build-time edits.
+_GIT_CLEAN_HISTORY = "\n".join(
+    [
+        "git tag -d $(git tag -l) 2>/dev/null || true",
+        "git reflog expire --expire=now --all || true",
+        "git gc --prune=now || true",
+    ]
+)
+
+
+class SWEBenchMultilingualTaskConfig(TaskConfig):
+    name: str = "swe_bench_multilingual"
+    run_gold_patch: bool = Field(
+        default=False,
+        description="Oracle mode: skip the agent and score the dataset's gold patch directly.",
+    )
+    eval_timeout: float = Field(
+        default=1800.0,
+        gt=0,
+        description="Maximum number of seconds allowed for multilingual evaluation.",
+    )
+
+
+@register_task("swe_bench_multilingual")
+class SWEBenchMultilingualTask(Task):
+    name = "swe_bench_multilingual"
+    config_model = SWEBenchMultilingualTaskConfig
+
+    async def run(self) -> TaskResult:
+        cfg: SWEBenchMultilingualTaskConfig = self.config  # type: ignore[assignment]
+        sample = cfg.metadata
+        instance_id = sample.get("instance_id", "?")
+        task_config_dump = cfg.model_dump(mode="json", exclude={"metadata", "prompt"})
+        logger.info(
+            "starting swe_bench_multilingual task "
+            f"(instance_id={instance_id}, run_gold_patch={cfg.run_gold_patch})\n"
+            f"task config: {json.dumps(task_config_dump, indent=2)}"
+        )
+
+        async with self.build_sandbox() as sandbox:
+            # Preserve build-time worktree edits while removing history that could
+            # expose the upstream solution to the agent.
+            await sandbox.exec_shell(_GIT_CLEAN_HISTORY, workdir="/testbed")
+
+            if cfg.run_gold_patch:
+                logger.info("applying gold patch to /testbed")
+                patch_path = "/tmp/gold_patch.patch"
+                await sandbox.write_file(patch_path, sample["patch"])
+                apply_result = await sandbox.exec(
+                    ["git", "apply", "--whitespace=fix", patch_path],
+                    workdir="/testbed",
+                )
+                if apply_result.exit_code != 0:
+                    error = apply_result.stderr.strip() or apply_result.stdout.strip()
+                    raise RuntimeError(f"failed to apply gold patch for {instance_id}: {error}")
+                finished = True
+            else:
+                agent = self.build_agent()
+                agent_result = await agent.run(sandbox=sandbox, messages=cfg.prompt)
+                finished = agent_result.finished
+
+            try:
+                from .reward import compute_reward
+
+                result = await compute_reward(
+                    sample,
+                    sandbox,
+                    eval_timeout=cfg.eval_timeout,
+                )
+            except Exception:
+                logger.exception("scoring failed for instance_id=%s", instance_id)
+                raise
+
+            logger.info("task done: resolved=%s", result["resolved"])
+            return TaskResult(
+                reward=float(result["resolved"]),
+                accuracy=float(result["resolved"]),
+                finished=finished,
+                extra_info=result,
+            )


### PR DESCRIPTION
## Summary

Verification Results:

Sandbox: Modal

### Verify Gold Patch

```text
------------------ eval summary ------------------
  resolved     295   (98.3%)
  wrong-ans      4
  timeout/err    1
  total        300
-------- avg 30.2s | wall 428.3s | n=299 ---------

2026-08-05 18:54:10,806 | INFO | fail_wa instance names: ['babel__babel-13928', 'babel__babel-14532', 'jqlang__jq-2839', 'tokio-rs__tokio-4384']
2026-08-05 18:54:10,806 | INFO | fail_tle instance names: ['jqlang__jq-2681']
```

This mostly aligns with the results before the refactor.

### Inference using Qwen3-Coder-30B

Setting: Qwen3-Coder-30B, using React Agent, with temp=0.8, top_p=0.9, turns=200, context=128k

Results:

```text
--------------- inference summary ----------------
  mean rm_score        0.3500   (over 300 sessions)
  mean over prompts    0.3500   (over 300 prompts)
  scored sessions     300 / 300  (300 prompts x n=1)
  failed prompts        0
------------------ wall 2784.5s ------------------
```

Official Results: 34.7

## PR title

Use `[area] type: summary`.

- Areas: `agents`, `framework`, `gateway`, `logging`, `sandbox`, `tasks`, `tools`, `training`, `app`, `docs`, `examples`, `ci`, `build`, `deps`, `misc`
- Types: `feat`, `fix`, `refactor`, `perf`, `test`, `docs`, `chore`, `revert`
- Separate multiple areas with comma-space: `[agents, sandbox] feat: add isolated harness execution`
- Prefix compatibility-breaking work with `[BREAKING]`: `[BREAKING][tasks, docs] refactor: replace task config schema`
- A stacked series may start with `[1/N]`: `[1/N][gateway] refactor: split protocol adapters`

## Checklist

- [ ] The PR is focused and linked to an issue or explains why no issue is needed.
- [ ] The title follows the format above and names the layer that owns the change.
- [ ] Tests cover the behavior, or the Validation section explains why they are not practical.
- [ ] User-facing API, config, and workflow changes include documentation or runnable examples.
- [ ] Compatibility impact and migration steps are documented.
- [ ] Logs, fixtures, and examples contain no credentials or private data.
- [ ] `pre-commit run --all-files --show-diff-on-failure` passes.
