### PR TITLE
[gateway] perf: add tool parser cache

### DIFF
--- a/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
+++ b/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
@@ -166,6 +166,7 @@ def test_build_gateway_manager_wires_gateway_config_defaults(
             "actor_rollout_ref": {
                 "model": {},
                 "rollout": {
+                    "name": "vllm",
                     "prompt_length": 128,
                     "response_length": 64,
                     "multi_turn": {"format": "hermes"},
@@ -188,6 +189,7 @@ def test_build_gateway_manager_wires_gateway_config_defaults(
     assert captured["gateway_actor_config"].prompt_length == 128
     assert captured["gateway_actor_config"].response_length == 64
     assert captured["gateway_actor_config"].tool_parser_name == "hermes"
+    assert captured["gateway_actor_config"].rollout_backend == "vllm"
     assert captured["gateway_actor_config"].enable_last_assistant_rollback is expected_rollback
     assert isinstance(captured["gateway_actor_config"].apply_chat_template_kwargs, dict)
     assert captured["gateway_actor_config"].apply_chat_template_kwargs == expected_chat_template_kwargs

--- a/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
+++ b/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
@@ -27,8 +27,8 @@ from tests.uni_agent.support import (
 ALLOWED_SAMPLING_KEYS = frozenset({"temperature", "top_p", "top_k", "max_tokens", "stop"})
 
 
-async def fake_tool_call_dispatch(response_ids, tools, parser_name, tokenizer):
-    text = tokenizer.decode(response_ids, skip_special_tokens=False)
+async def fake_tool_call_dispatch(self, response_ids, tools, parser_name):
+    text = self._tokenizer.decode(response_ids, skip_special_tokens=False)
     if "<tool_call>" not in text:
         return text, []
     arguments = '{"query":"crop"}' if "crop" in text else '{"query":"weather"}'
@@ -838,7 +838,7 @@ async def test_gateway_actor_continuation_with_tool_returned_image_appends_media
         initialize_turn_separator,
     )
 
-    monkeypatch.setattr(codec_mod, "_extract_tool_calls", fake_tool_call_dispatch)
+    monkeypatch.setattr(codec_mod.MessageCodec, "_extract_tool_calls", fake_tool_call_dispatch)
     processor = FakeProcessor()
     tool_call_text = '<tool_call>\n{"name": "search", "arguments": {"query": "crop"}}\n</tool_call>'
     actor = _GatewayActor(
@@ -1370,7 +1370,7 @@ async def test_gateway_actor_tool_call_decode_returns_openai_format(monkeypatch)
     from uni_agent.gateway.config import GatewayActorConfig
     from uni_agent.gateway.gateway import _GatewayActor
 
-    monkeypatch.setattr(codec_mod, "_extract_tool_calls", fake_tool_call_dispatch)
+    monkeypatch.setattr(codec_mod.MessageCodec, "_extract_tool_calls", fake_tool_call_dispatch)
     tool_call_text = '<tool_call>\n{"name": "search", "arguments": {"query": "weather"}}\n</tool_call>'
     actor = _GatewayActor(
         GatewayActorConfig(
@@ -1493,7 +1493,7 @@ async def test_anthropic_tool_turn_round_trip_extends_not_reencodes(monkeypatch)
     from uni_agent.gateway.config import GatewayActorConfig
     from uni_agent.gateway.gateway import _GatewayActor
 
-    monkeypatch.setattr(codec_mod, "_extract_tool_calls", fake_tool_call_dispatch)
+    monkeypatch.setattr(codec_mod.MessageCodec, "_extract_tool_calls", fake_tool_call_dispatch)
     tool_call_text = '<tool_call>\n{"name": "search", "arguments": {"query": "weather"}}\n</tool_call>'
     actor = _GatewayActor(
         GatewayActorConfig(

--- a/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
+++ b/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
@@ -1370,12 +1370,28 @@ async def test_gateway_actor_tool_call_decode_returns_openai_format(monkeypatch)
     from uni_agent.gateway.config import GatewayActorConfig
     from uni_agent.gateway.gateway import _GatewayActor
 
-    monkeypatch.setattr(codec_mod.MessageCodec, "_extract_tool_calls", fake_tool_call_dispatch)
+    def fake_vllm_parser(self, text, tools, parser_name):
+        assert tools
+        assert parser_name == "hermes"
+        if "<tool_call>" not in text:
+            return text, []
+        return "", [SimpleNamespace(name="search", arguments='{"query":"weather"}')]
+
+    def fail_sync_parser(*args, **kwargs):
+        raise AssertionError("rollout backend should select the vLLM parser")
+
+    async def fail_async_parser(*args, **kwargs):
+        raise AssertionError("rollout backend should select the vLLM parser")
+
+    monkeypatch.setattr(codec_mod.MessageCodec, "_process_tool_calls_sglang", fail_sync_parser)
+    monkeypatch.setattr(codec_mod.MessageCodec, "_process_tool_calls_vllm", fake_vllm_parser)
+    monkeypatch.setattr(codec_mod.MessageCodec, "_process_tool_calls_verl", fail_async_parser)
     tool_call_text = '<tool_call>\n{"name": "search", "arguments": {"query": "weather"}}\n</tool_call>'
     actor = _GatewayActor(
         GatewayActorConfig(
             tokenizer=FakeTokenizer(),
             tool_parser_name="hermes",
+            rollout_backend="vllm",
         ),
         QueuedBackend([tool_call_text, "sunny today"]),
     )

--- a/tests/uni_agent/gateway/test_message_codec_parser_cache.py
+++ b/tests/uni_agent/gateway/test_message_codec_parser_cache.py
@@ -1,0 +1,244 @@
+import logging
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from tests.uni_agent.support import FakeTokenizer
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "search",
+            "description": "search docs",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+            },
+        },
+    }
+]
+
+
+def _equivalent_tools():
+    return [
+        {
+            "function": {
+                "parameters": {
+                    "properties": {"query": {"type": "string"}},
+                    "type": "object",
+                },
+                "description": "search docs",
+                "name": "search",
+            },
+            "type": "function",
+        }
+    ]
+
+
+def _install_fake_sglang(monkeypatch, constructions):
+    protocol = types.ModuleType("sglang.srt.entrypoints.openai.protocol")
+    function_call_parser = types.ModuleType("sglang.srt.function_call.function_call_parser")
+
+    class Function:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class Tool:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class FunctionCallParser:
+        def __init__(self, tools, parser_name):
+            constructions.append((tools, parser_name))
+
+        def has_tool_call(self, text):
+            return False
+
+    protocol.Function = Function
+    protocol.Tool = Tool
+    function_call_parser.FunctionCallParser = FunctionCallParser
+    for name, module in {
+        "sglang": types.ModuleType("sglang"),
+        "sglang.srt": types.ModuleType("sglang.srt"),
+        "sglang.srt.entrypoints": types.ModuleType("sglang.srt.entrypoints"),
+        "sglang.srt.entrypoints.openai": types.ModuleType("sglang.srt.entrypoints.openai"),
+        "sglang.srt.entrypoints.openai.protocol": protocol,
+        "sglang.srt.function_call": types.ModuleType("sglang.srt.function_call"),
+        "sglang.srt.function_call.function_call_parser": function_call_parser,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+
+def _install_fake_vllm(monkeypatch, constructions, lookups=None):
+    protocol = types.ModuleType("vllm.entrypoints.openai.chat_completion.protocol")
+    tool_parsers = types.ModuleType("vllm.tool_parsers")
+
+    class ChatCompletionToolsParam:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class Parser:
+        def __init__(self, tokenizer, *, tools):
+            del tokenizer
+            constructions.append(tools)
+
+        def extract_tool_calls(self, text, request):
+            del request
+            return SimpleNamespace(tools_called=False, content=text, tool_calls=[])
+
+    class ToolParserManager:
+        @classmethod
+        def get_tool_parser(cls, name):
+            del cls
+            if lookups is not None:
+                lookups.append(name)
+            return Parser
+
+    protocol.ChatCompletionToolsParam = ChatCompletionToolsParam
+    tool_parsers.ToolParserManager = ToolParserManager
+    for name, module in {
+        "vllm": types.ModuleType("vllm"),
+        "vllm.entrypoints": types.ModuleType("vllm.entrypoints"),
+        "vllm.entrypoints.openai": types.ModuleType("vllm.entrypoints.openai"),
+        "vllm.entrypoints.openai.chat_completion": types.ModuleType("vllm.entrypoints.openai.chat_completion"),
+        "vllm.entrypoints.openai.chat_completion.protocol": protocol,
+        "vllm.tool_parsers": tool_parsers,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+
+def _install_fake_verl(monkeypatch, lookups):
+    tool_parser_module = types.ModuleType("verl.experimental.agent_loop.tool_parser")
+    schemas_module = types.ModuleType("verl.tools.schemas")
+
+    class Parser:
+        async def extract_tool_calls(self, response_ids, tool_schemas):
+            del response_ids, tool_schemas
+            return "plain", []
+
+    class ToolParser:
+        @classmethod
+        def get_tool_parser(cls, name, tokenizer):
+            del cls, tokenizer
+            lookups.append(name)
+            return Parser()
+
+    class OpenAIFunctionToolSchema:
+        @classmethod
+        def model_validate(cls, tool):
+            return tool
+
+    tool_parser_module.ToolParser = ToolParser
+    schemas_module.OpenAIFunctionToolSchema = OpenAIFunctionToolSchema
+    monkeypatch.setitem(sys.modules, "verl.experimental.agent_loop.tool_parser", tool_parser_module)
+    monkeypatch.setitem(sys.modules, "verl.tools.schemas", schemas_module)
+
+
+def test_sglang_parser_cache_reuses_equivalent_tool_schemas(monkeypatch):
+    from uni_agent.gateway.session.codec import MessageCodec
+
+    constructions = []
+    _install_fake_sglang(monkeypatch, constructions)
+    codec = MessageCodec(FakeTokenizer())
+
+    assert codec._process_tool_calls_sglang("plain", TOOLS, "qwen3_coder") == (
+        "plain",
+        [],
+    )
+    assert codec._process_tool_calls_sglang("plain", _equivalent_tools(), "qwen3_coder") == (
+        "plain",
+        [],
+    )
+
+    assert len(constructions) == 1
+
+
+def test_vllm_parser_cache_separates_tool_schemas(monkeypatch):
+    from uni_agent.gateway.session.codec import MessageCodec
+
+    constructions = []
+    _install_fake_vllm(monkeypatch, constructions)
+    codec = MessageCodec(FakeTokenizer())
+    codec._process_tool_calls_vllm("plain", TOOLS, "qwen3_coder")
+    codec._process_tool_calls_vllm("plain", _equivalent_tools(), "qwen3_coder")
+    different_tools = [{**TOOLS[0], "function": {**TOOLS[0]["function"], "name": "lookup"}}]
+    codec._process_tool_calls_vllm("plain", different_tools, "qwen3_coder")
+
+    assert len(constructions) == 2
+
+
+def test_parser_cache_debug_log_identifies_backend_on_construction(monkeypatch, caplog):
+    from uni_agent.gateway.session.codec import MessageCodec
+
+    constructions = []
+    _install_fake_vllm(monkeypatch, constructions)
+    codec = MessageCodec(FakeTokenizer())
+    with caplog.at_level(logging.DEBUG, logger="gateway"):
+        codec._process_tool_calls_vllm("plain", TOOLS, "qwen3_coder")
+
+    assert "backend=vllm" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_message_codec_uses_parser_cache_across_decode_calls(monkeypatch):
+    from uni_agent.gateway.session.codec import MessageCodec
+
+    constructions = []
+    _install_fake_vllm(monkeypatch, constructions)
+    codec = MessageCodec(FakeTokenizer(), tool_parser_name="qwen3_coder")
+
+    def missing_sglang(*args, **kwargs):
+        raise ModuleNotFoundError("sglang")
+
+    monkeypatch.setattr(
+        codec,
+        "_process_tool_calls_sglang",
+        missing_sglang,
+    )
+
+    await codec.decode_response([ord("x")], tools=TOOLS)
+    await codec.decode_response([ord("x")], tools=_equivalent_tools())
+
+    assert len(constructions) == 1
+
+
+@pytest.mark.asyncio
+async def test_message_codec_skips_vllm_parser_lookup_on_cache_hit(monkeypatch):
+    from uni_agent.gateway.session.codec import MessageCodec
+
+    constructions = []
+    lookups = []
+    _install_fake_vllm(monkeypatch, constructions, lookups)
+    codec = MessageCodec(FakeTokenizer(), tool_parser_name="qwen3_coder")
+
+    def missing_sglang(*args, **kwargs):
+        raise ModuleNotFoundError("sglang")
+
+    monkeypatch.setattr(
+        codec,
+        "_process_tool_calls_sglang",
+        missing_sglang,
+    )
+
+    await codec.decode_response([ord("x")], tools=TOOLS)
+    await codec.decode_response([ord("x")], tools=_equivalent_tools())
+
+    assert lookups == ["qwen3_coder"]
+
+
+@pytest.mark.asyncio
+async def test_verl_parser_cache_ignores_tool_schema(monkeypatch):
+    from uni_agent.gateway.session.codec import MessageCodec
+
+    lookups = []
+    _install_fake_verl(monkeypatch, lookups)
+    codec = MessageCodec(FakeTokenizer())
+
+    await codec._process_tool_calls_verl([ord("x")], TOOLS, "hermes")
+    await codec._process_tool_calls_verl([ord("y")], _equivalent_tools(), "hermes")
+
+    assert lookups == ["hermes"]
+    assert set(codec._tool_parser_cache) == {("verl", "hermes")}

--- a/tests/uni_agent/gateway/test_message_codec_parser_cache.py
+++ b/tests/uni_agent/gateway/test_message_codec_parser_cache.py
@@ -176,15 +176,10 @@ async def test_message_codec_reuses_vllm_parser_across_decode_calls(monkeypatch)
     constructions = []
     lookups = []
     _install_fake_vllm(monkeypatch, constructions, lookups)
-    codec = MessageCodec(FakeTokenizer(), tool_parser_name="qwen3_coder")
-
-    def missing_sglang(*args, **kwargs):
-        raise ModuleNotFoundError("sglang")
-
-    monkeypatch.setattr(
-        codec,
-        "_process_tool_calls_sglang",
-        missing_sglang,
+    codec = MessageCodec(
+        FakeTokenizer(),
+        tool_parser_name="qwen3_coder",
+        rollout_backend="vllm",
     )
 
     await codec.decode_response([ord("x")], tools=TOOLS)

--- a/tests/uni_agent/gateway/test_message_codec_parser_cache.py
+++ b/tests/uni_agent/gateway/test_message_codec_parser_cache.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 import types
 from types import SimpleNamespace
@@ -170,43 +169,8 @@ def test_vllm_parser_cache_separates_tool_schemas(monkeypatch):
     assert len(constructions) == 2
 
 
-def test_parser_cache_debug_log_identifies_backend_on_construction(monkeypatch, caplog):
-    from uni_agent.gateway.session.codec import MessageCodec
-
-    constructions = []
-    _install_fake_vllm(monkeypatch, constructions)
-    codec = MessageCodec(FakeTokenizer())
-    with caplog.at_level(logging.DEBUG, logger="gateway"):
-        codec._process_tool_calls_vllm("plain", TOOLS, "qwen3_coder")
-
-    assert "backend=vllm" in caplog.text
-
-
 @pytest.mark.asyncio
-async def test_message_codec_uses_parser_cache_across_decode_calls(monkeypatch):
-    from uni_agent.gateway.session.codec import MessageCodec
-
-    constructions = []
-    _install_fake_vllm(monkeypatch, constructions)
-    codec = MessageCodec(FakeTokenizer(), tool_parser_name="qwen3_coder")
-
-    def missing_sglang(*args, **kwargs):
-        raise ModuleNotFoundError("sglang")
-
-    monkeypatch.setattr(
-        codec,
-        "_process_tool_calls_sglang",
-        missing_sglang,
-    )
-
-    await codec.decode_response([ord("x")], tools=TOOLS)
-    await codec.decode_response([ord("x")], tools=_equivalent_tools())
-
-    assert len(constructions) == 1
-
-
-@pytest.mark.asyncio
-async def test_message_codec_skips_vllm_parser_lookup_on_cache_hit(monkeypatch):
+async def test_message_codec_reuses_vllm_parser_across_decode_calls(monkeypatch):
     from uni_agent.gateway.session.codec import MessageCodec
 
     constructions = []
@@ -226,7 +190,20 @@ async def test_message_codec_skips_vllm_parser_lookup_on_cache_hit(monkeypatch):
     await codec.decode_response([ord("x")], tools=TOOLS)
     await codec.decode_response([ord("x")], tools=_equivalent_tools())
 
+    assert len(constructions) == 1
     assert lookups == ["qwen3_coder"]
+
+
+def test_parser_cache_is_scoped_to_message_codec(monkeypatch):
+    from uni_agent.gateway.session.codec import MessageCodec
+
+    constructions = []
+    _install_fake_vllm(monkeypatch, constructions)
+
+    MessageCodec(FakeTokenizer())._process_tool_calls_vllm("plain", TOOLS, "qwen3_coder")
+    MessageCodec(FakeTokenizer())._process_tool_calls_vllm("plain", TOOLS, "qwen3_coder")
+
+    assert len(constructions) == 2
 
 
 @pytest.mark.asyncio
@@ -241,4 +218,3 @@ async def test_verl_parser_cache_ignores_tool_schema(monkeypatch):
     await codec._process_tool_calls_verl([ord("y")], _equivalent_tools(), "hermes")
 
     assert lookups == ["hermes"]
-    assert set(codec._tool_parser_cache) == {("verl", "hermes")}

--- a/tests/uni_agent/gateway/test_message_codec_tool_dispatch.py
+++ b/tests/uni_agent/gateway/test_message_codec_tool_dispatch.py
@@ -102,7 +102,7 @@ def test_vllm_parser_supports_tool_schema_constructor_contracts(monkeypatch, con
 
 
 @pytest.mark.asyncio
-async def test_tool_call_dispatch_prefers_sglang(monkeypatch):
+async def test_tool_call_dispatch_uses_sglang_for_sglang_rollout(monkeypatch):
     from uni_agent.gateway.session.codec import MessageCodec
 
     seen = {}
@@ -117,7 +117,7 @@ async def test_tool_call_dispatch_prefers_sglang(monkeypatch):
     async def fail_verl(*args, **kwargs):
         raise AssertionError("verl should not run when an engine succeeds")
 
-    codec = MessageCodec(FakeTokenizer())
+    codec = MessageCodec(FakeTokenizer(), rollout_backend="sglang")
     monkeypatch.setattr(codec, "_process_tool_calls_sglang", fake_sglang)
     monkeypatch.setattr(codec, "_process_tool_calls_vllm", fail_vllm)
     monkeypatch.setattr(codec, "_process_tool_calls_verl", fail_verl)
@@ -130,13 +130,13 @@ async def test_tool_call_dispatch_prefers_sglang(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_tool_call_dispatch_falls_back_to_vllm_with_name_mapping(monkeypatch):
+async def test_tool_call_dispatch_uses_vllm_for_vllm_rollout_with_name_mapping(monkeypatch):
     from uni_agent.gateway.session.codec import MessageCodec
 
     seen = {}
 
-    def missing_sglang(*args, **kwargs):
-        raise ModuleNotFoundError("sglang")
+    def fail_sglang(*args, **kwargs):
+        raise AssertionError("SGLang should not run for a vLLM rollout")
 
     def fake_vllm(text, tools, parser_name):
         seen["vllm"] = (text, tools, parser_name)
@@ -145,8 +145,8 @@ async def test_tool_call_dispatch_falls_back_to_vllm_with_name_mapping(monkeypat
     async def fail_verl(*args, **kwargs):
         raise AssertionError("verl should not run when an engine succeeds")
 
-    codec = MessageCodec(FakeTokenizer())
-    monkeypatch.setattr(codec, "_process_tool_calls_sglang", missing_sglang)
+    codec = MessageCodec(FakeTokenizer(), rollout_backend="vllm")
+    monkeypatch.setattr(codec, "_process_tool_calls_sglang", fail_sglang)
     monkeypatch.setattr(codec, "_process_tool_calls_vllm", fake_vllm)
     monkeypatch.setattr(codec, "_process_tool_calls_verl", fail_verl)
 
@@ -158,23 +158,21 @@ async def test_tool_call_dispatch_falls_back_to_vllm_with_name_mapping(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_tool_call_dispatch_falls_back_to_verl_when_engines_unavailable(monkeypatch):
-    """With neither SGLang nor vLLM importable, the dispatcher hands the response token ids
-    to verl's tool-parser registry, which needs no inference engine."""
+async def test_tool_call_dispatch_uses_verl_for_other_rollout_backends(monkeypatch):
     from uni_agent.gateway.session.codec import MessageCodec
 
     seen = {}
 
-    def missing_engine(*args, **kwargs):
-        raise ModuleNotFoundError("tool parser engine")
+    def fail_engine(*args, **kwargs):
+        raise AssertionError("engine parser should not run for another rollout backend")
 
     async def fake_verl(response_ids, tools, parser_name):
         seen["verl"] = (response_ids, tools, parser_name)
         return "thinking", [SimpleNamespace(name="search", arguments='{"query":"docs"}')]
 
-    codec = MessageCodec(FakeTokenizer())
-    monkeypatch.setattr(codec, "_process_tool_calls_sglang", missing_engine)
-    monkeypatch.setattr(codec, "_process_tool_calls_vllm", missing_engine)
+    codec = MessageCodec(FakeTokenizer(), rollout_backend="hf")
+    monkeypatch.setattr(codec, "_process_tool_calls_sglang", fail_engine)
+    monkeypatch.setattr(codec, "_process_tool_calls_vllm", fail_engine)
     monkeypatch.setattr(codec, "_process_tool_calls_verl", fake_verl)
 
     text = 'thinking\n<tool_call>\n{"name": "search", "arguments": {"query": "docs"}}\n</tool_call>'
@@ -186,57 +184,30 @@ async def test_tool_call_dispatch_falls_back_to_verl_when_engines_unavailable(mo
 
 
 @pytest.mark.asyncio
-async def test_tool_call_dispatch_returns_text_when_verl_does_not_register_the_parser(monkeypatch):
-    """verl's registry raises ValueError for a parser name it does not know; the dispatcher
-    then returns the raw text unchanged."""
+async def test_tool_call_dispatch_surfaces_selected_parser_failure_without_fallback(monkeypatch):
     from uni_agent.gateway.session.codec import MessageCodec
 
-    def missing_engine(*args, **kwargs):
-        raise ModuleNotFoundError("tool parser engine")
+    def broken_vllm(*args, **kwargs):
+        raise ModuleNotFoundError("vllm")
 
-    async def unknown_parser(*args, **kwargs):
-        raise ValueError("Unknown tool parser: qwen3_xml")
+    async def fail_verl(*args, **kwargs):
+        raise AssertionError("verl must not hide a selected vLLM parser failure")
 
-    codec = MessageCodec(FakeTokenizer())
-    monkeypatch.setattr(codec, "_process_tool_calls_sglang", missing_engine)
-    monkeypatch.setattr(codec, "_process_tool_calls_vllm", missing_engine)
-    monkeypatch.setattr(codec, "_process_tool_calls_verl", unknown_parser)
+    codec = MessageCodec(FakeTokenizer(), rollout_backend="vllm")
+    monkeypatch.setattr(codec, "_process_tool_calls_vllm", broken_vllm)
+    monkeypatch.setattr(codec, "_process_tool_calls_verl", fail_verl)
 
-    text = '<tool_call>\n{"name": "search", "arguments": {"query": "docs"}}\n</tool_call>'
-    content, calls = await codec._extract_tool_calls(_ids(text), TOOLS, "qwen3_xml")
+    with pytest.raises(RuntimeError, match="vLLM tool parser 'hermes' failed") as exc_info:
+        await codec._extract_tool_calls(_ids("plain text"), TOOLS, "hermes")
 
-    assert content == text
-    assert calls == []
+    assert isinstance(exc_info.value.__cause__, ModuleNotFoundError)
 
 
 @pytest.mark.asyncio
-async def test_tool_call_dispatch_returns_text_when_verl_parsing_fails(monkeypatch):
+async def test_selected_parser_empty_result_is_not_an_error(monkeypatch):
     from uni_agent.gateway.session.codec import MessageCodec
 
-    def missing_engine(*args, **kwargs):
-        raise ModuleNotFoundError("tool parser engine")
-
-    async def broken_verl(*args, **kwargs):
-        raise RuntimeError("boom")
-
-    codec = MessageCodec(FakeTokenizer())
-    monkeypatch.setattr(codec, "_process_tool_calls_sglang", missing_engine)
-    monkeypatch.setattr(codec, "_process_tool_calls_vllm", missing_engine)
-    monkeypatch.setattr(codec, "_process_tool_calls_verl", broken_verl)
-
-    content, calls = await codec._extract_tool_calls(_ids("plain text"), TOOLS, "hermes")
-
-    assert content == "plain text"
-    assert calls == []
-
-
-@pytest.mark.asyncio
-async def test_tool_call_dispatch_prefers_sglang_empty_result_over_fallback(monkeypatch):
-    """An installed engine that reports no tool call is authoritative; the fallbacks exist for
-    hosts where no engine can run at all, not to second-guess one that did."""
-    from uni_agent.gateway.session.codec import MessageCodec
-
-    codec = MessageCodec(FakeTokenizer())
+    codec = MessageCodec(FakeTokenizer(), rollout_backend="sglang")
     monkeypatch.setattr(
         codec,
         "_process_tool_calls_sglang",
@@ -260,9 +231,7 @@ async def test_tool_call_dispatch_prefers_sglang_empty_result_over_fallback(monk
 
 
 @pytest.mark.asyncio
-async def test_verl_fallback_parses_hermes_envelope():
-    """The engine-less path uses verl's own registry, so a Hermes envelope is parsed even on
-    a host with neither SGLang nor vLLM installed."""
+async def test_verl_parser_parses_hermes_envelope():
     from uni_agent.gateway.session.codec import MessageCodec
 
     text = 'thinking\n<tool_call>\n{"name": "search", "arguments": {"query": "docs", "limit": 2}}\n</tool_call>'

--- a/tests/uni_agent/gateway/test_message_codec_tool_dispatch.py
+++ b/tests/uni_agent/gateway/test_message_codec_tool_dispatch.py
@@ -197,7 +197,7 @@ async def test_tool_call_dispatch_surfaces_selected_parser_failure_without_fallb
     monkeypatch.setattr(codec, "_process_tool_calls_vllm", broken_vllm)
     monkeypatch.setattr(codec, "_process_tool_calls_verl", fail_verl)
 
-    with pytest.raises(RuntimeError, match="vLLM tool parser 'hermes' failed") as exc_info:
+    with pytest.raises(RuntimeError, match="vllm tool parser 'hermes' failed") as exc_info:
         await codec._extract_tool_calls(_ids("plain text"), TOOLS, "hermes")
 
     assert isinstance(exc_info.value.__cause__, ModuleNotFoundError)

--- a/tests/uni_agent/gateway/test_message_codec_tool_dispatch.py
+++ b/tests/uni_agent/gateway/test_message_codec_tool_dispatch.py
@@ -28,7 +28,7 @@ def _ids(text: str) -> list[int]:
 
 
 def test_qwen_vllm_parser_uses_tool_schema_for_argument_types():
-    import uni_agent.gateway.session.codec as codec_mod
+    from uni_agent.gateway.session.codec import MessageCodec
 
     class QwenTokenizer(FakeTokenizer):
         def get_vocab(self):
@@ -42,7 +42,7 @@ def test_qwen_vllm_parser_uses_tool_schema_for_argument_types():
         "</function>\n"
         "</tool_call>"
     )
-    content, calls = codec_mod._process_tool_calls_vllm(text, TOOLS, "qwen3_coder", QwenTokenizer())
+    content, calls = MessageCodec(QwenTokenizer())._process_tool_calls_vllm(text, TOOLS, "qwen3_coder")
 
     assert content == ""
     assert json.loads(calls[0].arguments) == {"query": "docs", "limit": 2}
@@ -57,7 +57,7 @@ def test_vllm_parser_supports_tool_schema_constructor_contracts(monkeypatch, con
     from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionToolsParam
     from vllm.tool_parsers import ToolParserManager
 
-    import uni_agent.gateway.session.codec as codec_mod
+    from uni_agent.gateway.session.codec import MessageCodec
 
     seen = {}
 
@@ -88,7 +88,7 @@ def test_vllm_parser_supports_tool_schema_constructor_contracts(monkeypatch, con
     )
 
     tokenizer = FakeTokenizer()
-    content, calls = codec_mod._process_tool_calls_vllm("raw", TOOLS, "qwen3_coder", tokenizer)
+    content, calls = MessageCodec(tokenizer)._process_tool_calls_vllm("raw", TOOLS, "qwen3_coder")
 
     assert content == "visible"
     assert calls[0].name == "search"
@@ -103,7 +103,7 @@ def test_vllm_parser_supports_tool_schema_constructor_contracts(monkeypatch, con
 
 @pytest.mark.asyncio
 async def test_tool_call_dispatch_prefers_sglang(monkeypatch):
-    import uni_agent.gateway.session.codec as codec_mod
+    from uni_agent.gateway.session.codec import MessageCodec
 
     seen = {}
 
@@ -117,11 +117,12 @@ async def test_tool_call_dispatch_prefers_sglang(monkeypatch):
     async def fail_verl(*args, **kwargs):
         raise AssertionError("verl should not run when an engine succeeds")
 
-    monkeypatch.setattr(codec_mod, "_process_tool_calls_sglang", fake_sglang, raising=False)
-    monkeypatch.setattr(codec_mod, "_process_tool_calls_vllm", fail_vllm, raising=False)
-    monkeypatch.setattr(codec_mod, "_process_tool_calls_verl", fail_verl, raising=False)
+    codec = MessageCodec(FakeTokenizer())
+    monkeypatch.setattr(codec, "_process_tool_calls_sglang", fake_sglang)
+    monkeypatch.setattr(codec, "_process_tool_calls_vllm", fail_vllm)
+    monkeypatch.setattr(codec, "_process_tool_calls_verl", fail_verl)
 
-    content, calls = await codec_mod._extract_tool_calls(_ids("raw"), TOOLS, "hermes", FakeTokenizer())
+    content, calls = await codec._extract_tool_calls(_ids("raw"), TOOLS, "hermes")
 
     assert content == "visible"
     assert calls[0].name == "search"
@@ -130,65 +131,65 @@ async def test_tool_call_dispatch_prefers_sglang(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_tool_call_dispatch_falls_back_to_vllm_with_name_mapping(monkeypatch):
-    import uni_agent.gateway.session.codec as codec_mod
+    from uni_agent.gateway.session.codec import MessageCodec
 
     seen = {}
 
     def missing_sglang(*args, **kwargs):
         raise ModuleNotFoundError("sglang")
 
-    def fake_vllm(text, tools, parser_name, tokenizer):
-        seen["vllm"] = (text, tools, parser_name, tokenizer)
+    def fake_vllm(text, tools, parser_name):
+        seen["vllm"] = (text, tools, parser_name)
         return "", [SimpleNamespace(name="search", arguments='{"query":"x"}')]
 
     async def fail_verl(*args, **kwargs):
         raise AssertionError("verl should not run when an engine succeeds")
 
-    monkeypatch.setattr(codec_mod, "_process_tool_calls_sglang", missing_sglang, raising=False)
-    monkeypatch.setattr(codec_mod, "_process_tool_calls_vllm", fake_vllm, raising=False)
-    monkeypatch.setattr(codec_mod, "_process_tool_calls_verl", fail_verl, raising=False)
+    codec = MessageCodec(FakeTokenizer())
+    monkeypatch.setattr(codec, "_process_tool_calls_sglang", missing_sglang)
+    monkeypatch.setattr(codec, "_process_tool_calls_vllm", fake_vllm)
+    monkeypatch.setattr(codec, "_process_tool_calls_verl", fail_verl)
 
-    tokenizer = FakeTokenizer()
-    content, calls = await codec_mod._extract_tool_calls(_ids("raw"), TOOLS, "qwen25", tokenizer)
+    content, calls = await codec._extract_tool_calls(_ids("raw"), TOOLS, "qwen25")
 
     assert content == ""
     assert calls[0].arguments == '{"query":"x"}'
-    assert seen["vllm"] == ("raw", TOOLS, "qwen3_xml", tokenizer)
+    assert seen["vllm"] == ("raw", TOOLS, "qwen3_xml")
 
 
 @pytest.mark.asyncio
 async def test_tool_call_dispatch_falls_back_to_verl_when_engines_unavailable(monkeypatch):
     """With neither SGLang nor vLLM importable, the dispatcher hands the response token ids
     to verl's tool-parser registry, which needs no inference engine."""
-    import uni_agent.gateway.session.codec as codec_mod
+    from uni_agent.gateway.session.codec import MessageCodec
 
     seen = {}
 
     def missing_engine(*args, **kwargs):
         raise ModuleNotFoundError("tool parser engine")
 
-    async def fake_verl(response_ids, tools, parser_name, tokenizer):
-        seen["verl"] = (response_ids, tools, parser_name, tokenizer)
+    async def fake_verl(response_ids, tools, parser_name):
+        seen["verl"] = (response_ids, tools, parser_name)
         return "thinking", [SimpleNamespace(name="search", arguments='{"query":"docs"}')]
 
-    monkeypatch.setattr(codec_mod, "_process_tool_calls_sglang", missing_engine, raising=False)
-    monkeypatch.setattr(codec_mod, "_process_tool_calls_vllm", missing_engine, raising=False)
-    monkeypatch.setattr(codec_mod, "_process_tool_calls_verl", fake_verl, raising=False)
+    codec = MessageCodec(FakeTokenizer())
+    monkeypatch.setattr(codec, "_process_tool_calls_sglang", missing_engine)
+    monkeypatch.setattr(codec, "_process_tool_calls_vllm", missing_engine)
+    monkeypatch.setattr(codec, "_process_tool_calls_verl", fake_verl)
 
     text = 'thinking\n<tool_call>\n{"name": "search", "arguments": {"query": "docs"}}\n</tool_call>'
-    tokenizer = FakeTokenizer()
-    content, calls = await codec_mod._extract_tool_calls(_ids(text), TOOLS, "hermes", tokenizer)
+    content, calls = await codec._extract_tool_calls(_ids(text), TOOLS, "hermes")
 
     assert content == "thinking"
     assert calls[0].name == "search"
-    assert seen["verl"] == (_ids(text), TOOLS, "hermes", tokenizer)
+    assert seen["verl"] == (_ids(text), TOOLS, "hermes")
 
 
 @pytest.mark.asyncio
 async def test_tool_call_dispatch_returns_text_when_verl_does_not_register_the_parser(monkeypatch):
     """verl's registry raises ValueError for a parser name it does not know; the dispatcher
     then returns the raw text unchanged."""
-    import uni_agent.gateway.session.codec as codec_mod
+    from uni_agent.gateway.session.codec import MessageCodec
 
     def missing_engine(*args, **kwargs):
         raise ModuleNotFoundError("tool parser engine")
@@ -196,12 +197,13 @@ async def test_tool_call_dispatch_returns_text_when_verl_does_not_register_the_p
     async def unknown_parser(*args, **kwargs):
         raise ValueError("Unknown tool parser: qwen3_xml")
 
-    monkeypatch.setattr(codec_mod, "_process_tool_calls_sglang", missing_engine, raising=False)
-    monkeypatch.setattr(codec_mod, "_process_tool_calls_vllm", missing_engine, raising=False)
-    monkeypatch.setattr(codec_mod, "_process_tool_calls_verl", unknown_parser, raising=False)
+    codec = MessageCodec(FakeTokenizer())
+    monkeypatch.setattr(codec, "_process_tool_calls_sglang", missing_engine)
+    monkeypatch.setattr(codec, "_process_tool_calls_vllm", missing_engine)
+    monkeypatch.setattr(codec, "_process_tool_calls_verl", unknown_parser)
 
     text = '<tool_call>\n{"name": "search", "arguments": {"query": "docs"}}\n</tool_call>'
-    content, calls = await codec_mod._extract_tool_calls(_ids(text), TOOLS, "qwen3_xml", FakeTokenizer())
+    content, calls = await codec._extract_tool_calls(_ids(text), TOOLS, "qwen3_xml")
 
     assert content == text
     assert calls == []
@@ -209,7 +211,7 @@ async def test_tool_call_dispatch_returns_text_when_verl_does_not_register_the_p
 
 @pytest.mark.asyncio
 async def test_tool_call_dispatch_returns_text_when_verl_parsing_fails(monkeypatch):
-    import uni_agent.gateway.session.codec as codec_mod
+    from uni_agent.gateway.session.codec import MessageCodec
 
     def missing_engine(*args, **kwargs):
         raise ModuleNotFoundError("tool parser engine")
@@ -217,11 +219,12 @@ async def test_tool_call_dispatch_returns_text_when_verl_parsing_fails(monkeypat
     async def broken_verl(*args, **kwargs):
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(codec_mod, "_process_tool_calls_sglang", missing_engine, raising=False)
-    monkeypatch.setattr(codec_mod, "_process_tool_calls_vllm", missing_engine, raising=False)
-    monkeypatch.setattr(codec_mod, "_process_tool_calls_verl", broken_verl, raising=False)
+    codec = MessageCodec(FakeTokenizer())
+    monkeypatch.setattr(codec, "_process_tool_calls_sglang", missing_engine)
+    monkeypatch.setattr(codec, "_process_tool_calls_vllm", missing_engine)
+    monkeypatch.setattr(codec, "_process_tool_calls_verl", broken_verl)
 
-    content, calls = await codec_mod._extract_tool_calls(_ids("plain text"), TOOLS, "hermes", FakeTokenizer())
+    content, calls = await codec._extract_tool_calls(_ids("plain text"), TOOLS, "hermes")
 
     assert content == "plain text"
     assert calls == []
@@ -231,22 +234,22 @@ async def test_tool_call_dispatch_returns_text_when_verl_parsing_fails(monkeypat
 async def test_tool_call_dispatch_prefers_sglang_empty_result_over_fallback(monkeypatch):
     """An installed engine that reports no tool call is authoritative; the fallbacks exist for
     hosts where no engine can run at all, not to second-guess one that did."""
-    import uni_agent.gateway.session.codec as codec_mod
+    from uni_agent.gateway.session.codec import MessageCodec
 
+    codec = MessageCodec(FakeTokenizer())
     monkeypatch.setattr(
-        codec_mod,
+        codec,
         "_process_tool_calls_sglang",
         lambda text, tools, parser_name: (text, []),
-        raising=False,
     )
 
     async def fail_verl(*args, **kwargs):
         raise AssertionError("verl should not run when an engine already answered")
 
-    monkeypatch.setattr(codec_mod, "_process_tool_calls_verl", fail_verl, raising=False)
+    monkeypatch.setattr(codec, "_process_tool_calls_verl", fail_verl)
 
     text = '<tool_call>\n{"name": "search", "arguments": {"query": "docs"}}\n</tool_call>'
-    content, calls = await codec_mod._extract_tool_calls(_ids(text), TOOLS, "hermes", FakeTokenizer())
+    content, calls = await codec._extract_tool_calls(_ids(text), TOOLS, "hermes")
 
     assert content == text
     assert calls == []
@@ -256,10 +259,10 @@ async def test_tool_call_dispatch_prefers_sglang_empty_result_over_fallback(monk
 async def test_verl_fallback_parses_hermes_envelope():
     """The engine-less path uses verl's own registry, so a Hermes envelope is parsed even on
     a host with neither SGLang nor vLLM installed."""
-    import uni_agent.gateway.session.codec as codec_mod
+    from uni_agent.gateway.session.codec import MessageCodec
 
     text = 'thinking\n<tool_call>\n{"name": "search", "arguments": {"query": "docs", "limit": 2}}\n</tool_call>'
-    content, calls = await codec_mod._process_tool_calls_verl(_ids(text), TOOLS, "hermes", FakeTokenizer())
+    content, calls = await MessageCodec(FakeTokenizer())._process_tool_calls_verl(_ids(text), TOOLS, "hermes")
 
     assert content == "thinking\n"
     assert calls[0].name == "search"
@@ -268,19 +271,17 @@ async def test_verl_fallback_parses_hermes_envelope():
 
 @pytest.mark.asyncio
 async def test_decode_response_uses_gateway_dispatcher_for_tool_calls(monkeypatch):
-    import uni_agent.gateway.session.codec as codec_mod
     from uni_agent.gateway.session.codec import MessageCodec
 
     seen = {}
 
-    async def fake_dispatch(response_ids, tools, parser_name, tokenizer):
-        seen["dispatch"] = (response_ids, tools, parser_name, tokenizer)
+    async def fake_dispatch(response_ids, tools, parser_name):
+        seen["dispatch"] = (response_ids, tools, parser_name)
         return "", [SimpleNamespace(name="search", arguments='{"query":"weather"}')]
-
-    monkeypatch.setattr(codec_mod, "_extract_tool_calls", fake_dispatch, raising=False)
 
     tokenizer = FakeTokenizer()
     codec = MessageCodec(tokenizer, tool_parser_name="qwen3_xml")
+    monkeypatch.setattr(codec, "_extract_tool_calls", fake_dispatch)
     response_ids = [ord(char) for char in "<tool_call>ignored</tool_call>"]
     message, finish_reason = await codec.decode_response(
         response_ids,

--- a/tests/uni_agent/gateway/test_message_codec_tool_dispatch.py
+++ b/tests/uni_agent/gateway/test_message_codec_tool_dispatch.py
@@ -246,6 +246,10 @@ async def test_tool_call_dispatch_prefers_sglang_empty_result_over_fallback(monk
     async def fail_verl(*args, **kwargs):
         raise AssertionError("verl should not run when an engine already answered")
 
+    def fail_vllm(*args, **kwargs):
+        raise AssertionError("vLLM should not run when SGLang already answered")
+
+    monkeypatch.setattr(codec, "_process_tool_calls_vllm", fail_vllm)
     monkeypatch.setattr(codec, "_process_tool_calls_verl", fail_verl)
 
     text = '<tool_call>\n{"name": "search", "arguments": {"query": "docs"}}\n</tool_call>'

--- a/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
+++ b/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
@@ -19,8 +19,8 @@ SUBAGENT_SYS = {"role": "system", "content": "You are a focused subagent."}
 ALLOWED_SAMPLING_KEYS = frozenset({"temperature", "top_p", "top_k", "max_tokens", "stop"})
 
 
-async def _fake_tool_call_dispatch(response_ids, tools, parser_name, tokenizer):
-    text = tokenizer.decode(response_ids, skip_special_tokens=False)
+async def _fake_tool_call_dispatch(self, response_ids, tools, parser_name):
+    text = self._tokenizer.decode(response_ids, skip_special_tokens=False)
     if "<tool_call>" not in text:
         return text, []
     return "", [SimpleNamespace(name="search", arguments='{"query":"weather"}')]
@@ -1575,7 +1575,7 @@ async def test_multiple_chains_tool_call_echo_reuses_chain_despite_fresh_tool_re
     """Match on the committed prefix; a fresh tool-result ID is outside that boundary."""
     import uni_agent.gateway.session.codec as codec_mod
 
-    monkeypatch.setattr(codec_mod, "_extract_tool_calls", _fake_tool_call_dispatch)
+    monkeypatch.setattr(codec_mod.MessageCodec, "_extract_tool_calls", _fake_tool_call_dispatch)
     session = _session("tool-call-echo", tool_parser_name="hermes")
     tools = [{"type": "function", "function": {"name": "search", "parameters": {"type": "object"}}}]
     tool_call_text = '<tool_call>\n{"name": "search", "arguments": {"query": "weather"}}\n</tool_call>'
@@ -1625,7 +1625,7 @@ async def test_multiple_chains_tool_call_id_rewrite_reuses_chain(monkeypatch):
     """Reuse a chain when committed tool-call IDs are rewritten."""
     import uni_agent.gateway.session.codec as codec_mod
 
-    monkeypatch.setattr(codec_mod, "_extract_tool_calls", _fake_tool_call_dispatch)
+    monkeypatch.setattr(codec_mod.MessageCodec, "_extract_tool_calls", _fake_tool_call_dispatch)
     session = _session("tool-call-id-rewrite", tool_parser_name="hermes")
     tools = [{"type": "function", "function": {"name": "search", "parameters": {"type": "object"}}}]
     tool_call_text = '<tool_call>\n{"name": "search", "arguments": {"query": "weather"}}\n</tool_call>'

--- a/uni_agent/framework/entry.py
+++ b/uni_agent/framework/entry.py
@@ -42,6 +42,7 @@ def build_gateway_manager(*, config, llm_client) -> GatewayManager:
         tokenizer=model_config.tokenizer,
         processor=model_config.processor,
         tool_parser_name=config.actor_rollout_ref.rollout.get("multi_turn", {}).get("format"),
+        rollout_backend=config.actor_rollout_ref.rollout.get("name"),
         apply_chat_template_kwargs=dict(apply_chat_template_kwargs),
         prompt_length=config.actor_rollout_ref.rollout.prompt_length,
         response_length=config.actor_rollout_ref.rollout.response_length,

--- a/uni_agent/gateway/config.py
+++ b/uni_agent/gateway/config.py
@@ -1,9 +1,8 @@
 """Public config dataclass for GatewayActor wiring.
 
 Carries model, codec, and session knobs that entry.py forwards to the
-gateway actor. Backend is NOT in this
-config: it is injected separately by GatewayManager so the codec/
-session boundary has no view of the LLM client lifecycle.
+gateway actor. The backend client is injected separately by GatewayManager;
+only its rollout name is forwarded here to select a matching tool parser.
 """
 
 from __future__ import annotations
@@ -20,7 +19,9 @@ class GatewayActorConfig:
     Attributes:
         tokenizer: Tokenizer used by the message codec.
         processor: Optional multimodal processor used for vision requests.
-        tool_parser_name: Optional VERL tool parser name for decoding tool calls.
+        tool_parser_name: Optional tool parser name for decoding tool calls.
+        rollout_backend: Inference backend name used to select the matching
+            SGLang or vLLM parser. Other backends use verl's parser registry.
         apply_chat_template_kwargs: Default kwargs passed to chat-template rendering.
         allowed_request_sampling_param_keys: Request sampling keys accepted by the
             provider adapters when merging payload sampling params.
@@ -36,6 +37,7 @@ class GatewayActorConfig:
     tokenizer: Any
     processor: Any | None = None
     tool_parser_name: str | None = None
+    rollout_backend: str | None = None
     apply_chat_template_kwargs: dict[str, Any] | None = None
     allowed_request_sampling_param_keys: set[str] | frozenset[str] | None = None
     vision_info_extractor: Callable | None = None

--- a/uni_agent/gateway/gateway.py
+++ b/uni_agent/gateway/gateway.py
@@ -70,6 +70,7 @@ class _GatewayActor:
             vision_info_extractor=config.vision_info_extractor,
             vision_info_extractor_kwargs=config.vision_info_extractor_kwargs,
             tool_parser_name=config.tool_parser_name,
+            rollout_backend=config.rollout_backend,
             apply_chat_template_kwargs=config.apply_chat_template_kwargs,
         )
         self._allowed_request_sampling_param_keys = (

--- a/uni_agent/gateway/session/codec.py
+++ b/uni_agent/gateway/session/codec.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import hashlib
 import inspect
 import json
-import logging
 from types import SimpleNamespace
 from typing import Any
 from uuid import uuid4
@@ -17,8 +16,6 @@ from uuid import uuid4
 from verl.utils.tokenizer import normalize_token_ids
 from verl.utils.tokenizer.chat_template import apply_chat_template as _apply_chat_template
 from verl.utils.tokenizer.chat_template import initialize_turn_separator
-
-logger = logging.getLogger("gateway")
 
 # Map backend stop_reason values into the gateway's internal finish_reason vocabulary.
 _FINISH_REASON_MAP = {
@@ -100,6 +97,7 @@ class MessageCodec:
         vision_info_extractor=None,
         vision_info_extractor_kwargs: dict[str, Any] | None = None,
         tool_parser_name: str | None = None,
+        rollout_backend: str | None = None,
         apply_chat_template_kwargs: dict[str, Any] | None = None,
     ):
         self._tokenizer = tokenizer
@@ -117,6 +115,7 @@ class MessageCodec:
             **self._apply_chat_template_kwargs,
         )
         self._tool_parser_name = tool_parser_name
+        self._rollout_backend = rollout_backend
         # Backend parser construction performs expensive setup, so reuse parsers
         # within this actor-scoped codec. SGLang/vLLM bind tool schemas at
         # construction, while verl receives schemas per extraction call; this is
@@ -352,29 +351,17 @@ class MessageCodec:
     ) -> tuple[str, list[Any]]:
         text = self._tokenizer.decode(response_ids, skip_special_tokens=False)
 
-        sglang_name = _SGLANG_TOOL_PARSER_ALIASES.get(parser_name, parser_name)
         try:
-            return self._process_tool_calls_sglang(text, tools, sglang_name)
-        except ModuleNotFoundError:
-            pass
-        except Exception:
-            logger.warning("SGLang tool-call parsing failed; trying vLLM", exc_info=True)
-
-        vllm_name = _VLLM_TOOL_PARSER_ALIASES.get(parser_name, parser_name)
-        try:
-            return self._process_tool_calls_vllm(text, tools, vllm_name)
-        except ModuleNotFoundError:
-            pass
-        except Exception:
-            logger.warning("vLLM tool-call parsing failed; trying verl", exc_info=True)
-
-        try:
+            if self._rollout_backend == "sglang":
+                sglang_name = _SGLANG_TOOL_PARSER_ALIASES.get(parser_name, parser_name)
+                return self._process_tool_calls_sglang(text, tools, sglang_name)
+            if self._rollout_backend == "vllm":
+                vllm_name = _VLLM_TOOL_PARSER_ALIASES.get(parser_name, parser_name)
+                return self._process_tool_calls_vllm(text, tools, vllm_name)
             return await self._process_tool_calls_verl(response_ids, tools, parser_name)
-        except ValueError:
-            logger.warning("verl does not provide tool parser %r; returning raw text", parser_name, exc_info=True)
-        except Exception:
-            logger.warning("verl tool-call parsing failed; returning raw text", exc_info=True)
-        return text, []
+        except Exception as exc:
+            parser_backend = {"sglang": "SGLang", "vllm": "vLLM"}.get(self._rollout_backend, "verl")
+            raise RuntimeError(f"{parser_backend} tool parser {parser_name!r} failed") from exc
 
     async def decode_response(
         self,

--- a/uni_agent/gateway/session/codec.py
+++ b/uni_agent/gateway/session/codec.py
@@ -281,7 +281,6 @@ class MessageCodec:
             from sglang.srt.entrypoints.openai.protocol import Tool as SglTool
             from sglang.srt.function_call.function_call_parser import FunctionCallParser
 
-            logger.debug("Initializing tool parser backend=sglang name=%s", parser_name)
             sglang_tools = [SglTool(type=tool["type"], function=SglFunction(**tool["function"])) for tool in tools]
             parser = FunctionCallParser(sglang_tools, parser_name)
             self._tool_parser_cache[cache_key] = parser
@@ -305,7 +304,6 @@ class MessageCodec:
         if parser is None:
             from vllm.tool_parsers import ToolParserManager
 
-            logger.debug("Initializing tool parser backend=vllm name=%s", parser_name)
             parser_cls = ToolParserManager.get_tool_parser(parser_name)
             parser_parameters = inspect.signature(parser_cls).parameters
             if "tools" in parser_parameters:
@@ -333,7 +331,6 @@ class MessageCodec:
         cache_key = ("verl", parser_name)
         parser = self._tool_parser_cache.get(cache_key)
         if parser is None:
-            logger.debug("Initializing tool parser backend=verl name=%s", parser_name)
             parser = ToolParser.get_tool_parser(parser_name, self._tokenizer)
             self._tool_parser_cache[cache_key] = parser
 

--- a/uni_agent/gateway/session/codec.py
+++ b/uni_agent/gateway/session/codec.py
@@ -350,17 +350,17 @@ class MessageCodec:
         parser_name: str,
     ) -> tuple[str, list[Any]]:
         text = self._tokenizer.decode(response_ids, skip_special_tokens=False)
+        parser_backend = self._rollout_backend if self._rollout_backend in {"sglang", "vllm"} else "verl"
 
         try:
-            if self._rollout_backend == "sglang":
+            if parser_backend == "sglang":
                 sglang_name = _SGLANG_TOOL_PARSER_ALIASES.get(parser_name, parser_name)
                 return self._process_tool_calls_sglang(text, tools, sglang_name)
-            if self._rollout_backend == "vllm":
+            if parser_backend == "vllm":
                 vllm_name = _VLLM_TOOL_PARSER_ALIASES.get(parser_name, parser_name)
                 return self._process_tool_calls_vllm(text, tools, vllm_name)
             return await self._process_tool_calls_verl(response_ids, tools, parser_name)
         except Exception as exc:
-            parser_backend = {"sglang": "SGLang", "vllm": "vLLM"}.get(self._rollout_backend, "verl")
             raise RuntimeError(f"{parser_backend} tool parser {parser_name!r} failed") from exc
 
     async def decode_response(

--- a/uni_agent/gateway/session/codec.py
+++ b/uni_agent/gateway/session/codec.py
@@ -117,6 +117,12 @@ class MessageCodec:
             **self._apply_chat_template_kwargs,
         )
         self._tool_parser_name = tool_parser_name
+        # Backend parser construction performs expensive setup, so reuse parsers
+        # within this actor-scoped codec. SGLang/vLLM bind tool schemas at
+        # construction, while verl receives schemas per extraction call; this is
+        # why their cache keys differ. Keep the cache codec-scoped because parser
+        # instances may retain mutable request state and dynamic schemas can grow
+        # the mapping over the codec lifetime.
         self._tool_parser_cache: dict[tuple[str, ...], Any] = {}
 
     @property

--- a/uni_agent/gateway/session/codec.py
+++ b/uni_agent/gateway/session/codec.py
@@ -6,6 +6,7 @@ processor-backed multimodal inputs, parses tools, and decodes backend outputs.
 
 from __future__ import annotations
 
+import hashlib
 import inspect
 import json
 import logging
@@ -42,6 +43,12 @@ _VLLM_TOOL_PARSER_ALIASES = {
 }
 
 
+def _canonical_tools_hash(tools: list[dict[str, Any]]) -> str:
+    """Return a stable hash for a tool schema independent of dict key order."""
+    canonical = json.dumps(tools, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
 def initialize_generation_prompt(processing_class, **apply_chat_template_kwargs) -> list[int]:
     """Initialize the token suffix inserted by ``add_generation_prompt=True``."""
     without_generation_prompt = normalize_token_ids(
@@ -74,101 +81,6 @@ def _canonicalize_tool_arguments_for_comparison(arguments: Any) -> tuple[str, An
         except json.JSONDecodeError:
             return ("raw", arguments)
     return ("raw", arguments)
-
-
-def _process_tool_calls_sglang(
-    text: str,
-    tools: list[dict[str, Any]],
-    parser_name: str,
-) -> tuple[str, list[Any]]:
-    from sglang.srt.entrypoints.openai.protocol import Function as SglFunction
-    from sglang.srt.entrypoints.openai.protocol import Tool as SglTool
-    from sglang.srt.function_call.function_call_parser import FunctionCallParser
-
-    sglang_tools = [SglTool(type=tool["type"], function=SglFunction(**tool["function"])) for tool in tools]
-    parser = FunctionCallParser(sglang_tools, parser_name)
-    if not parser.has_tool_call(text):
-        return text, []
-
-    content, calls = parser.parse_non_stream(text)
-    return content, [SimpleNamespace(name=call.name, arguments=call.parameters) for call in calls]
-
-
-def _process_tool_calls_vllm(
-    text: str,
-    tools: list[dict[str, Any]],
-    parser_name: str,
-    tokenizer,
-) -> tuple[str, list[Any]]:
-    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionToolsParam
-    from vllm.tool_parsers import ToolParserManager
-
-    parser_cls = ToolParserManager.get_tool_parser(parser_name)
-    vllm_tools = [ChatCompletionToolsParam(**tool) if isinstance(tool, dict) else tool for tool in tools]
-    parser_parameters = inspect.signature(parser_cls).parameters
-    if "tools" in parser_parameters:
-        parser = parser_cls(tokenizer, tools=vllm_tools)
-    else:
-        parser = parser_cls(tokenizer)
-    request = SimpleNamespace(
-        tools=vllm_tools,
-        tool_choice="auto",
-        skip_special_tokens=True,
-    )
-    parsed = parser.extract_tool_calls(text, request)
-    if not parsed.tools_called:
-        return text, []
-    return parsed.content or "", [tool_call.function for tool_call in parsed.tool_calls]
-
-
-async def _process_tool_calls_verl(
-    response_ids: list[int],
-    tools: list[dict[str, Any]],
-    parser_name: str,
-    tokenizer,
-) -> tuple[str, list[Any]]:
-    """Parse tool calls with verl's built-in tool-parser registry."""
-    from verl.experimental.agent_loop.tool_parser import ToolParser
-    from verl.tools.schemas import OpenAIFunctionToolSchema
-
-    parser = ToolParser.get_tool_parser(parser_name, tokenizer)
-    tool_schemas = [OpenAIFunctionToolSchema.model_validate(tool) for tool in tools]
-    content, calls = await parser.extract_tool_calls(response_ids, tool_schemas)
-    return content, [SimpleNamespace(name=call.name, arguments=call.arguments) for call in calls]
-
-
-async def _extract_tool_calls(
-    response_ids: list[int],
-    tools: list[dict[str, Any]],
-    parser_name: str,
-    tokenizer,
-) -> tuple[str, list[Any]]:
-    text = tokenizer.decode(response_ids, skip_special_tokens=False)
-
-    sglang_name = _SGLANG_TOOL_PARSER_ALIASES.get(parser_name, parser_name)
-    try:
-        return _process_tool_calls_sglang(text, tools, sglang_name)
-    except ModuleNotFoundError:
-        pass
-    except Exception:
-        logger.warning("SGLang tool-call parsing failed; trying vLLM", exc_info=True)
-
-    vllm_name = _VLLM_TOOL_PARSER_ALIASES.get(parser_name, parser_name)
-    try:
-        return _process_tool_calls_vllm(text, tools, vllm_name, tokenizer)
-    except ModuleNotFoundError:
-        pass
-    except Exception:
-        logger.warning("vLLM tool-call parsing failed; trying verl", exc_info=True)
-
-    try:
-        return await _process_tool_calls_verl(response_ids, tools, parser_name, tokenizer)
-    except ValueError:
-        # get_tool_parser raises ValueError for a parser name verl does not register.
-        logger.warning("verl does not provide tool parser %r; returning raw text", parser_name, exc_info=True)
-    except Exception:
-        logger.warning("verl tool-call parsing failed; returning raw text", exc_info=True)
-    return text, []
 
 
 class MessageCodec:
@@ -205,6 +117,7 @@ class MessageCodec:
             **self._apply_chat_template_kwargs,
         )
         self._tool_parser_name = tool_parser_name
+        self._tool_parser_cache: dict[tuple[str, ...], Any] = {}
 
     @property
     def generation_prompt(self) -> list[int]:
@@ -355,6 +268,111 @@ class MessageCodec:
             video_data,
         )
 
+    def _process_tool_calls_sglang(
+        self,
+        text: str,
+        tools: list[dict[str, Any]],
+        parser_name: str,
+    ) -> tuple[str, list[Any]]:
+        cache_key = ("sglang", parser_name, _canonical_tools_hash(tools))
+        parser = self._tool_parser_cache.get(cache_key)
+        if parser is None:
+            from sglang.srt.entrypoints.openai.protocol import Function as SglFunction
+            from sglang.srt.entrypoints.openai.protocol import Tool as SglTool
+            from sglang.srt.function_call.function_call_parser import FunctionCallParser
+
+            logger.debug("Initializing tool parser backend=sglang name=%s", parser_name)
+            sglang_tools = [SglTool(type=tool["type"], function=SglFunction(**tool["function"])) for tool in tools]
+            parser = FunctionCallParser(sglang_tools, parser_name)
+            self._tool_parser_cache[cache_key] = parser
+
+        if not parser.has_tool_call(text):
+            return text, []
+        content, calls = parser.parse_non_stream(text)
+        return content, [SimpleNamespace(name=call.name, arguments=call.parameters) for call in calls]
+
+    def _process_tool_calls_vllm(
+        self,
+        text: str,
+        tools: list[dict[str, Any]],
+        parser_name: str,
+    ) -> tuple[str, list[Any]]:
+        from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionToolsParam
+
+        cache_key = ("vllm", parser_name, _canonical_tools_hash(tools))
+        parser = self._tool_parser_cache.get(cache_key)
+        vllm_tools = [ChatCompletionToolsParam(**tool) if isinstance(tool, dict) else tool for tool in tools]
+        if parser is None:
+            from vllm.tool_parsers import ToolParserManager
+
+            logger.debug("Initializing tool parser backend=vllm name=%s", parser_name)
+            parser_cls = ToolParserManager.get_tool_parser(parser_name)
+            parser_parameters = inspect.signature(parser_cls).parameters
+            if "tools" in parser_parameters:
+                parser = parser_cls(self._tokenizer, tools=vllm_tools)
+            else:
+                parser = parser_cls(self._tokenizer)
+            self._tool_parser_cache[cache_key] = parser
+
+        request = SimpleNamespace(tools=vllm_tools, tool_choice="auto", skip_special_tokens=True)
+        parsed = parser.extract_tool_calls(text, request)
+        if not parsed.tools_called:
+            return text, []
+        return parsed.content or "", [tool_call.function for tool_call in parsed.tool_calls]
+
+    async def _process_tool_calls_verl(
+        self,
+        response_ids: list[int],
+        tools: list[dict[str, Any]],
+        parser_name: str,
+    ) -> tuple[str, list[Any]]:
+        """Parse tool calls with verl's built-in tool-parser registry."""
+        from verl.experimental.agent_loop.tool_parser import ToolParser
+        from verl.tools.schemas import OpenAIFunctionToolSchema
+
+        cache_key = ("verl", parser_name)
+        parser = self._tool_parser_cache.get(cache_key)
+        if parser is None:
+            logger.debug("Initializing tool parser backend=verl name=%s", parser_name)
+            parser = ToolParser.get_tool_parser(parser_name, self._tokenizer)
+            self._tool_parser_cache[cache_key] = parser
+
+        tool_schemas = [OpenAIFunctionToolSchema.model_validate(tool) for tool in tools]
+        content, calls = await parser.extract_tool_calls(response_ids, tool_schemas)
+        return content, [SimpleNamespace(name=call.name, arguments=call.arguments) for call in calls]
+
+    async def _extract_tool_calls(
+        self,
+        response_ids: list[int],
+        tools: list[dict[str, Any]],
+        parser_name: str,
+    ) -> tuple[str, list[Any]]:
+        text = self._tokenizer.decode(response_ids, skip_special_tokens=False)
+
+        sglang_name = _SGLANG_TOOL_PARSER_ALIASES.get(parser_name, parser_name)
+        try:
+            return self._process_tool_calls_sglang(text, tools, sglang_name)
+        except ModuleNotFoundError:
+            pass
+        except Exception:
+            logger.warning("SGLang tool-call parsing failed; trying vLLM", exc_info=True)
+
+        vllm_name = _VLLM_TOOL_PARSER_ALIASES.get(parser_name, parser_name)
+        try:
+            return self._process_tool_calls_vllm(text, tools, vllm_name)
+        except ModuleNotFoundError:
+            pass
+        except Exception:
+            logger.warning("vLLM tool-call parsing failed; trying verl", exc_info=True)
+
+        try:
+            return await self._process_tool_calls_verl(response_ids, tools, parser_name)
+        except ValueError:
+            logger.warning("verl does not provide tool parser %r; returning raw text", parser_name, exc_info=True)
+        except Exception:
+            logger.warning("verl tool-call parsing failed; returning raw text", exc_info=True)
+        return text, []
+
     async def decode_response(
         self,
         response_ids: list[int],
@@ -364,11 +382,10 @@ class MessageCodec:
     ) -> tuple[dict[str, Any], str]:
         """Decode model output tokens into an assistant message and finish reason."""
         if self._tool_parser_name and tools:
-            content, function_calls = await _extract_tool_calls(
+            content, function_calls = await self._extract_tool_calls(
                 response_ids,
                 tools,
                 self._tool_parser_name,
-                self._tokenizer,
             )
             if function_calls:
                 tool_calls = [


### PR DESCRIPTION
## Summary

Avoid reconstructing the same tool parser for every Gateway request by keeping a parser cache on the model-scoped `MessageCodec`, and select the parser backend from the configured `actor_rollout_ref.rollout.name`.

This PR is intentionally limited to parser lifecycle and backend selection. Encode offload and parser execution offload are out of scope.

## Changes

- Move SGLang, vLLM, and verl parser processing onto `MessageCodec`, which owns the cache for its tokenizer/model boundary.
- Cache SGLang and vLLM parsers by backend, parser name, and a canonical tool-schema hash so equivalent schemas reuse one parser while different schemas remain isolated.
- Cache verl parsers by backend and parser name; verl receives validated tool schemas for each extraction call, so the schema is not part of its cache key.
- Select SGLang, vLLM, or verl parsing from the configured rollout backend: `sglang` uses SGLang, `vllm` uses vLLM, and all other rollout names use verl.
- Preserve parser-name alias mapping and the Hermes parser introduced by PR#115. A configured parser failure now raises an explicit error instead of silently crossing backends or returning raw text.
- Update Gateway actor/session test fakes and dispatcher tests to the codec-owned API.
- Keep focused coverage for cache reuse, schema separation, codec isolation, backend selection and failure handling, and OpenAI-format tool-call output.

## Compatibility

- No configuration or user-facing API changes.
- The existing `actor_rollout_ref.rollout.name` setting is reused; no new user-facing configuration is required.
- Parser failures are explicit request errors. The dispatcher does not silently fall back to a parser from a different inference backend, preventing malformed tool-call trajectories.
- Parser caches are scoped to individual `MessageCodec` instances and are not shared across models/tokenizers.

## Performance Evidence

A local mechanism benchmark used a 100,903-token context, 21 tools, three turns, and 5,000 output tokens per turn. It ran one warmup and seven measured repetitions against a fixed in-process backend, so generation and transport were excluded.

- Per-turn parser time p50 decreased from approximately 188-193 ms without caching to 0.17-0.23 ms after the one-time parser initialization.
- Three-turn wall time p50 decreased from 903 ms to 336 ms with a warm cache.
- Including the one-time parser prime (187.6 ms p50), the three-turn result was 524 ms versus 903 ms, a 42% reduction or 1.72x improvement.
- This is mechanism-level evidence for eliminating repeated parser construction, not a production end-to-end A/B result. The benchmark used a fixed backend and an earlier profiling harness; it excludes vLLM scheduling, model/NPU generation, HTTP, and sandbox behavior.

## Validation

- `PYTHONPATH=$PWD pytest -q tests/uni_agent/gateway/test_message_codec_parser_cache.py`: 5 passed.
- `PYTHONPATH=$PWD pytest -q tests/uni_agent/gateway/test_message_codec_tool_dispatch.py -k 'not qwen_vllm_parser_uses_tool_schema_for_argument_types and not vllm_parser_supports_tool_schema_constructor_contracts'`: 7 passed, 3 deselected.
- `PYTHONPATH=$PWD pytest -q tests/uni_agent/framework/test_generate_sequences_on_cpu.py`: 26 passed.
- `PYTHONPATH=$PWD pytest -q tests/uni_agent/gateway`: 185 passed, 3 failed because the installed vLLM 0.26.0 imports `NamespaceTool`, which is absent from the installed OpenAI package. The failures are environment dependency incompatibilities, not product assertions.
- `pre-commit run --all-files --show-diff-on-failure --color=always`: passed (ruff, format, mypy, compileall).

## Checklist

- [x] The PR is focused and explains why no issue is needed.
- [x] The title follows the repository format: `[gateway] perf: align tool parsers with rollout backend`.
- [x] Tests cover the changed behavior; the known optional-dependency limitation is documented above.
- [x] No user-facing API, config, or workflow changes.
- [x] No credentials or private data in logs, fixtures, or examples.
- [x] Full all-files pre-commit passes.
