### PR TITLE
[gateway] fix: support vLLM 0.18 tool parsers

### DIFF
--- a/tests/uni_agent/gateway/test_message_codec_tool_dispatch.py
+++ b/tests/uni_agent/gateway/test_message_codec_tool_dispatch.py
@@ -44,7 +44,12 @@ def test_qwen_vllm_parser_uses_tool_schema_for_argument_types():
     assert json.loads(calls[0].arguments) == {"query": "docs", "limit": 2}
 
 
-def test_vllm_parser_is_constructed_with_request_tools(monkeypatch):
+@pytest.mark.parametrize(
+    "constructor_accepts_tools",
+    [False, True],
+    ids=["tokenizer-only", "tokenizer-and-tools"],
+)
+def test_vllm_parser_supports_tool_schema_constructor_contracts(monkeypatch, constructor_accepts_tools):
     from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionToolsParam
     from vllm.tool_parsers import ToolParserManager
 
@@ -52,59 +57,30 @@ def test_vllm_parser_is_constructed_with_request_tools(monkeypatch):
 
     seen = {}
 
-    class FakeParser:
+    class ParserBase:
+        def extract_tool_calls(self, text, request):
+            seen["request"] = request
+            return SimpleNamespace(
+                tools_called=True,
+                content="visible",
+                tool_calls=[SimpleNamespace(function=SimpleNamespace(name="search", arguments='{"query":"x"}'))],
+            )
+
+    class ParserWithoutConstructorTools(ParserBase):
+        def __init__(self, tokenizer):
+            seen["tokenizer"] = tokenizer
+
+    class ParserWithConstructorTools(ParserBase):
         def __init__(self, tokenizer, *, tools):
             seen["tokenizer"] = tokenizer
             seen["tools"] = tools
 
-        def extract_tool_calls(self, text, request):
-            seen["request"] = request
-            return SimpleNamespace(
-                tools_called=True,
-                content="visible",
-                tool_calls=[SimpleNamespace(function=SimpleNamespace(name="search", arguments='{"query":"x"}'))],
-            )
+    parser_cls = ParserWithConstructorTools if constructor_accepts_tools else ParserWithoutConstructorTools
 
     monkeypatch.setattr(
         ToolParserManager,
         "get_tool_parser",
-        classmethod(lambda cls, name: FakeParser),
-    )
-
-    tokenizer = FakeTokenizer()
-    content, calls = codec_mod._process_tool_calls_vllm("raw", TOOLS, "qwen3_coder", tokenizer)
-
-    assert content == "visible"
-    assert calls[0].name == "search"
-    assert seen["tokenizer"] is tokenizer
-    assert len(seen["tools"]) == 1
-    assert isinstance(seen["tools"][0], ChatCompletionToolsParam)
-    assert seen["request"].tools is seen["tools"]
-
-
-def test_vllm_parser_without_constructor_tools_uses_request_tools(monkeypatch):
-    from vllm.tool_parsers import ToolParserManager
-
-    import uni_agent.gateway.session.codec as codec_mod
-
-    seen = {}
-
-    class LegacyParser:
-        def __init__(self, tokenizer):
-            seen["tokenizer"] = tokenizer
-
-        def extract_tool_calls(self, text, request):
-            seen["request"] = request
-            return SimpleNamespace(
-                tools_called=True,
-                content="visible",
-                tool_calls=[SimpleNamespace(function=SimpleNamespace(name="search", arguments='{"query":"x"}'))],
-            )
-
-    monkeypatch.setattr(
-        ToolParserManager,
-        "get_tool_parser",
-        classmethod(lambda cls, name: LegacyParser),
+        classmethod(lambda cls, name: parser_cls),
     )
 
     tokenizer = FakeTokenizer()
@@ -114,6 +90,11 @@ def test_vllm_parser_without_constructor_tools_uses_request_tools(monkeypatch):
     assert calls[0].name == "search"
     assert seen["tokenizer"] is tokenizer
     assert len(seen["request"].tools) == 1
+    assert isinstance(seen["request"].tools[0], ChatCompletionToolsParam)
+    if constructor_accepts_tools:
+        assert seen["tools"] is seen["request"].tools
+    else:
+        assert "tools" not in seen
 
 
 def test_tool_call_dispatch_prefers_sglang(monkeypatch):

--- a/tests/uni_agent/gateway/test_message_codec_tool_dispatch.py
+++ b/tests/uni_agent/gateway/test_message_codec_tool_dispatch.py
@@ -82,6 +82,40 @@ def test_vllm_parser_is_constructed_with_request_tools(monkeypatch):
     assert seen["request"].tools is seen["tools"]
 
 
+def test_vllm_parser_without_constructor_tools_uses_request_tools(monkeypatch):
+    from vllm.tool_parsers import ToolParserManager
+
+    import uni_agent.gateway.session.codec as codec_mod
+
+    seen = {}
+
+    class LegacyParser:
+        def __init__(self, tokenizer):
+            seen["tokenizer"] = tokenizer
+
+        def extract_tool_calls(self, text, request):
+            seen["request"] = request
+            return SimpleNamespace(
+                tools_called=True,
+                content="visible",
+                tool_calls=[SimpleNamespace(function=SimpleNamespace(name="search", arguments='{"query":"x"}'))],
+            )
+
+    monkeypatch.setattr(
+        ToolParserManager,
+        "get_tool_parser",
+        classmethod(lambda cls, name: LegacyParser),
+    )
+
+    tokenizer = FakeTokenizer()
+    content, calls = codec_mod._process_tool_calls_vllm("raw", TOOLS, "qwen3_coder", tokenizer)
+
+    assert content == "visible"
+    assert calls[0].name == "search"
+    assert seen["tokenizer"] is tokenizer
+    assert len(seen["request"].tools) == 1
+
+
 def test_tool_call_dispatch_prefers_sglang(monkeypatch):
     import uni_agent.gateway.session.codec as codec_mod
 

--- a/uni_agent/gateway/session/codec.py
+++ b/uni_agent/gateway/session/codec.py
@@ -6,6 +6,7 @@ processor-backed multimodal inputs, parses tools, and decodes backend outputs.
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 from types import SimpleNamespace
@@ -104,7 +105,13 @@ def _process_tool_calls_vllm(
 
     parser_cls = ToolParserManager.get_tool_parser(parser_name)
     vllm_tools = [ChatCompletionToolsParam(**tool) if isinstance(tool, dict) else tool for tool in tools]
-    parser = parser_cls(tokenizer, tools=vllm_tools)
+    parser_parameters = inspect.signature(parser_cls).parameters
+    if "tools" in parser_parameters or any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parser_parameters.values()
+    ):
+        parser = parser_cls(tokenizer, tools=vllm_tools)
+    else:
+        parser = parser_cls(tokenizer)
     request = SimpleNamespace(
         tools=vllm_tools,
         tool_choice="auto",

--- a/uni_agent/gateway/session/codec.py
+++ b/uni_agent/gateway/session/codec.py
@@ -106,9 +106,7 @@ def _process_tool_calls_vllm(
     parser_cls = ToolParserManager.get_tool_parser(parser_name)
     vllm_tools = [ChatCompletionToolsParam(**tool) if isinstance(tool, dict) else tool for tool in tools]
     parser_parameters = inspect.signature(parser_cls).parameters
-    if "tools" in parser_parameters or any(
-        parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parser_parameters.values()
-    ):
+    if "tools" in parser_parameters:
         parser = parser_cls(tokenizer, tools=vllm_tools)
     else:
         parser = parser_cls(tokenizer)


### PR DESCRIPTION
## Summary

Keep Gateway tool-call parsing compatible with vLLM 0.18 while preserving the
tool-aware parser construction introduced for newer vLLM releases.

VERL currently declares `vllm>=0.18.0`, but vLLM 0.18 tool parser constructors
accept only `tokenizer`. Passing `tools=` unconditionally raises `TypeError` and
causes Gateway to return the raw tool-call markup instead of executing the tool.

## Changes

- Inspect the selected vLLM parser constructor before instantiation.
- Pass `tools=` when the parser constructor declares support for it.
- Fall back to the vLLM 0.18 constructor contract without catching constructor
  exceptions.
- Continue passing the same normalized tool schemas through `request.tools` on
  both paths so schema-based argument conversion remains available.
- Add parameterized regression coverage for both supported parser constructor
  contracts: `tokenizer-only` and `tokenizer-and-tools`.

## Validation

- `python -m pytest tests/uni_agent/gateway/test_message_codec_tool_dispatch.py tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py tests/uni_agent/gateway/test_gateway_actor_on_cpu.py -q`
  - 115 passed
- Qwen3-Coder schema conversion test with vLLM 0.18.0: passed
- Qwen3-Coder schema conversion test with vLLM 0.19.0: passed
- `pre-commit run --all-files --show-diff-on-failure --color=always`: passed

## Compatibility

This restores the declared vLLM 0.18 compatibility without changing behavior
for newer parsers. No configuration or migration is required.

## Checklist

- [x] The PR is focused and explains why no issue is needed.
- [x] The title follows the repository format and names the owning layer.
- [x] Tests cover the compatibility behavior.
- [x] There is no user-facing API, config, or workflow change requiring docs.
- [x] Compatibility impact and migration requirements are documented.
- [x] Logs, fixtures, and examples contain no credentials or private data.
- [x] `pre-commit run --all-files --show-diff-on-failure` passes.

<!-- ledger_update: none; constructor compatibility only, no architecture or feature-ledger change -->
