### PR TITLE
[tasks, sandbox] feat: bake image rewrite via DATASET_RULES, drop veFaaS mapping

### DIFF
--- a/uni_agent/sandbox/vefaas.py
+++ b/uni_agent/sandbox/vefaas.py
@@ -23,17 +23,6 @@ logger = logging.getLogger(__name__)
 _RUNTIME_PORT = 8000
 
 
-def _to_vefaas_image(image: str) -> str:
-    if image == "python:3.12":
-        return "enterprise-public-2-cn-beijing.cr.volces.com/vefaas-public/python:3.12"
-    elif image.startswith("swebench/"):
-        return image.replace("swebench/", "enterprise-public-cn-beijing.cr.volces.com/swe-bench-verified/") + ":v2"
-    elif image.startswith("swerebench/"):
-        return image.replace("swerebench/", "enterprise-public-cn-beijing.cr.volces.com/swe-rebench/") + ":latest"
-    else:
-        raise ValueError(f"Unsupported image: {image}")
-
-
 def _split_env_list(raw: str | None) -> list[str]:
     """Parse a comma-separated env value into a list of trimmed, non-empty items."""
     if not raw:
@@ -280,9 +269,7 @@ class VefaasSandbox(Sandbox):
         # (VEFAAS_FUNCTION_ID / VEFAAS_FUNCTION_ROUTE / SANDBOX_PROXY). The two
         # function env vars may each hold a comma-separated list of paired values;
         # each sandbox binds to one randomly chosen pair.
-        return cls(
-            image=_to_vefaas_image(config.image), runtime_timeout=config.runtime_timeout, **config.sandbox_kwargs
-        )
+        return cls(image=config.image, runtime_timeout=config.runtime_timeout, **config.sandbox_kwargs)
 
     # ----- control plane -----
     async def start(self) -> None:

--- a/uni_agent/tasks/swe_bench/preprocess.py
+++ b/uni_agent/tasks/swe_bench/preprocess.py
@@ -1,13 +1,22 @@
 # ruff: noqa: E501
 """Preprocess SWE-bench Verified into the new-framework SWE task format.
 
-Provider-agnostic on purpose: the row only carries the canonical *open-source*
-image ref (the published ``swebench/sweb.eval.x86_64.<id>``); mapping that to a
-service-provider image is the sandbox provider's job (e.g. ``_to_vefaas_image``),
-decided at run time, not baked into the dataset.
+By default each row carries the canonical open-source image
+(``swebench/sweb.eval.x86_64.<id>``). Set ``DATASET_RULES`` to bake a concrete
+registry address into the parquet (platform mapping stays in the env, not here).
+
+Format of ``DATASET_RULES`` (one rule)::
+
+    old_prefix=new_prefix
+    old_prefix=new_prefix|tag
 
 Example::
 
+    # Canonical images (provider may remap at run time)
+    python -m uni_agent.tasks.swe_bench.preprocess --local-save-dir ~/data/swe_agent
+
+    # Same mapping veFaaS uses at run time, expressed via env
+    export DATASET_RULES='swebench/=enterprise-public-cn-beijing.cr.volces.com/swe-bench-verified/|v2'
     python -m uni_agent.tasks.swe_bench.preprocess --local-save-dir ~/data/swe_agent
 """
 
@@ -18,11 +27,32 @@ from datasets import load_dataset
 
 
 def get_image_name(instance_id: str) -> str:
-    """Canonical open-source image ref (mirrors swebench's ``instance_image_key``).
+    """Image ref for this instance (canonical, or rewritten via ``DATASET_RULES``).
 
-    Provider-agnostic; a provider maps this to its own registry at run time.
+    Canonical form mirrors swebench's ``instance_image_key``. When
+    ``DATASET_RULES`` is set (``old_prefix=new_prefix`` or ``old_prefix=new_prefix|tag``),
+    rewrite before writing the dataset.
     """
-    return f"swebench/sweb.eval.x86_64.{instance_id.lower().replace('__', '_1776_')}"
+    image = f"swebench/sweb.eval.x86_64.{instance_id.lower().replace('__', '_1776_')}"
+    rules = os.getenv("DATASET_RULES", "").strip()
+    if not rules:
+        return image
+    if "=" not in rules:
+        raise ValueError(f"DATASET_RULES must look like 'old=new' or 'old=new|tag', got {rules!r}")
+
+    old, new = rules.split("=", 1)
+    old, new = old.strip(), new.strip()
+    tag = ""
+    if "|" in new:
+        new, tag = new.split("|", 1)
+        new, tag = new.strip(), tag.strip()
+    if not old or not image.startswith(old):
+        raise ValueError(f"DATASET_RULES old_prefix {old!r} does not match image {image!r}")
+
+    mapped = new + image[len(old) :]
+    if tag:
+        mapped = f"{mapped}:{tag.lstrip(':')}"
+    return mapped
 
 
 SYSTEM_PROMPT = """
@@ -144,6 +174,9 @@ def build_swe_bench_verified(max_instances: int | None = None):
 
     data_source = "princeton-nlp/SWE-bench_Verified"
     print(f"Loading the {data_source} dataset from huggingface...", flush=True)
+    rules = os.getenv("DATASET_RULES", "").strip()
+    if rules:
+        print(f"DATASET_RULES={rules!r}; baking rewritten images into the dataset", flush=True)
     dataset = load_dataset(data_source, split="test")
     print(f"Loaded {len(dataset)} raw instances", flush=True)
 

--- a/uni_agent/tasks/swe_bench_multilingual/preprocess.py
+++ b/uni_agent/tasks/swe_bench_multilingual/preprocess.py
@@ -1,12 +1,22 @@
 # ruff: noqa: E501
 """Preprocess SWE-bench Multilingual into the new-framework SWE task format.
 
-The generated rows are provider-agnostic: they carry the canonical public
-``swebench/sweb.eval.x86_64.<id>`` image reference and leave provider-specific
-image mapping and resource configuration to the sandbox at run time.
+By default each row carries the canonical open-source image
+(``swebench/sweb.eval.x86_64.<id>``). Set ``DATASET_RULES`` to bake a concrete
+registry address into the parquet (platform mapping stays in the env, not here).
+
+Format of ``DATASET_RULES`` (one rule)::
+
+    old_prefix=new_prefix
+    old_prefix=new_prefix|tag
 
 Example::
 
+    python -m uni_agent.tasks.swe_bench_multilingual.preprocess \
+        --local-save-dir ~/data/swe_agent
+
+    # Same mapping veFaaS uses at run time, expressed via env
+    export DATASET_RULES='swebench/=enterprise-public-cn-beijing.cr.volces.com/swe-bench-verified/|v2'
     python -m uni_agent.tasks.swe_bench_multilingual.preprocess \
         --local-save-dir ~/data/swe_agent
 """
@@ -19,8 +29,32 @@ from swebench.harness.constants import MAP_REPO_TO_EXT
 
 
 def get_image_name(instance_id: str) -> str:
-    """Return the canonical image ref, mirroring swebench's instance image key."""
-    return f"swebench/sweb.eval.x86_64.{instance_id.lower().replace('__', '_1776_')}"
+    """Image ref for this instance (canonical, or rewritten via ``DATASET_RULES``).
+
+    Canonical form mirrors swebench's instance image key. When
+    ``DATASET_RULES`` is set (``old_prefix=new_prefix`` or ``old_prefix=new_prefix|tag``),
+    rewrite before writing the dataset.
+    """
+    image = f"swebench/sweb.eval.x86_64.{instance_id.lower().replace('__', '_1776_')}"
+    rules = os.getenv("DATASET_RULES", "").strip()
+    if not rules:
+        return image
+    if "=" not in rules:
+        raise ValueError(f"DATASET_RULES must look like 'old=new' or 'old=new|tag', got {rules!r}")
+
+    old, new = rules.split("=", 1)
+    old, new = old.strip(), new.strip()
+    tag = ""
+    if "|" in new:
+        new, tag = new.split("|", 1)
+        new, tag = new.strip(), tag.strip()
+    if not old or not image.startswith(old):
+        raise ValueError(f"DATASET_RULES old_prefix {old!r} does not match image {image!r}")
+
+    mapped = new + image[len(old) :]
+    if tag:
+        mapped = f"{mapped}:{tag.lstrip(':')}"
+    return mapped
 
 
 # Map swebench's file-extension code to a human-readable language for the prompt.
@@ -136,6 +170,9 @@ def build_swe_bench_multilingual(max_instances: int | None = None):
 
     data_source = "SWE-bench/SWE-bench_Multilingual"
     print(f"Loading the {data_source} dataset from huggingface...", flush=True)
+    rules = os.getenv("DATASET_RULES", "").strip()
+    if rules:
+        print(f"DATASET_RULES={rules!r}; baking rewritten images into the dataset", flush=True)
     dataset = load_dataset(data_source, split="test")
     print(f"Loaded {len(dataset)} raw instances", flush=True)
 

--- a/uni_agent/tasks/swe_rebench/preprocess.py
+++ b/uni_agent/tasks/swe_rebench/preprocess.py
@@ -1,8 +1,21 @@
 # ruff: noqa: E501
 """Preprocess SWE-rebench into the new-framework SWE task format.
 
+By default each row carries the canonical open-source image
+(``swerebench/sweb.eval.x86_64.<id>``). Set ``DATASET_RULES`` to bake a concrete
+registry address into the parquet (platform mapping stays in the env, not here).
+
+Format of ``DATASET_RULES`` (one rule)::
+
+    old_prefix=new_prefix
+    old_prefix=new_prefix|tag
+
 Example::
 
+    python -m uni_agent.tasks.swe_rebench.preprocess --local-save-dir ~/data/swe_agent
+
+    # Same mapping veFaaS uses at run time, expressed via env
+    export DATASET_RULES='swerebench/=enterprise-public-cn-beijing.cr.volces.com/swe-rebench/|latest'
     python -m uni_agent.tasks.swe_rebench.preprocess --local-save-dir ~/data/swe_agent
 """
 
@@ -13,12 +26,32 @@ from datasets import load_dataset
 
 
 def get_image_name(instance_id: str) -> str:
-    """Canonical open-source image ref for a swe-rebench instance.
+    """Image ref for this instance (canonical, or rewritten via ``DATASET_RULES``).
 
-    Published under the ``swerebench`` org (mirrors the modal image naming); a
-    provider maps this to its own registry at run time.
+    Canonical form is published under the ``swerebench`` org. When
+    ``DATASET_RULES`` is set (``old_prefix=new_prefix`` or ``old_prefix=new_prefix|tag``),
+    rewrite before writing the dataset.
     """
-    return f"swerebench/sweb.eval.x86_64.{instance_id.lower().replace('__', '_1776_')}"
+    image = f"swerebench/sweb.eval.x86_64.{instance_id.lower().replace('__', '_1776_')}"
+    rules = os.getenv("DATASET_RULES", "").strip()
+    if not rules:
+        return image
+    if "=" not in rules:
+        raise ValueError(f"DATASET_RULES must look like 'old=new' or 'old=new|tag', got {rules!r}")
+
+    old, new = rules.split("=", 1)
+    old, new = old.strip(), new.strip()
+    tag = ""
+    if "|" in new:
+        new, tag = new.split("|", 1)
+        new, tag = new.strip(), tag.strip()
+    if not old or not image.startswith(old):
+        raise ValueError(f"DATASET_RULES old_prefix {old!r} does not match image {image!r}")
+
+    mapped = new + image[len(old) :]
+    if tag:
+        mapped = f"{mapped}:{tag.lstrip(':')}"
+    return mapped
 
 
 SYSTEM_PROMPT = """
@@ -145,6 +178,9 @@ def build_swe_rebench(max_instances: int | None = None):
 
     data_source = "nebius/SWE-rebench"
     print(f"Loading the {data_source} dataset from huggingface...", flush=True)
+    rules = os.getenv("DATASET_RULES", "").strip()
+    if rules:
+        print(f"DATASET_RULES={rules!r}; baking rewritten images into the dataset", flush=True)
     dataset = load_dataset(data_source, split="filtered")
     print(f"Loaded {len(dataset)} raw instances", flush=True)
 


### PR DESCRIPTION
## Summary

SWE preprocess previously always wrote canonical public image refs (`swebench/...` / `swerebench/...`), and veFaaS remapped them at runtime via `_to_vefaas_image`. That couples datasets to one provider and blocks other backends that need concrete registry addresses.

This PR lets preprocess bake usable image refs through the `DATASET_RULES` env var (`old_prefix=new_prefix` or `old_prefix=new_prefix|tag`), and removes the veFaaS runtime image rewrite so all providers consume `config.image` as-is.

No linked issue; targeted Task/Sandbox cleanup for portable image configuration.

## Changes

- **Tasks (`swe_bench` / `swe_rebench` / `swe_bench_multilingual` preprocess)**: honor `DATASET_RULES` when writing `sandbox.image` into parquet.
- **Sandbox (`vefaas`)**: delete `_to_vefaas_image`; `from_config` passes `config.image` through unchanged.
- Migration: regenerate SWE datasets with `DATASET_RULES` (or put full registry refs in config) before using veFaaS; short names like `python:3.12` / canonical `swebench/...` are no longer rewritten by veFaaS.

## Usage

`DATASET_RULES` is a **single** rewrite rule applied when preprocess writes `sandbox.image`. Unset or empty: keep the canonical image (`swebench/...` or `swerebench/...`). Set: replace the matching prefix, then optionally pin a tag.

### Rule syntax

```text
old_prefix=new_prefix
old_prefix=new_prefix|tag
```

| Piece | Meaning |
| --- | --- |
| `old_prefix` | Must be a prefix of the canonical image. Typical values: `swebench/` (Verified / Multilingual) or `swerebench/` (rebench). |
| `new_prefix` | Registry + repo prefix to splice in. Keep a trailing `/` so the remainder concatenates as a path, not a glued name. |
| `\|tag` | Optional. If present, append `:<tag>` after the rewritten name. Canonical images have no tag, so this is how you pin `v2` / `latest`. |

Rewrite is string prefix replacement, not a registry-aware parser:

```text
mapped = new_prefix + canonical[len(old_prefix):]
if tag:
    mapped = mapped + ':' + tag
```

Constraints:

- One rule only (no comma-separated list).
- `old_prefix` is checked with `image.startswith(...)`. If it does not match, preprocess **raises** instead of silently keeping the canonical name.
- `|` splits only the **right-hand** side (`new_prefix|tag`). A leading `:` on the tag is stripped.
- Whitespace around `=`, prefixes, and tag is ignored.

### Examples

Canonical (no rewrite; provider may remap at run time):

```bash
python -m uni_agent.tasks.swe_bench.preprocess --local-save-dir ~/data/swe_agent
# sandbox.image = swebench/sweb.eval.x86_64.astropy_1776_astropy-12907
```

Prefix + tag (typical veFaaS / private-registry bake):

```bash
# swe_bench / swe_bench_multilingual
export DATASET_RULES='swebench/=enterprise-public-cn-beijing.cr.volces.com/swe-bench-verified/|v2'
python -m uni_agent.tasks.swe_bench.preprocess --local-save-dir ~/data/swe_agent

# swe_rebench
export DATASET_RULES='swerebench/=enterprise-public-cn-beijing.cr.volces.com/swe-rebench/|latest'
python -m uni_agent.tasks.swe_rebench.preprocess --local-save-dir ~/data/swe_agent
```

Worked rewrite (`swe_bench`):

```text
canonical  = swebench/sweb.eval.x86_64.astropy_1776_astropy-12907
old_prefix = swebench/
new_prefix = enterprise-public-cn-beijing.cr.volces.com/swe-bench-verified/
tag        = v2

remainder  = sweb.eval.x86_64.astropy_1776_astropy-12907
mapped     = enterprise-public-cn-beijing.cr.volces.com/swe-bench-verified/sweb.eval.x86_64.astropy_1776_astropy-12907:v2
```

Prefix only (keep untagged name):

```bash
export DATASET_RULES='swebench/=my.registry.com/swe/'
# swebench/sweb.eval.x86_64.foo → my.registry.com/swe/sweb.eval.x86_64.foo
```

Mismatch (will fail): using a `swerebench/` rule on `swe_bench` preprocess, whose images start with `swebench/`.

## Test results

Smoke-tested `swe_bench` preprocess with `--max-instances 1` (HF `princeton-nlp/SWE-bench_Verified` test split, 500 instances loaded then capped):

```bash
export DATASET_RULES='swebench/=enterprise-public-cn-beijing.cr.volces.com/swe-bench-verified/|v2'
python -m uni_agent.tasks.swe_bench.preprocess \
  --local-save-dir ~/data/swe_agent_smoke \
  --max-instances 1
```

Wrote `~/data/swe_agent_smoke/swe_bench_verified.parquet` (~42KB). Inspected with pyarrow:

| Field | Value |
| --- | --- |
| rows | 1 |
| columns | `data_source`, `prompt`, `extra_info` |
| `instance_id` | `astropy__astropy-12907` |
| `sandbox.image` | `enterprise-public-cn-beijing.cr.volces.com/swe-bench-verified/sweb.eval.x86_64.astropy_1776_astropy-12907:v2` |

`prompt` is nested (system + user, user text ~114 lines), so a parquet viewer can look like many lines even though the dataset has a single sample.

Unit-style mapping check (no dataset write):

```bash
DATASET_RULES='swebench/=enterprise-public-cn-beijing.cr.volces.com/swe-bench-verified/|v2' \
python -c "from uni_agent.tasks.swe_bench.preprocess import get_image_name; print(get_image_name('django__django-12345'))"
```

## Checklist

- [x] The PR is focused and linked to an issue or explains why no issue is needed.
- [x] The title follows the format above and names the layer that owns the change.
- [x] Tests cover the behavior, or the Validation section explains why they are not practical.
- [x] User-facing API, config, and workflow changes include documentation or runnable examples.
- [x] Compatibility impact and migration steps are documented.
- [x] Logs, fixtures, and examples contain no credentials or private data.
- [x] `pre-commit run --all-files --show-diff-on-failure` passes.

Made with [Cursor](https://cursor.com)