### PR TITLE
[tools] fix: align text editor behavior

### DIFF
--- a/uni_agent/tools/edit_file.py
+++ b/uni_agent/tools/edit_file.py
@@ -120,7 +120,11 @@ class EditFileTool(Tool):
     @staticmethod
     async def _read(sandbox: SandboxBackend, path: str) -> str:
         data = await sandbox.read_file(path)
-        return data.decode("utf-8", errors="replace")
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ToolError(f"The file `{path}` is not valid UTF-8 text.") from exc
+        return text.replace("\r\n", "\n").replace("\r", "\n")
 
     # ----- dispatch -----
     async def run(self, args: dict[str, Any], *, timeout: float | None = None) -> ToolResult:
@@ -164,6 +168,8 @@ class EditFileTool(Tool):
         )
 
     async def _validate_path(self, command: str, sandbox: SandboxBackend, path: str) -> str | None:
+        if command == "create" and path.endswith("/"):
+            return f"The path `{path}` ends with `/`. The `create` command requires a file path."
         exists = await self._exists(sandbox, path)
         is_dir = await self._is_dir(sandbox, path) if exists else False
         if not exists and command != "create":
@@ -222,7 +228,7 @@ class EditFileTool(Tool):
         if not await self._is_dir(sandbox, parent):
             return f"The parent directory {parent} does not exist. Please create it first."
         await sandbox.write_file(path, file_text)
-        self._history[path].append(file_text)
+        self._history[path].append("")
         return f"File created successfully at: {path}"
 
     async def _str_replace(
@@ -275,7 +281,6 @@ class EditFileTool(Tool):
         new_str = new_str.expandtabs()
         file_lines = file_text.split("\n")
         n_lines = len(file_lines)
-        insert_line -= 1  # convert to 0-based index
 
         if insert_line < 0 or insert_line > n_lines:
             return (
@@ -309,6 +314,7 @@ class EditFileTool(Tool):
     async def _undo_edit(self, sandbox: SandboxBackend, path: str) -> str:
         if not self._history.get(path):
             return f"No edit history found for {path}."
-        old_text = self._history[path].pop()
+        old_text = self._history[path][-1]
         await sandbox.write_file(path, old_text)
+        self._history[path].pop()
         return f"Last edit to {path} undone successfully. {_make_output(old_text, str(path))}"


### PR DESCRIPTION
Honor insert-after semantics and avoid lossy or inconsistent file edits across create, read, and undo operations.

https://github.com/verl-project/uni-agent/issues/119

## PR title

Use `[area] type: summary`.

- Areas: `agents`, `framework`, `gateway`, `logging`, `sandbox`, `tasks`, `tools`, `training`, `app`, `docs`, `examples`, `ci`, `build`, `deps`, `misc`
- Types: `feat`, `fix`, `refactor`, `perf`, `test`, `docs`, `chore`, `revert`
- Separate multiple areas with comma-space: `[agents, sandbox] feat: add isolated harness execution`
- Prefix compatibility-breaking work with `[BREAKING]`: `[BREAKING][tasks, docs] refactor: replace task config schema`
- A stacked series may start with `[1/N]`: `[1/N][gateway] refactor: split protocol adapters`

## Checklist

- [ ] The PR is focused and linked to an issue or explains why no issue is needed.
- [ ] The title follows the format above and names the layer that owns the change.
- [ ] Tests cover the behavior, or the Validation section explains why they are not practical.
- [ ] User-facing API, config, and workflow changes include documentation or runnable examples.
- [ ] Compatibility impact and migration steps are documented.
- [ ] Logs, fixtures, and examples contain no credentials or private data.
- [ ] `pre-commit run --all-files --show-diff-on-failure` passes.
