### PR TITLE
[gateway] fix: reuse first-assistant rollback chains

### DIFF
--- a/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
+++ b/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
@@ -308,7 +308,7 @@ async def test_first_assistant_rewrite_reuses_chain_without_stale_response():
 
 
 @pytest.mark.asyncio
-async def test_first_assistant_rollback_failure_preserves_chain_for_retry():
+async def test_first_assistant_rollback_failure_preserves_original_chain():
     """Keep the original first-turn chain when replacement generation fails."""
     session = _session("rollback-first-failure", enable_last_assistant_rollback=True)
     first_messages = [{"role": "user", "content": "run mini-swe"}]
@@ -316,7 +316,7 @@ async def test_first_assistant_rollback_failure_preserves_chain_for_retry():
         *first_messages,
         {"role": "user", "content": "user_error: missing import"},
     ]
-    backend = SequencedBackend(["FORMAT_ERROR", RuntimeError("boom"), "FIXED"])
+    backend = SequencedBackend(["FORMAT_ERROR", RuntimeError("boom")])
 
     await _run(session, backend, first_messages)
     with pytest.raises(HTTPException, match="RuntimeError: boom"):
@@ -327,16 +327,10 @@ async def test_first_assistant_rollback_failure_preserves_chain_for_retry():
     assert state["rollback_count"] == 0
     assert _decode_response_ids(session.active_chains[0].buffer.response_ids) == "FORMAT_ERROR"
 
-    await _run(session, backend, rewrite_messages)
-    state = session.snapshot_state()
-    assert state["active_chain_ids"] == [1]
-    assert state["rollback_count"] == 1
-    assert session.active_chains[0].buffer.response_ids[-len("FIXED") :] == _ids("FIXED")
-
 
 @pytest.mark.asyncio
-async def test_first_assistant_rollback_keeps_chain_when_replacement_exceeds_capacity():
-    """Leave the old chain untouched when the replacement prompt cannot fit."""
+async def test_first_assistant_rollback_drops_chain_when_replacement_exceeds_capacity():
+    """Drop the empty-prefix chain when the replacement prompt cannot fit."""
     first_messages = [{"role": "user", "content": "run mini-swe"}]
     rewrite_messages = [
         *first_messages,
@@ -356,8 +350,11 @@ async def test_first_assistant_rollback_keeps_chain_when_replacement_exceeds_cap
 
     assert outcome.finish_reason == "length"
     assert len(backend.calls) == 1
-    assert [chain.chain_id for chain in session.active_chains] == [1]
-    assert _decode_response_ids(session.active_chains[0].buffer.response_ids) == "FORMAT_ERROR"
+    state = session.snapshot_state()
+    assert state["active_chain_ids"] == []
+    assert state["rollback_count"] == 1
+    assert state["rollback_dropped_trainable_tokens_total"] == len("FORMAT_ERROR")
+    assert await session.finalize() == []
 
 
 @pytest.mark.asyncio
@@ -457,9 +454,11 @@ async def test_later_user_rollback_deduplicates_incremental_turn_separator():
 
 
 @pytest.mark.asyncio
-async def test_later_assistant_rollback_rejects_misaligned_generation_prompt():
-    """Fail closed when a stored response-side GP no longer matches the codec."""
-    session = _session("rollback-gp-assert", enable_last_assistant_rollback=True)
+async def test_later_assistant_rollback_rejects_misaligned_assistant_prefix():
+    """Fail closed when the stored turn separator no longer matches the codec."""
+    session = _session("rollback-prefix-assert", enable_last_assistant_rollback=True)
+    codec = session._codec
+    codec._turn_separator = _ids("\n")
     backend = SequencedBackend(["A1", "A2", "FIXED"])
     first_messages = [{"role": "user", "content": "start"}]
     continuation = [
@@ -473,9 +472,10 @@ async def test_later_assistant_rollback_rejects_misaligned_generation_prompt():
     await _run(session, backend, continuation)
     [chain] = session.active_chains
     snapshot = chain.last_assistant_start
-    chain.buffer.response_ids[snapshot.response_ids_len - 1] += 1
+    separator_end = snapshot.response_ids_len - len(codec.generation_prompt)
+    chain.buffer.response_ids[separator_end - 1] += 1
 
-    with pytest.raises(ValueError, match="generation prompt"):
+    with pytest.raises(ValueError, match="assistant prefix"):
         await _run(session, backend, rewrite_messages)
 
 

--- a/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
+++ b/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
@@ -297,11 +297,14 @@ async def test_first_assistant_rewrite_reuses_chain_without_stale_response():
     assert state["rollback_count"] == 1
     assert state["rollback_dropped_trainable_tokens_total"] == len("FORMAT_ERROR")
     chain = session.active_chains[0]
-    expected_prompt_ids = codec.encode_full(rewrite_messages)
-    assert backend.calls[1]["prompt_ids"] == expected_prompt_ids
+    expected_prompt_ids = codec.encode_full(first_messages)
+    del expected_prompt_ids[-len(codec.turn_separator) - len(codec.generation_prompt) :]
+    incremental_ids = codec.encode_incremental(rewrite_messages[len(first_messages) :])
+    assert backend.calls[1]["prompt_ids"] == codec.encode_full(rewrite_messages)
     assert chain.buffer.prompt_ids == expected_prompt_ids
-    assert _decode_response_ids(chain.buffer.response_ids) == "FIXED"
-    assert chain.buffer.response_logprobs == [-0.1] * len("FIXED")
+    assert chain.buffer.response_ids == incremental_ids + _ids("FIXED")
+    assert chain.buffer.response_mask == [0] * len(incremental_ids) + [1] * len("FIXED")
+    assert chain.buffer.response_logprobs == [0.0] * len(incremental_ids) + [-0.1] * len("FIXED")
 
 
 @pytest.mark.asyncio
@@ -328,7 +331,7 @@ async def test_first_assistant_rollback_failure_preserves_chain_for_retry():
     state = session.snapshot_state()
     assert state["active_chain_ids"] == [1]
     assert state["rollback_count"] == 1
-    assert _decode_response_ids(session.active_chains[0].buffer.response_ids) == "FIXED"
+    assert session.active_chains[0].buffer.response_ids[-len("FIXED") :] == _ids("FIXED")
 
 
 @pytest.mark.asyncio
@@ -374,10 +377,9 @@ async def test_first_assistant_rewrite_with_assistant_tool_context_reuses_chain(
 
     assert [chain.chain_id for chain in session.active_chains] == [1]
     chain = session.active_chains[0]
-    expected_prompt_ids = session._codec.encode_full(rewrite_messages)
-    assert backend.calls[1]["prompt_ids"] == expected_prompt_ids
-    assert chain.buffer.prompt_ids == expected_prompt_ids
-    assert chain.buffer.response_ids == _ids("FIXED")
+    codec = session._codec
+    assert backend.calls[1]["prompt_ids"] == codec.encode_full(rewrite_messages)
+    assert chain.buffer.response_ids[-len("FIXED") :] == _ids("FIXED")
 
 
 @pytest.mark.asyncio

--- a/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
+++ b/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
@@ -274,9 +274,13 @@ async def test_multiple_chains_context_compaction_starts_new_chain():
 
 
 @pytest.mark.asyncio
-async def test_first_assistant_rewrite_splits_without_rollback():
-    """Split a first-assistant rewrite because there are no trainable tokens to preserve."""
-    session = _session("rollback-token-truth", enable_last_assistant_rollback=True)
+async def test_first_assistant_rewrite_reuses_chain_without_stale_response():
+    """Replace a first assistant in place when no earlier response tokens exist."""
+    session = _session(
+        "rollback-token-truth",
+        sampling_params={"logprobs": True},
+        enable_last_assistant_rollback=True,
+    )
     first_messages = [{"role": "user", "content": "run mini-swe"}]
     rewrite_messages = [
         *first_messages,
@@ -289,19 +293,73 @@ async def test_first_assistant_rewrite_splits_without_rollback():
     await _run(session, backend, rewrite_messages)
 
     state = session.snapshot_state()
-    assert state["active_chain_ids"] == [1, 2]
-    assert state["rollback_count"] == 0
-    chains_by_id = {chain.chain_id: chain for chain in session.active_chains}
-    assert _decode_response_ids(chains_by_id[1].buffer.response_ids) == "FORMAT_ERROR"
+    assert state["active_chain_ids"] == [1]
+    assert state["rollback_count"] == 1
+    assert state["rollback_dropped_trainable_tokens_total"] == len("FORMAT_ERROR")
+    chain = session.active_chains[0]
     expected_prompt_ids = codec.encode_full(rewrite_messages)
     assert backend.calls[1]["prompt_ids"] == expected_prompt_ids
-    assert chains_by_id[2].buffer.prompt_ids == expected_prompt_ids
-    assert _decode_response_ids(chains_by_id[2].buffer.response_ids) == "FIXED"
+    assert chain.buffer.prompt_ids == expected_prompt_ids
+    assert _decode_response_ids(chain.buffer.response_ids) == "FIXED"
+    assert chain.buffer.response_logprobs == [-0.1] * len("FIXED")
 
 
 @pytest.mark.asyncio
-async def test_first_assistant_rewrite_with_assistant_tool_context_splits():
-    """Split a first-turn assistant/tool rewrite as a fresh full prompt."""
+async def test_first_assistant_rollback_failure_preserves_chain_for_retry():
+    """Keep the original first-turn chain when replacement generation fails."""
+    session = _session("rollback-first-failure", enable_last_assistant_rollback=True)
+    first_messages = [{"role": "user", "content": "run mini-swe"}]
+    rewrite_messages = [
+        *first_messages,
+        {"role": "user", "content": "user_error: missing import"},
+    ]
+    backend = SequencedBackend(["FORMAT_ERROR", RuntimeError("boom"), "FIXED"])
+
+    await _run(session, backend, first_messages)
+    with pytest.raises(HTTPException, match="RuntimeError: boom"):
+        await _run(session, backend, rewrite_messages)
+
+    state = session.snapshot_state()
+    assert state["active_chain_ids"] == [1]
+    assert state["rollback_count"] == 0
+    assert _decode_response_ids(session.active_chains[0].buffer.response_ids) == "FORMAT_ERROR"
+
+    await _run(session, backend, rewrite_messages)
+    state = session.snapshot_state()
+    assert state["active_chain_ids"] == [1]
+    assert state["rollback_count"] == 1
+    assert _decode_response_ids(session.active_chains[0].buffer.response_ids) == "FIXED"
+
+
+@pytest.mark.asyncio
+async def test_first_assistant_rollback_keeps_chain_when_replacement_exceeds_capacity():
+    """Leave the old chain untouched when the replacement prompt cannot fit."""
+    first_messages = [{"role": "user", "content": "run mini-swe"}]
+    rewrite_messages = [
+        *first_messages,
+        {"role": "user", "content": "user_error: missing import"},
+    ]
+    total_capacity = _prompt_length(rewrite_messages) - 1
+    session = _session(
+        "rollback-first-capacity",
+        prompt_length=1,
+        response_length=total_capacity - 1,
+        enable_last_assistant_rollback=True,
+    )
+    backend = SequencedBackend(["FORMAT_ERROR", "SHOULD_NOT_RUN"])
+
+    await _run(session, backend, first_messages)
+    outcome = await _run(session, backend, rewrite_messages)
+
+    assert outcome.finish_reason == "length"
+    assert len(backend.calls) == 1
+    assert [chain.chain_id for chain in session.active_chains] == [1]
+    assert _decode_response_ids(session.active_chains[0].buffer.response_ids) == "FORMAT_ERROR"
+
+
+@pytest.mark.asyncio
+async def test_first_assistant_rewrite_with_assistant_tool_context_reuses_chain():
+    """Replace a first-turn assistant/tool context in the existing chain."""
     session = _session("rollback-first-assistant-tool", enable_last_assistant_rollback=True)
     first_messages = [{"role": "user", "content": "run task"}]
     rewrite_messages = [
@@ -314,13 +372,12 @@ async def test_first_assistant_rewrite_with_assistant_tool_context_splits():
     await _run(session, backend, first_messages)
     await _run(session, backend, rewrite_messages)
 
-    assert [chain.chain_id for chain in session.active_chains] == [1, 2]
-    chains_by_id = {chain.chain_id: chain for chain in session.active_chains}
-    assert _decode_response_ids(chains_by_id[1].buffer.response_ids) == "BAD"
+    assert [chain.chain_id for chain in session.active_chains] == [1]
+    chain = session.active_chains[0]
     expected_prompt_ids = session._codec.encode_full(rewrite_messages)
     assert backend.calls[1]["prompt_ids"] == expected_prompt_ids
-    assert chains_by_id[2].buffer.prompt_ids == expected_prompt_ids
-    assert chains_by_id[2].buffer.response_ids == _ids("FIXED")
+    assert chain.buffer.prompt_ids == expected_prompt_ids
+    assert chain.buffer.response_ids == _ids("FIXED")
 
 
 @pytest.mark.asyncio

--- a/uni_agent/gateway/session/session.py
+++ b/uni_agent/gateway/session/session.py
@@ -395,7 +395,6 @@ class GatewaySession:
         )
         rollback_applied = False
         rollback_dropped_trainable_tokens = 0
-        first_assistant_rollback = False
 
         if selection is None:
             image_data, video_data = await self._codec.extract_multi_modal_data(messages)
@@ -418,7 +417,6 @@ class GatewaySession:
                 last_assistant_start = selected_chain.last_assistant_start
                 assert last_assistant_start.response_ids_len <= len(buffer.response_ids)
                 rollback_dropped_trainable_tokens = sum(buffer.response_mask[last_assistant_start.response_ids_len :])
-                first_assistant_rollback = last_assistant_start.response_ids_len == 0
                 # One generation appends exactly one mark, so the rewritten
                 # assistant is always the last one.
                 del buffer.generation_versions[-1:]
@@ -430,28 +428,20 @@ class GatewaySession:
                     assert last_assistant_start.video_data_len <= len(video_data)
                     video_data = video_data[: last_assistant_start.video_data_len] or None
 
-                generation_prompt = self._codec.generation_prompt
-                turn_separator = self._codec.turn_separator
                 rollback_response_len = last_assistant_start.response_ids_len
-                if first_assistant_rollback:
-                    # The first assistant prefix is prompt-side; incremental
-                    # encoding restores its boundary with the replacement suffix.
-                    rollback_prompt_len = len(buffer.prompt_ids) - len(generation_prompt) - len(turn_separator)
-                    del buffer.prompt_ids[rollback_prompt_len:]
-                else:
-                    # Later rollbacks retain earlier trainable output; the snapshot was captured
-                    # after the prior incremental GP, so remove that verified suffix as well.
-                    rollback_response_len -= len(generation_prompt)
-                    if (
-                        rollback_response_len < 0
-                        or buffer.response_ids[rollback_response_len : last_assistant_start.response_ids_len]
-                        != generation_prompt
-                    ):
-                        raise ValueError("Stored response does not end its assistant prefix with the generation prompt")
-                    rollback_response_len -= len(turn_separator)
                 del buffer.response_ids[rollback_response_len:]
                 del buffer.response_mask[rollback_response_len:]
                 del buffer.response_logprobs[rollback_response_len:]
+
+                assistant_prefix = self._codec.turn_separator + self._codec.generation_prompt
+                stored_ids = buffer.prompt_ids if rollback_response_len == 0 else buffer.response_ids
+                assistant_prefix_start = len(stored_ids) - len(assistant_prefix)
+                if stored_ids[assistant_prefix_start:] != assistant_prefix:
+                    raise ValueError("Stored trajectory does not end with the assistant prefix")
+                del stored_ids[assistant_prefix_start:]
+                if rollback_response_len:
+                    del buffer.response_mask[assistant_prefix_start:]
+                    del buffer.response_logprobs[assistant_prefix_start:]
                 self._assert_response_logprob_alignment(buffer)
                 incremental_messages = messages[last_assistant_start.message_history_len :]
                 rollback_applied = True
@@ -476,10 +466,6 @@ class GatewaySession:
                     self._trajectory_capacity is not None
                     and current_trajectory_length + len(incremental_ids) >= self._trajectory_capacity
                 )
-            if first_assistant_rollback and capacity_exhausted:
-                # A replacement that cannot fit must leave the old chain retryable.
-                chain_id = None
-
             if not capacity_exhausted:
                 buffer.response_ids.extend(incremental_ids)
                 buffer.response_mask.extend([0] * len(incremental_ids))
@@ -731,6 +717,11 @@ class GatewaySession:
         if encoded.chain_id is None:
             raise RuntimeError("length-exhausted chain id is missing")
         chain_index, chain = self._find_active_chain(encoded.chain_id)
+        if encoded.rollback_applied and chain.last_assistant_start.response_ids_len == 0:
+            # No trainable response prefix survives this rollback.
+            self._record_rollback_stats(encoded)
+            del self.active_chains[chain_index]
+            return
         chain_to_materialize = chain
         if encoded.rollback_applied:
             message_history_len = chain.last_assistant_start.message_history_len

--- a/uni_agent/gateway/session/session.py
+++ b/uni_agent/gateway/session/session.py
@@ -395,6 +395,7 @@ class GatewaySession:
         )
         rollback_applied = False
         rollback_dropped_trainable_tokens = 0
+        first_assistant_rollback = False
 
         if selection is None:
             image_data, video_data = await self._codec.extract_multi_modal_data(messages)
@@ -417,48 +418,42 @@ class GatewaySession:
                 last_assistant_start = selected_chain.last_assistant_start
                 assert last_assistant_start.response_ids_len <= len(buffer.response_ids)
                 rollback_dropped_trainable_tokens = sum(buffer.response_mask[last_assistant_start.response_ids_len :])
-                if last_assistant_start.response_ids_len == 0:
-                    image_data, video_data = await self._codec.extract_multi_modal_data(messages)
-                    buffer = TrajectoryBuffer(
-                        prompt_ids=self._codec.encode_full(
-                            messages,
-                            tools=tools,
-                            image_data=image_data,
-                            video_data=video_data,
-                        )
-                    )
-                    if self._trajectory_capacity is not None and len(buffer.prompt_ids) >= self._trajectory_capacity:
-                        # A replacement that cannot fit must leave the old chain retryable.
-                        chain_id = None
-                    incremental_messages = []
-                else:
-                    # One generation appends exactly one mark, so the rewritten
-                    # assistant is always the last one.
-                    del buffer.generation_versions[-1:]
+                first_assistant_rollback = last_assistant_start.response_ids_len == 0
+                # One generation appends exactly one mark, so the rewritten
+                # assistant is always the last one.
+                del buffer.generation_versions[-1:]
 
-                    if image_data is not None:
-                        assert last_assistant_start.image_data_len <= len(image_data)
-                        image_data = image_data[: last_assistant_start.image_data_len] or None
-                    if video_data is not None:
-                        assert last_assistant_start.video_data_len <= len(video_data)
-                        video_data = video_data[: last_assistant_start.video_data_len] or None
+                if image_data is not None:
+                    assert last_assistant_start.image_data_len <= len(image_data)
+                    image_data = image_data[: last_assistant_start.image_data_len] or None
+                if video_data is not None:
+                    assert last_assistant_start.video_data_len <= len(video_data)
+                    video_data = video_data[: last_assistant_start.video_data_len] or None
+
+                generation_prompt = self._codec.generation_prompt
+                turn_separator = self._codec.turn_separator
+                rollback_response_len = last_assistant_start.response_ids_len
+                if first_assistant_rollback:
+                    # The first assistant prefix is prompt-side; incremental
+                    # encoding restores its boundary with the replacement suffix.
+                    rollback_prompt_len = len(buffer.prompt_ids) - len(generation_prompt) - len(turn_separator)
+                    del buffer.prompt_ids[rollback_prompt_len:]
+                else:
                     # Later rollbacks retain earlier trainable output; the snapshot was captured
                     # after the prior incremental GP, so remove that verified suffix as well.
-                    generation_prompt = self._codec.generation_prompt
-                    rollback_response_len = last_assistant_start.response_ids_len - len(generation_prompt)
+                    rollback_response_len -= len(generation_prompt)
                     if (
                         rollback_response_len < 0
                         or buffer.response_ids[rollback_response_len : last_assistant_start.response_ids_len]
                         != generation_prompt
                     ):
                         raise ValueError("Stored response does not end its assistant prefix with the generation prompt")
-                    # Incremental encoding restores the turn separator with the replacement suffix.
-                    rollback_response_len -= len(self._codec.turn_separator)
-                    del buffer.response_ids[rollback_response_len:]
-                    del buffer.response_mask[rollback_response_len:]
-                    del buffer.response_logprobs[rollback_response_len:]
-                    self._assert_response_logprob_alignment(buffer)
-                    incremental_messages = messages[last_assistant_start.message_history_len :]
+                    rollback_response_len -= len(turn_separator)
+                del buffer.response_ids[rollback_response_len:]
+                del buffer.response_mask[rollback_response_len:]
+                del buffer.response_logprobs[rollback_response_len:]
+                self._assert_response_logprob_alignment(buffer)
+                incremental_messages = messages[last_assistant_start.message_history_len :]
                 rollback_applied = True
             else:
                 incremental_messages = messages[len(selected_chain.message_history) :]
@@ -481,6 +476,9 @@ class GatewaySession:
                     self._trajectory_capacity is not None
                     and current_trajectory_length + len(incremental_ids) >= self._trajectory_capacity
                 )
+            if first_assistant_rollback and capacity_exhausted:
+                # A replacement that cannot fit must leave the old chain retryable.
+                chain_id = None
 
             if not capacity_exhausted:
                 buffer.response_ids.extend(incremental_ids)

--- a/uni_agent/gateway/session/session.py
+++ b/uni_agent/gateway/session/session.py
@@ -417,39 +417,52 @@ class GatewaySession:
                 last_assistant_start = selected_chain.last_assistant_start
                 assert last_assistant_start.response_ids_len <= len(buffer.response_ids)
                 rollback_dropped_trainable_tokens = sum(buffer.response_mask[last_assistant_start.response_ids_len :])
-                # One generation appends exactly one mark, so the rewritten
-                # assistant is always the last one.
-                del buffer.generation_versions[-1:]
+                if last_assistant_start.response_ids_len == 0:
+                    image_data, video_data = await self._codec.extract_multi_modal_data(messages)
+                    buffer = TrajectoryBuffer(
+                        prompt_ids=self._codec.encode_full(
+                            messages,
+                            tools=tools,
+                            image_data=image_data,
+                            video_data=video_data,
+                        )
+                    )
+                    if self._trajectory_capacity is not None and len(buffer.prompt_ids) >= self._trajectory_capacity:
+                        # A replacement that cannot fit must leave the old chain retryable.
+                        chain_id = None
+                    incremental_messages = []
+                else:
+                    # One generation appends exactly one mark, so the rewritten
+                    # assistant is always the last one.
+                    del buffer.generation_versions[-1:]
 
-                if image_data is not None:
-                    assert last_assistant_start.image_data_len <= len(image_data)
-                    image_data = image_data[: last_assistant_start.image_data_len] or None
-                if video_data is not None:
-                    assert last_assistant_start.video_data_len <= len(video_data)
-                    video_data = video_data[: last_assistant_start.video_data_len] or None
-                assert last_assistant_start.response_ids_len > 0
-                # Later rollbacks retain earlier trainable output; the snapshot was captured
-                # after the prior incremental GP, so remove that verified suffix as well.
-                generation_prompt = self._codec.generation_prompt
-                rollback_response_len = last_assistant_start.response_ids_len - len(generation_prompt)
-                if (
-                    rollback_response_len < 0
-                    or buffer.response_ids[rollback_response_len : last_assistant_start.response_ids_len]
-                    != generation_prompt
-                ):
-                    raise ValueError("Stored response does not end its assistant prefix with the generation prompt")
-                # Incremental encoding restores the turn separator with the replacement suffix.
-                rollback_response_len -= len(self._codec.turn_separator)
-                del buffer.response_ids[rollback_response_len:]
-                del buffer.response_mask[rollback_response_len:]
-                del buffer.response_logprobs[rollback_response_len:]
-                self._assert_response_logprob_alignment(buffer)
-                incremental_start = last_assistant_start.message_history_len
+                    if image_data is not None:
+                        assert last_assistant_start.image_data_len <= len(image_data)
+                        image_data = image_data[: last_assistant_start.image_data_len] or None
+                    if video_data is not None:
+                        assert last_assistant_start.video_data_len <= len(video_data)
+                        video_data = video_data[: last_assistant_start.video_data_len] or None
+                    # Later rollbacks retain earlier trainable output; the snapshot was captured
+                    # after the prior incremental GP, so remove that verified suffix as well.
+                    generation_prompt = self._codec.generation_prompt
+                    rollback_response_len = last_assistant_start.response_ids_len - len(generation_prompt)
+                    if (
+                        rollback_response_len < 0
+                        or buffer.response_ids[rollback_response_len : last_assistant_start.response_ids_len]
+                        != generation_prompt
+                    ):
+                        raise ValueError("Stored response does not end its assistant prefix with the generation prompt")
+                    # Incremental encoding restores the turn separator with the replacement suffix.
+                    rollback_response_len -= len(self._codec.turn_separator)
+                    del buffer.response_ids[rollback_response_len:]
+                    del buffer.response_mask[rollback_response_len:]
+                    del buffer.response_logprobs[rollback_response_len:]
+                    self._assert_response_logprob_alignment(buffer)
+                    incremental_messages = messages[last_assistant_start.message_history_len :]
                 rollback_applied = True
             else:
-                incremental_start = len(selected_chain.message_history)
+                incremental_messages = messages[len(selected_chain.message_history) :]
 
-            incremental_messages = messages[incremental_start:]
             new_image_data = None
             new_video_data = None
             incremental_ids = []
@@ -559,10 +572,6 @@ class GatewaySession:
                 ranked_candidates.append((chain, len(chain.message_history), True))
                 continue
             if self._enable_last_assistant_rollback:
-                if assistant_start.response_ids_len == 0:
-                    # No response-side tokens predate this assistant, so rollback has nothing
-                    # to preserve. Omit it while still allowing an exact or later chain to win.
-                    continue
                 if assistant_start_len > deepest_rollback_service_value:
                     deepest_rollback_candidates = [chain]
                     deepest_rollback_service_value = assistant_start_len


### PR DESCRIPTION
## Summary

First-assistant rollbacks currently split into a new chain because the original
prompt-side generation prompt cannot be truncated incrementally. In workloads
where the first generated assistant is frequently rewritten, this preserves an
abandoned chain with no useful trainable history and produces unnecessary
trajectory splits.

Reuse the selected chain by removing its prompt-side turn separator and
generation prompt, then encoding the replacement suffix through the normal
incremental path. The replacement is committed only after generation and
decoding succeed, so the previous chain remains unchanged on failure. If the
replacement context already exhausts trajectory capacity, discard the abandoned
chain instead of emitting a prompt-only trajectory.

No separate issue is needed: this is a focused follow-up to the first-assistant
split behavior introduced in #106 after observing that path more frequently in
training workloads.

## Changes

- Include first-assistant boundaries in rollback chain selection instead of
  forcing the split path.
- Remove and validate the complete turn separator plus generation prompt from
  either the prompt or response side before incremental suffix encoding.
- Share generation-version cleanup, media rollback, stale response removal, and
  incremental suffix encoding with later-turn rollback.
- Preserve the selected chain on backend or decode failure.
- When a first-assistant replacement exhausts trajectory capacity, record the
  rollback and delete the chain because no trainable response prefix survives.
- Keep focused CPU coverage for user-only and assistant/tool rewrites, failure
  isolation, capacity handling, rollback statistics, and token masks.

## Validation

- `PYTHONPATH="$PWD" python -m pytest -q tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py tests/uni_agent/gateway/test_message_codec_continuous_token.py tests/uni_agent/gateway/test_gateway_actor_on_cpu.py`: 122 passed, 5 environment warnings.
- `pre-commit run --all-files --show-diff-on-failure --color=always`: passed.
- `PR_TITLE='[gateway] fix: reuse first-assistant rollback chains' python tests/special_sanity/check_pr_title.py`: passed.
- `ledger_update: candidate`
- `ledger_evidence: K06 update candidate for PR #123; no ledger write was performed.`

## Compatibility

No public API, configuration, or chat-template contract changes. A uniquely
selected first-assistant rollback now retains the original prompt prefix and
records the replacement suffix as masked response context instead of preserving
an abandoned sibling trajectory. If that replacement cannot fit, the abandoned
chain is omitted from the finalized trajectories.

## Checklist

- [x] The PR is focused and explains why no issue is needed.
- [x] The title follows the repository format and names the owning layer.
- [x] Tests cover the behavior and failure-state semantics.
- [x] No user-facing API, config, or workflow documentation changes are needed.
- [x] Compatibility impact is documented above.
- [x] Logs and tests contain no credentials or private data.
- [x] `pre-commit run --all-files --show-diff-on-failure` passes.
