### PR TITLE
[sandbox] feat: add native local shell for local provider

### DIFF
--- a/tests/uni_agent/sandbox/test_local_sandbox_shell.py
+++ b/tests/uni_agent/sandbox/test_local_sandbox_shell.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from uni_agent.sandbox.local import LocalSandbox
+
+
+def test_local_sandbox_advertises_native_shell():
+    sandbox = LocalSandbox()
+
+    assert sandbox.supports_shell is True
+    assert "open_shell" in LocalSandbox.__dict__
+
+
+def test_open_shell_captures_stdout_and_exit_code(tmp_path):
+    async def scenario():
+        sandbox = LocalSandbox()
+        shell = await sandbox.open_shell(cwd=str(tmp_path))
+        try:
+            cwd_result = await shell.run("pwd")
+            assert cwd_result.exit_code == 0
+            assert cwd_result.stdout.strip() == str(tmp_path)
+            assert cwd_result.stderr.strip() == ""
+
+            ok_result = await shell.run("printf 'ok'")
+            assert ok_result.exit_code == 0
+            assert ok_result.stdout.strip() == "ok"
+
+            failed_result = await shell.run("false")
+            assert failed_result.exit_code == 1
+            assert failed_result.stdout.strip() == ""
+            assert failed_result.stderr.strip() == ""
+        finally:
+            await shell.close()
+
+    asyncio.run(scenario())
+
+
+def test_open_shell_persists_cwd_and_environment(tmp_path):
+    async def scenario():
+        sandbox = LocalSandbox()
+        shell = await sandbox.open_shell(cwd=str(tmp_path), env={"FOO": "bar"})
+        try:
+            env_result = await shell.run('printf "%s" "$FOO"')
+            assert env_result.exit_code == 0
+            assert env_result.stdout.strip() == "bar"
+
+            export_result = await shell.run('export ANSWER=42; printf "%s" "$ANSWER"')
+            assert export_result.exit_code == 0
+            assert export_result.stdout.strip() == "42"
+
+            cd_result = await shell.run("cd /tmp && pwd")
+            assert cd_result.exit_code == 0
+            assert cd_result.stdout.strip() == "/tmp"
+
+            persisted_cwd_result = await shell.run("pwd")
+            assert persisted_cwd_result.exit_code == 0
+            assert persisted_cwd_result.stdout.strip() == "/tmp"
+        finally:
+            await shell.close()
+
+    asyncio.run(scenario())
+
+
+def test_open_shell_times_out_and_cleanly_stops_subprocess():
+    async def scenario():
+        sandbox = LocalSandbox()
+        shell = await sandbox.open_shell()
+        try:
+            with pytest.raises(TimeoutError, match="timed out"):
+                await shell.run("sleep 5", timeout=0.2)
+        finally:
+            await shell.close()
+            await shell.close()
+
+    asyncio.run(scenario())

--- a/uni_agent/sandbox/local.py
+++ b/uni_agent/sandbox/local.py
@@ -1,10 +1,165 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import re
+import signal
+import uuid
 from pathlib import Path
 
 from .base import ExecResult, Sandbox, _to_str
 from .registry import register_sandbox
+
+
+class _LocalShell:
+    """Long-lived local bash session for :meth:`LocalSandbox.open_shell`.
+
+    ``provider: local`` runs on the host filesystem, so a native shell is a
+    normal subprocess instead of the tmux/apt fallback used by remote-only
+    providers.  Each command is delimited by unique markers written to stdout
+    and stderr so output and the exit code can be captured without a PTY.
+    """
+
+    def __init__(
+        self,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        self._cwd = cwd
+        self._env = dict(env or {})
+        self._proc: asyncio.subprocess.Process | None = None
+        self._lock = asyncio.Lock()
+
+    async def start(self) -> None:
+        if self._proc is not None and self._proc.returncode is None:
+            return
+
+        env = {**os.environ, "TERM": "dumb", "PS1": ""}
+        env.update(self._env)
+        self._proc = await asyncio.create_subprocess_exec(
+            "bash",
+            "--noprofile",
+            "--norc",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self._cwd,
+            env=env,
+            start_new_session=True,
+        )
+
+    def _process(self) -> asyncio.subprocess.Process:
+        proc = self._proc
+        if proc is None or proc.returncode is not None:
+            raise RuntimeError("local shell process is not running")
+        return proc
+
+    @staticmethod
+    def _signal_process(proc: asyncio.subprocess.Process, sig: int) -> None:
+        try:
+            os.killpg(os.getpgid(proc.pid), sig)
+        except (ProcessLookupError, PermissionError):
+            try:
+                proc.send_signal(sig)
+            except ProcessLookupError:
+                pass
+
+    async def _read_until(
+        self,
+        stream: asyncio.StreamReader,
+        pattern: re.Pattern[str],
+    ) -> tuple[str, int | None]:
+        buf = ""
+        try:
+            while True:
+                chunk = await stream.read(4096)
+                if not chunk:
+                    return buf, None
+                buf += chunk.decode("utf-8", "replace")
+                match = pattern.search(buf)
+                if match:
+                    return buf[: match.start()], int(match.group(1))
+        except asyncio.CancelledError:
+            return buf, None
+
+    async def _run_once(self, command: str, timeout: float | None) -> ExecResult:
+        proc = self._process()
+        token = uuid.uuid4().hex
+        stdout_pattern = re.compile(
+            rf"__UNI_AGENT_END_STDOUT_{token}_(-?\d+)__"
+        )
+        stderr_pattern = re.compile(
+            rf"__UNI_AGENT_END_STDERR_{token}_(-?\d+)__"
+        )
+        script = (
+            f"{command}\n"
+            "__uni_rc=$?\n"
+            'printf "\\n__UNI_AGENT_END_STDOUT_' + token + '_${__uni_rc}__\\n" >&1\n'
+            'printf "\\n__UNI_AGENT_END_STDERR_' + token + '_${__uni_rc}__\\n" >&2\n'
+        )
+
+        assert proc.stdin is not None
+        assert proc.stdout is not None
+        assert proc.stderr is not None
+        try:
+            proc.stdin.write(script.encode("utf-8"))
+            await proc.stdin.drain()
+        except (BrokenPipeError, ConnectionResetError):
+            return ExecResult(
+                exit_code=-1,
+                stdout="",
+                stderr="local shell process exited before the command could be sent",
+            )
+
+        stdout_task = asyncio.create_task(
+            self._read_until(proc.stdout, stdout_pattern)
+        )
+        stderr_task = asyncio.create_task(
+            self._read_until(proc.stderr, stderr_pattern)
+        )
+        pending = {stdout_task, stderr_task}
+        done, pending = await asyncio.wait(pending, timeout=timeout)
+
+        if pending:
+            self._signal_process(proc, signal.SIGKILL)
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+            self._proc = None
+            raise TimeoutError(f"local shell command timed out after {timeout:g}s")
+
+        results = await asyncio.gather(stdout_task, stderr_task, return_exceptions=True)
+        stdout, stdout_rc = results[0] if not isinstance(results[0], BaseException) else ("", None)
+        stderr, stderr_rc = results[1] if not isinstance(results[1], BaseException) else ("", None)
+        exit_code = stdout_rc if stdout_rc is not None else stderr_rc
+        if exit_code is None:
+            exit_code = -1
+        return ExecResult(
+            exit_code=exit_code,
+            stdout=_to_str(stdout),
+            stderr=_to_str(stderr),
+        )
+
+    async def run(self, command: str, *, timeout: float | None = None) -> ExecResult:
+        async with self._lock:
+            await self.start()
+            try:
+                return await self._run_once(command, timeout)
+            except (TimeoutError, asyncio.TimeoutError):
+                proc = self._proc
+                if proc is not None and proc.returncode is None:
+                    self._signal_process(proc, signal.SIGKILL)
+                    await proc.wait()
+                self._proc = None
+                raise
+
+    async def close(self) -> None:
+        proc = self._proc
+        self._proc = None
+        if proc is not None and proc.returncode is None:
+            self._signal_process(proc, signal.SIGKILL)
+            await proc.wait()
 
 
 @register_sandbox("local")
@@ -15,6 +170,8 @@ class LocalSandbox(Sandbox):
     so it uses the base :meth:`Sandbox.from_config` (which ignores the config
     fields).
     """
+
+    supports_shell = True
 
     async def start(self) -> None:
         pass
@@ -37,6 +194,17 @@ class LocalSandbox(Sandbox):
 
         await asyncio.to_thread(_write)
 
+    async def open_shell(
+        self,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+    ) -> _LocalShell:
+        """Open a persistent local bash process; cwd/env persist across runs."""
+        shell = _LocalShell(cwd=cwd, env=env)
+        await shell.start()
+        return shell
+
     async def _exec(
         self,
         argv: list[str],
@@ -45,8 +213,6 @@ class LocalSandbox(Sandbox):
         workdir: str | None = None,
         env: dict[str, str] | None = None,
     ) -> ExecResult:
-        import os
-
         proc = await asyncio.create_subprocess_exec(
             *argv,
             stdout=asyncio.subprocess.PIPE,
@@ -61,5 +227,13 @@ class LocalSandbox(Sandbox):
                 proc.kill()
             except ProcessLookupError:
                 pass
-            return ExecResult(exit_code=-1, stdout="", stderr=f"local exec timed out after {timeout}s")
-        return ExecResult(exit_code=proc.returncode or 0, stdout=_to_str(out), stderr=_to_str(err))
+            return ExecResult(
+                exit_code=-1,
+                stdout="",
+                stderr=f"local exec timed out after {timeout}s",
+            )
+        return ExecResult(
+            exit_code=proc.returncode or 0,
+            stdout=_to_str(out),
+            stderr=_to_str(err),
+        )


### PR DESCRIPTION
## Summary

Adds a native persistent local shell for provider: local

### current behavior
<img width="933" height="458" alt="img_v3_0214h_a6a9d1bd-150a-452b-8999-d4dea16c9e2g" src="https://github.com/user-attachments/assets/2f980a5c-087a-4afd-8385-4cbca96178e1" />
<img width="924" height="318" alt="img_v3_0214h_048cc4b9-e711-4bcd-90ab-006447de742g" src="https://github.com/user-attachments/assets/347bf724-d8de-4dbb-b6bd-d54b46f32389" />

### why it fails
LocalSandbox did not implement open_shell(), so stateful_shell fell back to TmuxShell.
Local sandboxes do not need tmux. Under high concurrency, tmux session and apt lock contention causes shell startup timeouts and leftover processes.

## Changes

- Adds _LocalShell in uni_agent/sandbox/local.py
- Sets LocalSandbox.supports_shell = True
- Adds LocalSandbox.open_shell()
- Adds tests in tests/uni_agent/sandbox/test_local_sandbox_shell.py

- add _LocalShell with 

## PR title

Use `[area] type: summary`.

- Areas: `agents`, `framework`, `gateway`, `logging`, `sandbox`, `tasks`, `tools`, `training`, `app`, `docs`, `examples`, `ci`, `build`, `deps`, `misc`
- Types: `feat`, `fix`, `refactor`, `perf`, `test`, `docs`, `chore`, `revert`
- Separate multiple areas with comma-space: `[agents, sandbox] feat: add isolated harness execution`
- Prefix compatibility-breaking work with `[BREAKING]`: `[BREAKING][tasks, docs] refactor: replace task config schema`
- A stacked series may start with `[1/N]`: `[1/N][gateway] refactor: split protocol adapters`

## Checklist

- [ ] The PR is focused and linked to an issue or explains why no issue is needed.
- [ ] The title follows the format above and names the layer that owns the change.
- [ ] Tests cover the behavior, or the Validation section explains why they are not practical.
- [ ] User-facing API, config, and workflow changes include documentation or runnable examples.
- [ ] Compatibility impact and migration steps are documented.
- [ ] Logs, fixtures, and examples contain no credentials or private data.
- [ ] `pre-commit run --all-files --show-diff-on-failure` passes.
