### PR TITLE
[sandbox] fix: align OpenYuanrong with native SDK command and file APIs

### DIFF
--- a/examples/quickstart/sandbox/demo.py
+++ b/examples/quickstart/sandbox/demo.py
@@ -4,12 +4,13 @@ import asyncio
 import logging
 import os
 import sys
+import tempfile
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from uni_agent.logging import sample_logging
-from uni_agent.sandbox import SandboxConfig, build_sandbox
+from uni_agent.sandbox import Sandbox, SandboxConfig, build_sandbox
 from uni_agent.tools import Toolbox
 
 logger = logging.getLogger("demo")
@@ -49,6 +50,99 @@ def build_tool_specs() -> list[dict]:
     ]
 
 
+async def toolbox_operations(sandbox: Sandbox, tool_specs: list[dict]) -> None:
+    """Exercise Toolbox shell + str_replace_editor against the sandbox."""
+    logger.info(f"tools selected : {[t['name'] for t in tool_specs]}")
+    logger.info("(shell keeps a persistent shell channel; the editor is stateless)")
+    logger.info("each tool owns its own state")
+
+    toolbox = Toolbox.from_specs(tool_specs, sandbox=sandbox)
+
+    async with toolbox.entered(retry=3, timeout=60):
+        schemas = toolbox.schemas()
+        logger.info(f"-> tool schemas : {[s['function']['name'] for s in schemas]}")
+
+        banner("Sandbox demo: install dep -> create script -> run -> cat output")
+
+        # clean slate: local /tmp persists across runs (a fresh remote sandbox is already clean)
+        await toolbox.call("shell", {"command": "rm -f /tmp/demo.py /tmp/demo_out.txt"})
+
+        logger.info("[Step 0] shell: show shell env from config")
+        result = await toolbox.call("shell", {"command": "echo PAGER=$PAGER TQDM_DISABLE=$TQDM_DISABLE"})
+        logger.info(_indent(result))
+
+        logger.info("[Step 1] shell: pip install numpy (persists in this sandbox)")
+        result = await toolbox.call("shell", {"command": "pip install -q numpy && echo installed"})
+        logger.info(_indent(result))
+
+        script = "import numpy as np\nprint('sum =', int(np.array([1, 2, 4]).sum()))\n"
+        logger.info("[Step 2] str_replace_editor create /tmp/demo.py (writes via data plane)")
+        result = await toolbox.call(
+            "str_replace_editor", {"command": "create", "path": "/tmp/demo.py", "file_text": script}
+        )
+        logger.info(_indent(result))
+
+        logger.info("[Step 3] str_replace_editor view /tmp/demo.py")
+        result = await toolbox.call("str_replace_editor", {"command": "view", "path": "/tmp/demo.py"})
+        logger.info(_indent(result))
+
+        logger.info("[Step 4] shell: run script -> /tmp/demo_out.txt")
+        result = await toolbox.call("shell", {"command": "python3 /tmp/demo.py > /tmp/demo_out.txt 2>&1"})
+        logger.info(_indent(result))
+
+        logger.info("[Step 5] shell: cat /tmp/demo_out.txt (proves the file persisted)")
+        result = await toolbox.call("shell", {"command": "cat /tmp/demo_out.txt"})
+        logger.info(_indent(result))
+
+        logger.info("[Step 6] str_replace_editor str_replace (sum -> product), then re-run")
+        await toolbox.call(
+            "str_replace_editor",
+            {
+                "command": "str_replace",
+                "path": "/tmp/demo.py",
+                "old_str": "print('sum =', int(np.array([1, 2, 4]).sum()))",
+                "new_str": "print('product =', int(np.array([1, 2, 4]).prod()))",
+            },
+        )
+        result = await toolbox.call("shell", {"command": "python3 /tmp/demo.py"})
+        logger.info(_indent(result))
+
+        logger.info("[Step 7] stateful shell: cd /tmp, then a later call still sees it")
+        await toolbox.call("shell", {"command": "cd /tmp"})
+        result = await toolbox.call("shell", {"command": "echo cwd=$(pwd); python3 demo.py"})
+        logger.info(_indent(result))
+
+
+async def file_operations(sandbox: Sandbox) -> None:
+    """Exercise sandbox write/read/upload/download."""
+    banner("Sandbox file APIs: write_file / read_file / upload / download")
+
+    await sandbox.exec_shell("rm -f /tmp/sandbox_write.txt /tmp/sandbox_upload.txt")
+
+    logger.info("[Step 1] sandbox.write_file -> /tmp/sandbox_write.txt")
+    await sandbox.write_file("/tmp/sandbox_write.txt", "hello from write_file\n")
+    logger.info("[Step 2] sandbox.read_file /tmp/sandbox_write.txt")
+    written = await sandbox.read_file("/tmp/sandbox_write.txt")
+    logger.info(_indent(written.decode("utf-8")))
+    assert written.decode("utf-8") == "hello from write_file\n"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        local_src = Path(tmp) / "upload_src.txt"
+        local_dst = Path(tmp) / "download_dst.txt"
+        local_src.write_text("hello from upload\n", encoding="utf-8")
+
+        logger.info("[Step 3] sandbox.upload host file -> /tmp/sandbox_upload.txt")
+        await sandbox.upload(local_src, "/tmp/sandbox_upload.txt")
+        remote = await sandbox.read_file("/tmp/sandbox_upload.txt")
+        logger.info(_indent(remote.decode("utf-8")))
+        assert remote.decode("utf-8") == "hello from upload\n"
+
+        logger.info("[Step 4] sandbox.download /tmp/sandbox_upload.txt -> host")
+        await sandbox.download("/tmp/sandbox_upload.txt", local_dst)
+        logger.info(_indent(local_dst.read_text(encoding="utf-8")))
+        assert local_dst.read_text(encoding="utf-8") == "hello from upload\n"
+
+
 async def main() -> None:
     sandbox_config = build_sandbox_config()
     tool_specs = build_tool_specs()
@@ -56,67 +150,11 @@ async def main() -> None:
     sandbox = build_sandbox(sandbox_config)
     # No log_path -> console only (run with DEBUG_MODE=1 to see the INFO walkthrough).
     async with sample_logging("demo"), sandbox:
-        banner(f"sandbox (provider={sandbox_config.provider}); each tool owns its own state")
-        logger.info(f"tools selected : {[t['name'] for t in tool_specs]}")
-        logger.info("(shell keeps a persistent shell channel; the editor is stateless)")
+        banner(f"sandbox (provider={sandbox_config.provider})")
+        await toolbox_operations(sandbox, tool_specs)
+        await file_operations(sandbox)
 
-        toolbox = Toolbox.from_specs(tool_specs, sandbox=sandbox)
-
-        async with toolbox.entered(retry=3, timeout=60):
-            schemas = toolbox.schemas()
-            logger.info(f"-> tool schemas : {[s['function']['name'] for s in schemas]}")
-
-            banner("Sandbox demo: install dep -> create script -> run -> cat output")
-
-            # clean slate: local /tmp persists across runs (a fresh remote sandbox is already clean)
-            await toolbox.call("shell", {"command": "rm -f /tmp/demo.py /tmp/demo_out.txt"})
-
-            logger.info("[Step 0] shell: show shell env from config")
-            result = await toolbox.call("shell", {"command": "echo PAGER=$PAGER TQDM_DISABLE=$TQDM_DISABLE"})
-            logger.info(_indent(result))
-
-            logger.info("[Step 1] shell: pip install numpy (persists in this sandbox)")
-            result = await toolbox.call("shell", {"command": "pip install -q numpy && echo installed"})
-            logger.info(_indent(result))
-
-            script = "import numpy as np\nprint('sum =', int(np.array([1, 2, 4]).sum()))\n"
-            logger.info("[Step 2] str_replace_editor create /tmp/demo.py (writes via data plane)")
-            result = await toolbox.call(
-                "str_replace_editor", {"command": "create", "path": "/tmp/demo.py", "file_text": script}
-            )
-            logger.info(_indent(result))
-
-            logger.info("[Step 3] str_replace_editor view /tmp/demo.py")
-            result = await toolbox.call("str_replace_editor", {"command": "view", "path": "/tmp/demo.py"})
-            logger.info(_indent(result))
-
-            logger.info("[Step 4] shell: run script -> /tmp/demo_out.txt")
-            result = await toolbox.call("shell", {"command": "python3 /tmp/demo.py > /tmp/demo_out.txt 2>&1"})
-            logger.info(_indent(result))
-
-            logger.info("[Step 5] shell: cat /tmp/demo_out.txt (proves the file persisted)")
-            result = await toolbox.call("shell", {"command": "cat /tmp/demo_out.txt"})
-            logger.info(_indent(result))
-
-            logger.info("[Step 6] str_replace_editor str_replace (sum -> product), then re-run")
-            await toolbox.call(
-                "str_replace_editor",
-                {
-                    "command": "str_replace",
-                    "path": "/tmp/demo.py",
-                    "old_str": "print('sum =', int(np.array([1, 2, 4]).sum()))",
-                    "new_str": "print('product =', int(np.array([1, 2, 4]).prod()))",
-                },
-            )
-            result = await toolbox.call("shell", {"command": "python3 /tmp/demo.py"})
-            logger.info(_indent(result))
-
-            logger.info("[Step 7] stateful shell: cd /tmp, then a later call still sees it")
-            await toolbox.call("shell", {"command": "cd /tmp"})
-            result = await toolbox.call("shell", {"command": "echo cwd=$(pwd); python3 demo.py"})
-            logger.info(_indent(result))
-
-            banner("Demo done")
+        banner("Demo done")
 
 
 if __name__ == "__main__":

--- a/uni_agent/sandbox/base.py
+++ b/uni_agent/sandbox/base.py
@@ -149,10 +149,15 @@ async def _startup_slot() -> AsyncIterator[None]:
 class Sandbox(abc.ABC):
     """One provider = one class: owns lifecycle and is the data-plane backend.
 
-    Providers implement :meth:`start`, :meth:`stop` and the :meth:`_exec`
-    primitive; the public :meth:`exec` wraps ``_exec`` with a shared error
-    policy, and the non-login ``bash -c`` helper and exec-based file transfer build on
-    top. :meth:`expose_port` is optional (raises until a provider implements it).
+    Providers implement :meth:`start` and :meth:`stop`, plus either:
+
+    - :meth:`_exec` — the usual path; public :meth:`exec` wraps it with a shared
+      error policy, and :meth:`exec_shell` defaults to ``bash -c`` on top; or
+    - :meth:`exec` and :meth:`exec_shell` — override both when the backend has
+      its own command/shell semantics and should not use the base wrappers.
+
+    Exec-based file transfer builds on :meth:`exec` / :meth:`exec_shell`.
+    :meth:`expose_port` is optional (raises until a provider implements it).
     """
 
     #: Registry key for this provider, stamped by ``@register_sandbox``.

--- a/uni_agent/sandbox/base.py
+++ b/uni_agent/sandbox/base.py
@@ -149,10 +149,15 @@ async def _startup_slot() -> AsyncIterator[None]:
 class Sandbox(abc.ABC):
     """One provider = one class: owns lifecycle and is the data-plane backend.
 
-    Providers implement :meth:`start`, :meth:`stop` and the :meth:`_exec`
-    primitive; the public :meth:`exec` wraps ``_exec`` with a shared error
-    policy, and the ``bash -lc`` helper and exec-based file transfer build on
-    top. :meth:`expose_port` is optional (raises until a provider implements it).
+    Providers implement :meth:`start` and :meth:`stop`, plus either:
+
+    - :meth:`_exec` — the usual path; public :meth:`exec` wraps it with a shared
+      error policy, and :meth:`exec_shell` defaults to ``bash -lc`` on top; or
+    - :meth:`exec` and :meth:`exec_shell` — override both when the backend has
+      its own command/shell semantics and should not use the base wrappers.
+
+    Exec-based file transfer builds on :meth:`exec` / :meth:`exec_shell`.
+    :meth:`expose_port` is optional (raises until a provider implements it).
     """
 
     #: Registry key for this provider, stamped by ``@register_sandbox``.

--- a/uni_agent/sandbox/openyuanrong.py
+++ b/uni_agent/sandbox/openyuanrong.py
@@ -12,6 +12,7 @@ import os
 import shlex
 import sys
 import uuid
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from .base import ExecResult, Sandbox, _to_str
@@ -142,7 +143,7 @@ class OpenyuanrongSandbox(Sandbox):
     def from_config(cls, config: SandboxConfig) -> OpenyuanrongSandbox:
         return cls(image=config.image, runtime_timeout=config.runtime_timeout, **config.sandbox_kwargs)
 
-    # ----- control plane -----
+    # ----- public: control plane -----
     async def start(self) -> None:
         if self._sandbox is not None:
             return
@@ -184,18 +185,6 @@ class OpenyuanrongSandbox(Sandbox):
                 logger.warning("Failed to kill openyuanrong sandbox %s: %s", sid, e)
             self._sandbox = None
 
-    def _require(self) -> Any:
-        if self._sandbox is None:
-            raise RuntimeError("OpenyuanrongSandbox not started; call start() first")
-        return self._sandbox
-
-    @staticmethod
-    def _coerce_mount(m: Any, MountCls: type) -> Any:
-        """Accept a ``Mount`` instance or a dict (``target`` + ``image_url``/``s3_config``)."""
-        if isinstance(m, dict):
-            return MountCls(**m)
-        return m
-
     async def is_alive(self) -> bool:
         sb = self._sandbox
         if sb is None:
@@ -204,9 +193,6 @@ class OpenyuanrongSandbox(Sandbox):
             return bool(await asyncio.to_thread(sb.is_running))
         except Exception:
             return False
-
-    def _is_timeout_error(self, exc: BaseException) -> bool:
-        return type(exc).__name__ == "CommandTimeoutError" or super()._is_timeout_error(exc)
 
     async def open_shell(
         self,
@@ -219,7 +205,109 @@ class OpenyuanrongSandbox(Sandbox):
         shell = await sb.shells.create(cwd=cwd, envs=env)
         return _OpenyuanrongShell(shell)
 
-    # ----- data plane: one-shot shell (stdout/stderr merged via pty) -----
+    # ----- public: data plane (commands / files / ports) -----
+    async def exec(
+        self,
+        argv: list[str],
+        *,
+        timeout: float | None = None,
+        workdir: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> ExecResult:
+        """Fully overrides base ``exec``; does not use the base error-policy wrapper.
+
+        Joins ``argv`` and delegates to :meth:`exec_shell` (Yuanrong
+        ``commands.run``). Does not call ``super().exec`` or base ``_exec``.
+        """
+        return await self.exec_shell(shlex.join(argv), timeout=timeout, workdir=workdir, env=env)
+
+    async def exec_shell(
+        self,
+        script: str,
+        *,
+        timeout: float | None = None,
+        workdir: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> ExecResult:
+        """Fully overrides base ``exec_shell``; does not use ``bash -lc`` via base.
+
+        Runs ``script`` directly through Yuanrong ``commands.run``. Does not call
+        ``super().exec_shell`` / ``exec(["bash", "-lc", script])``. Owns its own
+        timeout / alive error policy (mirrors base ``exec``, not base ``exec_shell``).
+        """
+        try:
+            return await self._run_command(script, timeout=timeout, workdir=workdir, env=env)
+        except Exception as exc:
+            if self._is_timeout_error(exc):
+                return ExecResult(exit_code=-1, stdout="", stderr=f"exec timed out after {timeout}s: {exc}")
+            if not await self.is_alive():
+                raise
+            return ExecResult(exit_code=127, stdout="", stderr=str(exc))
+
+    async def read_file(self, path: str) -> bytes:
+        """Read via SDK ``files.read(..., format='bytes')``."""
+        data = await asyncio.to_thread(lambda: self._require().files.read(path, format="bytes"))
+        return data if isinstance(data, bytes) else bytes(data)
+
+    async def write_file(self, path: str, content: bytes | str) -> None:
+        """Write via SDK ``files.write``."""
+        data: bytes | str = content.encode("utf-8") if isinstance(content, str) else content
+        await asyncio.to_thread(self._require().files.write, path, data)
+
+    async def upload(self, local_path: Path | str, remote_path: str) -> None:
+        """Upload file or directory via SDK ``files.copy_from_local``."""
+        await asyncio.to_thread(self._require().files.copy_from_local, str(local_path), str(remote_path))
+
+    async def download(self, remote_path: str, local_path: Path | str) -> None:
+        """Download file or directory via SDK ``files.copy_to_local``."""
+        await asyncio.to_thread(self._require().files.copy_to_local, str(remote_path), str(local_path))
+
+    async def expose_port(self, port: int) -> str:
+        """Return gateway URL for a port declared in ``port_forwardings``."""
+        return await asyncio.to_thread(self._require().get_port_url, port)
+
+    def get_port_url(self, port: int) -> str:
+        return self._require().get_port_url(port)
+
+    def get_tunnel_url(self) -> str:
+        return self._require().get_tunnel_url()
+
+    # ----- private helpers -----
+    def _require(self) -> Any:
+        if self._sandbox is None:
+            raise RuntimeError("OpenyuanrongSandbox not started; call start() first")
+        return self._sandbox
+
+    @staticmethod
+    def _coerce_mount(m: Any, MountCls: type) -> Any:
+        """Accept a ``Mount`` instance or a dict (``target`` + ``image_url``/``s3_config``)."""
+        if isinstance(m, dict):
+            return MountCls(**m)
+        return m
+
+    def _is_timeout_error(self, exc: BaseException) -> bool:
+        return type(exc).__name__ == "CommandTimeoutError" or super()._is_timeout_error(exc)
+
+    async def _run_command(
+        self,
+        cmd: str,
+        *,
+        timeout: float | None = None,
+        workdir: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> ExecResult:
+        """Run a shell command string once via ``commands.run``."""
+        sb = self._require()
+        timeout_i = int(timeout) if timeout else 60
+        result = await asyncio.to_thread(
+            lambda: sb.commands.run(cmd, envs=env, cwd=workdir, timeout=timeout_i)
+        )
+        return ExecResult(
+            exit_code=int(getattr(result, "exit_code", -99)),
+            stdout=_to_str(getattr(result, "stdout", "")),
+            stderr=_to_str(getattr(result, "stderr", "")),
+        )
+
     async def _exec(
         self,
         argv: list[str],
@@ -228,28 +316,12 @@ class OpenyuanrongSandbox(Sandbox):
         workdir: str | None = None,
         env: dict[str, str] | None = None,
     ) -> ExecResult:
-        """Execute *cmd* inside the sandbox via a one-shot shell."""
-        sb = self._require()
-        cmd = shlex.join(argv)
-        shell = None
-        try:
-            shell = await sb.shells.create(cwd=workdir, envs=env)
-            result = await shell.run(cmd, timeout=int(timeout) if timeout else 60)
-            return ExecResult(
-                exit_code=getattr(result, "exit_code", -99),
-                stdout=_to_str(getattr(result, "stdout", "")),
-                stderr=_to_str(getattr(result, "stderr", "")),
-            )
-        finally:
-            if shell is not None:
-                try:
-                    await shell.kill()
-                except Exception:
-                    pass
+        """Intentionally unimplemented.
 
-    # ----- port forwarding / reverse tunnel helpers -----
-    def get_port_url(self, port: int) -> str:
-        return self._require().get_port_url(port)
-
-    def get_tunnel_url(self) -> str:
-        return self._require().get_tunnel_url()
+        Base marks ``_exec`` abstract, so this stub exists only to instantiate the
+        class. Public :meth:`exec` is fully overridden and never calls this (or
+        ``super().exec``).
+        """
+        raise NotImplementedError(
+            "OpenyuanrongSandbox overrides exec(); _exec is unused"
+        )

--- a/uni_agent/sandbox/openyuanrong.py
+++ b/uni_agent/sandbox/openyuanrong.py
@@ -299,9 +299,7 @@ class OpenyuanrongSandbox(Sandbox):
         """Run a shell command string once via ``commands.run``."""
         sb = self._require()
         timeout_i = int(timeout) if timeout else 60
-        result = await asyncio.to_thread(
-            lambda: sb.commands.run(cmd, envs=env, cwd=workdir, timeout=timeout_i)
-        )
+        result = await asyncio.to_thread(lambda: sb.commands.run(cmd, envs=env, cwd=workdir, timeout=timeout_i))
         return ExecResult(
             exit_code=int(getattr(result, "exit_code", -99)),
             stdout=_to_str(getattr(result, "stdout", "")),
@@ -322,6 +320,4 @@ class OpenyuanrongSandbox(Sandbox):
         class. Public :meth:`exec` is fully overridden and never calls this (or
         ``super().exec``).
         """
-        raise NotImplementedError(
-            "OpenyuanrongSandbox overrides exec(); _exec is unused"
-        )
+        raise NotImplementedError("OpenyuanrongSandbox overrides exec(); _exec is unused")


### PR DESCRIPTION
## Summary

OpenYuanrong sandbox previously fell back to base-class exec/`bash -lc` and generic file helpers, which does not match Yuanrong SDK semantics and can break shell redirects (e.g. SWE reward `bash ... 2>&1`) and native file/port channels.

This change aligns the Sandbox layer implementation with native SDK APIs: `commands.run` for command execution, `files.read`/`write`/`copy_*` for file I/O, and `get_port_url` for port exposure, while keeping `open_shell` on `shells.create` for stateful sessions. The base Sandbox contract docstring now documents that providers may implement `_exec` or override `exec`/`exec_shell`. The sandbox quickstart demo also exercises native file APIs and splits toolbox vs file walkthroughs.

No linked issue; this is a targeted Sandbox provider fix for correct Yuanrong API usage, with a related examples update.

## Changes

- **Sandbox (`openyuanrong`)**: override `exec` / `exec_shell` to call `commands.run` directly (no `bash -lc` wrapping); `exec` joins argv via `shlex.join`.
- **Sandbox (`openyuanrong`)**: use native `files.read`/`write`/`copy_from_local`/`copy_to_local` and `get_port_url` for read/write/upload/download/expose_port.
- **Sandbox (`openyuanrong`)**: leave `_exec` unimplemented (`NotImplementedError`) because the public exec path is fully overridden; retain timeout / `is_alive` / exit-127 handling in the overrides.
- **Sandbox (`base`)**: document that providers implement `start`/`stop` plus either `_exec` or both `exec` and `exec_shell`.
- **Examples (`quickstart/sandbox/demo.py`)**: split toolbox walkthrough into `toolbox_operations`; add `file_operations` covering `write_file` / `read_file` / `upload` / `download` via sandbox APIs directly.
- Trade-off: intentionally overrides `exec()` contrary to the usual “prefer base exec policy” convention, so Yuanrong command semantics stay faithful to the SDK.

## Validation

- Sandbox quickstart demo (`DEBUG_MODE=1 SANDBOX_PROVIDER=... python examples/quickstart/sandbox/demo.py`): pass for OpenYuanrong
<img width="1398" height="1040" alt="image" src="https://github.com/user-attachments/assets/181b8690-1852-4c33-89a5-33342dee2215" />

## Compatibility

None for public Task/Sample Config, datasets, model protocols, trajectories, checkpoints, or recipes.

OpenYuanrong-only behavior change: callers that relied on base-class `bash -lc` wrapping or base64/exec file fallbacks through this provider should now use native SDK paths. Other sandbox providers are unchanged. The demo refactor is additive and does not change product APIs.

## PR title

Use `[area] type: summary`.

- Areas: `agents`, `framework`, `gateway`, `logging`, `sandbox`, `tasks`, `tools`, `training`, `app`, `docs`, `examples`, `ci`, `build`, `deps`, `misc`
- Types: `feat`, `fix`, `refactor`, `perf`, `test`, `docs`, `chore`, `revert`
- Separate multiple areas with comma-space: `[agents, sandbox] feat: add isolated harness execution`
- Prefix compatibility-breaking work with `[BREAKING]`: `[BREAKING][tasks, docs] refactor: replace task config schema`
- A stacked series may start with `[1/N]`: `[1/N][gateway] refactor: split protocol adapters`

## Checklist

- [x] The PR is focused and linked to an issue or explains why no issue is needed.
- [x] The title follows the format above and names the layer that owns the change.
- [x] Tests cover the behavior, or the Validation section explains why they are not practical.
- [x] User-facing API, config, and workflow changes include documentation or runnable examples.
- [x] Compatibility impact and migration steps are documented.
- [x] Logs, fixtures, and examples contain no credentials or private data.
- [x] `pre-commit run --all-files --show-diff-on-failure` passes.