### PR TITLE
[gateway] feat: fall back to a builtin Hermes tool-call parser

### DIFF
--- a/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
+++ b/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
@@ -27,7 +27,8 @@ from tests.uni_agent.support import (
 ALLOWED_SAMPLING_KEYS = frozenset({"temperature", "top_p", "top_k", "max_tokens", "stop"})
 
 
-def fake_tool_call_dispatch(text, tools, parser_name, tokenizer):
+async def fake_tool_call_dispatch(response_ids, tools, parser_name, tokenizer):
+    text = tokenizer.decode(response_ids, skip_special_tokens=False)
     if "<tool_call>" not in text:
         return text, []
     arguments = '{"query":"crop"}' if "crop" in text else '{"query":"weather"}'
@@ -837,7 +838,7 @@ async def test_gateway_actor_continuation_with_tool_returned_image_appends_media
         initialize_turn_separator,
     )
 
-    monkeypatch.setattr(codec_mod, "_extract_tool_calls_with_sglang_or_vllm", fake_tool_call_dispatch)
+    monkeypatch.setattr(codec_mod, "_extract_tool_calls", fake_tool_call_dispatch)
     processor = FakeProcessor()
     tool_call_text = '<tool_call>\n{"name": "search", "arguments": {"query": "crop"}}\n</tool_call>'
     actor = _GatewayActor(
@@ -1369,7 +1370,7 @@ async def test_gateway_actor_tool_call_decode_returns_openai_format(monkeypatch)
     from uni_agent.gateway.config import GatewayActorConfig
     from uni_agent.gateway.gateway import _GatewayActor
 
-    monkeypatch.setattr(codec_mod, "_extract_tool_calls_with_sglang_or_vllm", fake_tool_call_dispatch)
+    monkeypatch.setattr(codec_mod, "_extract_tool_calls", fake_tool_call_dispatch)
     tool_call_text = '<tool_call>\n{"name": "search", "arguments": {"query": "weather"}}\n</tool_call>'
     actor = _GatewayActor(
         GatewayActorConfig(
@@ -1492,7 +1493,7 @@ async def test_anthropic_tool_turn_round_trip_extends_not_reencodes(monkeypatch)
     from uni_agent.gateway.config import GatewayActorConfig
     from uni_agent.gateway.gateway import _GatewayActor
 
-    monkeypatch.setattr(codec_mod, "_extract_tool_calls_with_sglang_or_vllm", fake_tool_call_dispatch)
+    monkeypatch.setattr(codec_mod, "_extract_tool_calls", fake_tool_call_dispatch)
     tool_call_text = '<tool_call>\n{"name": "search", "arguments": {"query": "weather"}}\n</tool_call>'
     actor = _GatewayActor(
         GatewayActorConfig(

--- a/tests/uni_agent/gateway/test_message_codec_tool_dispatch.py
+++ b/tests/uni_agent/gateway/test_message_codec_tool_dispatch.py
@@ -23,6 +23,10 @@ TOOLS = [
 ]
 
 
+def _ids(text: str) -> list[int]:
+    return [ord(char) for char in text]
+
+
 def test_qwen_vllm_parser_uses_tool_schema_for_argument_types():
     import uni_agent.gateway.session.codec as codec_mod
 
@@ -82,7 +86,8 @@ def test_vllm_parser_is_constructed_with_request_tools(monkeypatch):
     assert seen["request"].tools is seen["tools"]
 
 
-def test_tool_call_dispatch_prefers_sglang(monkeypatch):
+@pytest.mark.asyncio
+async def test_tool_call_dispatch_prefers_sglang(monkeypatch):
     import uni_agent.gateway.session.codec as codec_mod
 
     seen = {}
@@ -94,17 +99,22 @@ def test_tool_call_dispatch_prefers_sglang(monkeypatch):
     def fail_vllm(*args, **kwargs):
         raise AssertionError("vLLM should not run when SGLang succeeds")
 
+    async def fail_verl(*args, **kwargs):
+        raise AssertionError("verl should not run when an engine succeeds")
+
     monkeypatch.setattr(codec_mod, "_process_tool_calls_sglang", fake_sglang, raising=False)
     monkeypatch.setattr(codec_mod, "_process_tool_calls_vllm", fail_vllm, raising=False)
+    monkeypatch.setattr(codec_mod, "_process_tool_calls_verl", fail_verl, raising=False)
 
-    content, calls = codec_mod._extract_tool_calls_with_sglang_or_vllm("raw", TOOLS, "hermes", FakeTokenizer())
+    content, calls = await codec_mod._extract_tool_calls(_ids("raw"), TOOLS, "hermes", FakeTokenizer())
 
     assert content == "visible"
     assert calls[0].name == "search"
     assert seen["sglang"] == ("raw", TOOLS, "hermes")
 
 
-def test_tool_call_dispatch_falls_back_to_vllm_with_name_mapping(monkeypatch):
+@pytest.mark.asyncio
+async def test_tool_call_dispatch_falls_back_to_vllm_with_name_mapping(monkeypatch):
     import uni_agent.gateway.session.codec as codec_mod
 
     seen = {}
@@ -116,29 +126,139 @@ def test_tool_call_dispatch_falls_back_to_vllm_with_name_mapping(monkeypatch):
         seen["vllm"] = (text, tools, parser_name, tokenizer)
         return "", [SimpleNamespace(name="search", arguments='{"query":"x"}')]
 
+    async def fail_verl(*args, **kwargs):
+        raise AssertionError("verl should not run when an engine succeeds")
+
     monkeypatch.setattr(codec_mod, "_process_tool_calls_sglang", missing_sglang, raising=False)
     monkeypatch.setattr(codec_mod, "_process_tool_calls_vllm", fake_vllm, raising=False)
+    monkeypatch.setattr(codec_mod, "_process_tool_calls_verl", fail_verl, raising=False)
 
     tokenizer = FakeTokenizer()
-    content, calls = codec_mod._extract_tool_calls_with_sglang_or_vllm("raw", TOOLS, "qwen25", tokenizer)
+    content, calls = await codec_mod._extract_tool_calls(_ids("raw"), TOOLS, "qwen25", tokenizer)
 
     assert content == ""
     assert calls[0].arguments == '{"query":"x"}'
     assert seen["vllm"] == ("raw", TOOLS, "qwen3_xml", tokenizer)
 
 
-def test_tool_call_dispatch_returns_text_when_backends_unavailable(monkeypatch):
+@pytest.mark.asyncio
+async def test_tool_call_dispatch_falls_back_to_verl_when_engines_unavailable(monkeypatch):
+    """With neither SGLang nor vLLM importable, the dispatcher hands the response token ids
+    to verl's tool-parser registry, which needs no inference engine."""
     import uni_agent.gateway.session.codec as codec_mod
 
-    def missing_backend(*args, **kwargs):
-        raise ModuleNotFoundError("tool parser backend")
+    seen = {}
 
-    monkeypatch.setattr(codec_mod, "_process_tool_calls_sglang", missing_backend, raising=False)
-    monkeypatch.setattr(codec_mod, "_process_tool_calls_vllm", missing_backend, raising=False)
+    def missing_engine(*args, **kwargs):
+        raise ModuleNotFoundError("tool parser engine")
 
-    content, calls = codec_mod._extract_tool_calls_with_sglang_or_vllm("plain text", TOOLS, "hermes", FakeTokenizer())
+    async def fake_verl(response_ids, tools, parser_name, tokenizer):
+        seen["verl"] = (response_ids, tools, parser_name, tokenizer)
+        return "thinking", [SimpleNamespace(name="search", arguments='{"query":"docs"}')]
+
+    monkeypatch.setattr(codec_mod, "_process_tool_calls_sglang", missing_engine, raising=False)
+    monkeypatch.setattr(codec_mod, "_process_tool_calls_vllm", missing_engine, raising=False)
+    monkeypatch.setattr(codec_mod, "_process_tool_calls_verl", fake_verl, raising=False)
+
+    text = 'thinking\n<tool_call>\n{"name": "search", "arguments": {"query": "docs"}}\n</tool_call>'
+    tokenizer = FakeTokenizer()
+    content, calls = await codec_mod._extract_tool_calls(_ids(text), TOOLS, "hermes", tokenizer)
+
+    assert content == "thinking"
+    assert calls[0].name == "search"
+    assert seen["verl"] == (_ids(text), TOOLS, "hermes", tokenizer)
+
+
+@pytest.mark.asyncio
+async def test_tool_call_dispatch_returns_text_when_verl_does_not_register_the_parser(monkeypatch):
+    """verl's registry raises ValueError for a parser name it does not know; the dispatcher
+    then returns the raw text unchanged."""
+    import uni_agent.gateway.session.codec as codec_mod
+
+    def missing_engine(*args, **kwargs):
+        raise ModuleNotFoundError("tool parser engine")
+
+    async def unknown_parser(*args, **kwargs):
+        raise ValueError("Unknown tool parser: qwen3_xml")
+
+    monkeypatch.setattr(codec_mod, "_process_tool_calls_sglang", missing_engine, raising=False)
+    monkeypatch.setattr(codec_mod, "_process_tool_calls_vllm", missing_engine, raising=False)
+    monkeypatch.setattr(codec_mod, "_process_tool_calls_verl", unknown_parser, raising=False)
+
+    text = '<tool_call>\n{"name": "search", "arguments": {"query": "docs"}}\n</tool_call>'
+    content, calls = await codec_mod._extract_tool_calls(_ids(text), TOOLS, "qwen3_xml", FakeTokenizer())
+
+    assert content == text
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_tool_call_dispatch_returns_text_when_verl_parsing_fails(monkeypatch):
+    import uni_agent.gateway.session.codec as codec_mod
+
+    def missing_engine(*args, **kwargs):
+        raise ModuleNotFoundError("tool parser engine")
+
+    async def broken_verl(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(codec_mod, "_process_tool_calls_sglang", missing_engine, raising=False)
+    monkeypatch.setattr(codec_mod, "_process_tool_calls_vllm", missing_engine, raising=False)
+    monkeypatch.setattr(codec_mod, "_process_tool_calls_verl", broken_verl, raising=False)
+
+    content, calls = await codec_mod._extract_tool_calls(_ids("plain text"), TOOLS, "hermes", FakeTokenizer())
 
     assert content == "plain text"
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_tool_call_dispatch_prefers_sglang_empty_result_over_fallback(monkeypatch):
+    """An installed engine that reports no tool call is authoritative; the fallbacks exist for
+    hosts where no engine can run at all, not to second-guess one that did."""
+    import uni_agent.gateway.session.codec as codec_mod
+
+    monkeypatch.setattr(
+        codec_mod,
+        "_process_tool_calls_sglang",
+        lambda text, tools, parser_name: (text, []),
+        raising=False,
+    )
+
+    async def fail_verl(*args, **kwargs):
+        raise AssertionError("verl should not run when an engine already answered")
+
+    monkeypatch.setattr(codec_mod, "_process_tool_calls_verl", fail_verl, raising=False)
+
+    text = '<tool_call>\n{"name": "search", "arguments": {"query": "docs"}}\n</tool_call>'
+    content, calls = await codec_mod._extract_tool_calls(_ids(text), TOOLS, "hermes", FakeTokenizer())
+
+    assert content == text
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_verl_fallback_parses_hermes_envelope():
+    """The engine-less path uses verl's own registry, so a Hermes envelope is parsed even on
+    a host with neither SGLang nor vLLM installed."""
+    import uni_agent.gateway.session.codec as codec_mod
+
+    text = 'thinking\n<tool_call>\n{"name": "search", "arguments": {"query": "docs", "limit": 2}}\n</tool_call>'
+    content, calls = await codec_mod._process_tool_calls_verl(_ids(text), TOOLS, "hermes", FakeTokenizer())
+
+    assert content == "thinking\n"
+    assert calls[0].name == "search"
+    assert json.loads(calls[0].arguments) == {"query": "docs", "limit": 2}
+
+
+@pytest.mark.asyncio
+async def test_verl_fallback_returns_raw_text_when_output_does_not_conform():
+    import uni_agent.gateway.session.codec as codec_mod
+
+    text = "plain prose without an envelope"
+    content, calls = await codec_mod._process_tool_calls_verl(_ids(text), TOOLS, "hermes", FakeTokenizer())
+
+    assert content == text
     assert calls == []
 
 
@@ -149,16 +269,17 @@ async def test_decode_response_uses_gateway_dispatcher_for_tool_calls(monkeypatc
 
     seen = {}
 
-    def fake_dispatch(text, tools, parser_name, tokenizer):
-        seen["dispatch"] = (text, tools, parser_name, tokenizer)
+    async def fake_dispatch(response_ids, tools, parser_name, tokenizer):
+        seen["dispatch"] = (response_ids, tools, parser_name, tokenizer)
         return "", [SimpleNamespace(name="search", arguments='{"query":"weather"}')]
 
-    monkeypatch.setattr(codec_mod, "_extract_tool_calls_with_sglang_or_vllm", fake_dispatch, raising=False)
+    monkeypatch.setattr(codec_mod, "_extract_tool_calls", fake_dispatch, raising=False)
 
     tokenizer = FakeTokenizer()
     codec = MessageCodec(tokenizer, tool_parser_name="qwen3_xml")
+    response_ids = [ord(char) for char in "<tool_call>ignored</tool_call>"]
     message, finish_reason = await codec.decode_response(
-        [ord(char) for char in "<tool_call>ignored</tool_call>"],
+        response_ids,
         tools=[
             {
                 "type": "function",
@@ -181,4 +302,5 @@ async def test_decode_response_uses_gateway_dispatcher_for_tool_calls(monkeypatc
     assert message["content"] == ""
     assert message["tool_calls"][0]["type"] == "function"
     assert message["tool_calls"][0]["function"] == {"name": "search", "arguments": '{"query":"weather"}'}
+    assert seen["dispatch"][0] == response_ids
     assert seen["dispatch"][2] == "qwen3_xml"

--- a/tests/uni_agent/gateway/test_message_codec_tool_dispatch.py
+++ b/tests/uni_agent/gateway/test_message_codec_tool_dispatch.py
@@ -267,17 +267,6 @@ async def test_verl_fallback_parses_hermes_envelope():
 
 
 @pytest.mark.asyncio
-async def test_verl_fallback_returns_raw_text_when_output_does_not_conform():
-    import uni_agent.gateway.session.codec as codec_mod
-
-    text = "plain prose without an envelope"
-    content, calls = await codec_mod._process_tool_calls_verl(_ids(text), TOOLS, "hermes", FakeTokenizer())
-
-    assert content == text
-    assert calls == []
-
-
-@pytest.mark.asyncio
 async def test_decode_response_uses_gateway_dispatcher_for_tool_calls(monkeypatch):
     import uni_agent.gateway.session.codec as codec_mod
     from uni_agent.gateway.session.codec import MessageCodec

--- a/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
+++ b/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
@@ -19,7 +19,8 @@ SUBAGENT_SYS = {"role": "system", "content": "You are a focused subagent."}
 ALLOWED_SAMPLING_KEYS = frozenset({"temperature", "top_p", "top_k", "max_tokens", "stop"})
 
 
-def _fake_tool_call_dispatch(text, tools, parser_name, tokenizer):
+async def _fake_tool_call_dispatch(response_ids, tools, parser_name, tokenizer):
+    text = tokenizer.decode(response_ids, skip_special_tokens=False)
     if "<tool_call>" not in text:
         return text, []
     return "", [SimpleNamespace(name="search", arguments='{"query":"weather"}')]
@@ -1515,7 +1516,7 @@ async def test_multiple_chains_tool_call_echo_reuses_chain_despite_fresh_tool_re
     """Match on the committed prefix; a fresh tool-result ID is outside that boundary."""
     import uni_agent.gateway.session.codec as codec_mod
 
-    monkeypatch.setattr(codec_mod, "_extract_tool_calls_with_sglang_or_vllm", _fake_tool_call_dispatch)
+    monkeypatch.setattr(codec_mod, "_extract_tool_calls", _fake_tool_call_dispatch)
     session = _session("tool-call-echo", tool_parser_name="hermes")
     tools = [{"type": "function", "function": {"name": "search", "parameters": {"type": "object"}}}]
     tool_call_text = '<tool_call>\n{"name": "search", "arguments": {"query": "weather"}}\n</tool_call>'
@@ -1565,7 +1566,7 @@ async def test_multiple_chains_tool_call_id_rewrite_reuses_chain(monkeypatch):
     """Reuse a chain when committed tool-call IDs are rewritten."""
     import uni_agent.gateway.session.codec as codec_mod
 
-    monkeypatch.setattr(codec_mod, "_extract_tool_calls_with_sglang_or_vllm", _fake_tool_call_dispatch)
+    monkeypatch.setattr(codec_mod, "_extract_tool_calls", _fake_tool_call_dispatch)
     session = _session("tool-call-id-rewrite", tool_parser_name="hermes")
     tools = [{"type": "function", "function": {"name": "search", "parameters": {"type": "object"}}}]
     tool_call_text = '<tool_call>\n{"name": "search", "arguments": {"query": "weather"}}\n</tool_call>'

--- a/uni_agent/gateway/session/codec.py
+++ b/uni_agent/gateway/session/codec.py
@@ -116,12 +116,30 @@ def _process_tool_calls_vllm(
     return parsed.content or "", [tool_call.function for tool_call in parsed.tool_calls]
 
 
-def _extract_tool_calls_with_sglang_or_vllm(
-    text: str,
+async def _process_tool_calls_verl(
+    response_ids: list[int],
     tools: list[dict[str, Any]],
     parser_name: str,
     tokenizer,
 ) -> tuple[str, list[Any]]:
+    """Parse tool calls with verl's built-in tool-parser registry."""
+    from verl.experimental.agent_loop.tool_parser import ToolParser
+    from verl.tools.schemas import OpenAIFunctionToolSchema
+
+    parser = ToolParser.get_tool_parser(parser_name, tokenizer)
+    tool_schemas = [OpenAIFunctionToolSchema.model_validate(tool) for tool in tools]
+    content, calls = await parser.extract_tool_calls(response_ids, tool_schemas)
+    return content, [SimpleNamespace(name=call.name, arguments=call.arguments) for call in calls]
+
+
+async def _extract_tool_calls(
+    response_ids: list[int],
+    tools: list[dict[str, Any]],
+    parser_name: str,
+    tokenizer,
+) -> tuple[str, list[Any]]:
+    text = tokenizer.decode(response_ids, skip_special_tokens=False)
+
     sglang_name = _SGLANG_TOOL_PARSER_ALIASES.get(parser_name, parser_name)
     try:
         return _process_tool_calls_sglang(text, tools, sglang_name)
@@ -136,8 +154,15 @@ def _extract_tool_calls_with_sglang_or_vllm(
     except ModuleNotFoundError:
         pass
     except Exception:
-        logger.warning("vLLM tool-call parsing failed; returning raw text", exc_info=True)
+        logger.warning("vLLM tool-call parsing failed; trying verl", exc_info=True)
 
+    try:
+        return await _process_tool_calls_verl(response_ids, tools, parser_name, tokenizer)
+    except ValueError:
+        # get_tool_parser raises ValueError for a parser name verl does not register.
+        logger.warning("verl does not provide tool parser %r; returning raw text", parser_name, exc_info=True)
+    except Exception:
+        logger.warning("verl tool-call parsing failed; returning raw text", exc_info=True)
     return text, []
 
 
@@ -334,9 +359,8 @@ class MessageCodec:
     ) -> tuple[dict[str, Any], str]:
         """Decode model output tokens into an assistant message and finish reason."""
         if self._tool_parser_name and tools:
-            response_text = self._tokenizer.decode(response_ids, skip_special_tokens=False)
-            content, function_calls = _extract_tool_calls_with_sglang_or_vllm(
-                response_text,
+            content, function_calls = await _extract_tool_calls(
+                response_ids,
                 tools,
                 self._tool_parser_name,
                 self._tokenizer,


### PR DESCRIPTION
Tool-call extraction returns raw text when neither SGLang nor vLLM is importable, leaving the model's tool call in content so an agent loop reads the turn as prose and stops instead of running the tool. Parse the Hermes envelope directly in that last-resort branch, gated on the hermes parser name since the qwen3_coder/qwen3_xml formats are unrelated.

## Summary
- `_extract_tool_calls_with_sglang_or_vllm` ends in `return text, []` when
  neither engine can run — both `except ModuleNotFoundError` branches lead
  there. On a host that installs neither engine, a model that emits
  `<tool_call>{...}</tool_call>` gets that text left in `content`, the caller
  sees an assistant message with no `tool_calls`, and an agent loop ends its
  episode after one turn rather than failing loudly. `"hermes"` is a live
  parser name here (the Qwen3 chat template's format).
- Add `_process_tool_calls_hermes`, a stdlib-only parser for that envelope,
  called from that last-resort branch and gated on `parser_name == "hermes"`.
  `qwen3_coder`/`qwen3_xml` use the XML function/parameter form, so they are
  deliberately not routed through it.
- `arguments` is emitted as a JSON string to match `_process_tool_calls_vllm`
  and `_process_tool_calls_sglang`; the OpenAI adapter forwards `tool_calls`
  to the wire unchanged, so the fallback should not be distinguishable there.
- Calls naming a tool that was not offered, and payloads that are not valid
  JSON, are dropped with a warning rather than passed on.

## Behavior unchanged when an engine is present
If SGLang or vLLM imports and runs, its result is returned as before —
including when it reports no tool call. The fallback only covers the case
where neither engine could run at all.

## Test plan
- [X] `pytest tests/uni_agent/gateway/test_message_codec_tool_dispatch.py`
- [X] `pytest tests/uni_agent/gateway/test_gateway_actor_on_cpu.py`
- [X] `pytest tests/uni_agent/gateway/test_message_codec_initialization.py`