### PR TITLE
[gateway] feat: add tool parser cache opt-out

### DIFF
--- a/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
+++ b/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
@@ -124,30 +124,28 @@ async def _build_framework_with_agent_runners(
 @pytest.mark.parametrize(
     (
         "data_config",
-        "rollback_config",
+        "agent_framework_config",
         "expected_rollback",
-        "cache_config",
         "expected_cache",
         "expected_chat_template_kwargs",
     ),
     [
-        ({}, {}, True, {}, True, {}),
+        ({}, {}, True, True, {}),
         (
             {"apply_chat_template_kwargs": {"thinking": True}},
             {"enable_last_assistant_rollback": False},
             False,
-            {"enable_tool_parser_cache": False},
-            False,
+            True,
             {"thinking": True},
         ),
+        ({}, {"enable_tool_parser_cache": False}, True, False, {}),
     ],
 )
 def test_build_gateway_manager_wires_gateway_config_defaults(
     monkeypatch,
     data_config,
-    rollback_config,
+    agent_framework_config,
     expected_rollback,
-    cache_config,
     expected_cache,
     expected_chat_template_kwargs,
 ):
@@ -184,8 +182,7 @@ def test_build_gateway_manager_wires_gateway_config_defaults(
                     "custom": {
                         "agent_framework": {
                             "gateway_count": 2,
-                            **rollback_config,
-                            **cache_config,
+                            **agent_framework_config,
                         }
                     },
                 },

--- a/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
+++ b/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
@@ -122,12 +122,21 @@ async def _build_framework_with_agent_runners(
 
 
 @pytest.mark.parametrize(
-    ("data_config", "rollback_config", "expected_rollback", "expected_chat_template_kwargs"),
+    (
+        "data_config",
+        "rollback_config",
+        "expected_rollback",
+        "cache_config",
+        "expected_cache",
+        "expected_chat_template_kwargs",
+    ),
     [
-        ({}, {}, True, {}),
+        ({}, {}, True, {}, True, {}),
         (
             {"apply_chat_template_kwargs": {"thinking": True}},
             {"enable_last_assistant_rollback": False},
+            False,
+            {"enable_tool_parser_cache": False},
             False,
             {"thinking": True},
         ),
@@ -138,6 +147,8 @@ def test_build_gateway_manager_wires_gateway_config_defaults(
     data_config,
     rollback_config,
     expected_rollback,
+    cache_config,
+    expected_cache,
     expected_chat_template_kwargs,
 ):
     from omegaconf import OmegaConf
@@ -174,6 +185,7 @@ def test_build_gateway_manager_wires_gateway_config_defaults(
                         "agent_framework": {
                             "gateway_count": 2,
                             **rollback_config,
+                            **cache_config,
                         }
                     },
                 },
@@ -191,6 +203,7 @@ def test_build_gateway_manager_wires_gateway_config_defaults(
     assert captured["gateway_actor_config"].tool_parser_name == "hermes"
     assert captured["gateway_actor_config"].rollout_backend == "vllm"
     assert captured["gateway_actor_config"].enable_last_assistant_rollback is expected_rollback
+    assert captured["gateway_actor_config"].enable_tool_parser_cache is expected_cache
     assert isinstance(captured["gateway_actor_config"].apply_chat_template_kwargs, dict)
     assert captured["gateway_actor_config"].apply_chat_template_kwargs == expected_chat_template_kwargs
 

--- a/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
+++ b/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
@@ -58,20 +58,13 @@ def test_gateway_actor_config_rejects_non_positive_prompt_length(prompt_length):
         GatewayActorConfig(tokenizer=FakeTokenizer(), prompt_length=prompt_length)
 
 
+@pytest.mark.parametrize("field", ["enable_last_assistant_rollback", "enable_tool_parser_cache"])
 @pytest.mark.parametrize("value", ["true", 1, None])
-def test_gateway_actor_config_rejects_non_bool_last_assistant_rollback(value):
+def test_gateway_actor_config_rejects_non_bool_options(field, value):
     from uni_agent.gateway.config import GatewayActorConfig
 
-    with pytest.raises(ValueError, match="enable_last_assistant_rollback must be a bool"):
-        GatewayActorConfig(tokenizer=FakeTokenizer(), enable_last_assistant_rollback=value)
-
-
-@pytest.mark.parametrize("value", ["true", 1, None])
-def test_gateway_actor_config_rejects_non_bool_tool_parser_cache(value):
-    from uni_agent.gateway.config import GatewayActorConfig
-
-    with pytest.raises(ValueError, match="enable_tool_parser_cache must be a bool"):
-        GatewayActorConfig(tokenizer=FakeTokenizer(), enable_tool_parser_cache=value)
+    with pytest.raises(ValueError, match=rf"{field} must be a bool"):
+        GatewayActorConfig(tokenizer=FakeTokenizer(), **{field: value})
 
 
 def test_gateway_actor_config_enables_last_assistant_rollback_by_default():

--- a/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
+++ b/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
@@ -66,6 +66,14 @@ def test_gateway_actor_config_rejects_non_bool_last_assistant_rollback(value):
         GatewayActorConfig(tokenizer=FakeTokenizer(), enable_last_assistant_rollback=value)
 
 
+@pytest.mark.parametrize("value", ["true", 1, None])
+def test_gateway_actor_config_rejects_non_bool_tool_parser_cache(value):
+    from uni_agent.gateway.config import GatewayActorConfig
+
+    with pytest.raises(ValueError, match="enable_tool_parser_cache must be a bool"):
+        GatewayActorConfig(tokenizer=FakeTokenizer(), enable_tool_parser_cache=value)
+
+
 def test_gateway_actor_config_enables_last_assistant_rollback_by_default():
     from uni_agent.gateway.config import GatewayActorConfig
 

--- a/tests/uni_agent/gateway/test_message_codec_parser_cache.py
+++ b/tests/uni_agent/gateway/test_message_codec_parser_cache.py
@@ -170,38 +170,30 @@ def test_vllm_parser_cache_separates_tool_schemas(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_message_codec_reuses_vllm_parser_across_decode_calls(monkeypatch):
+@pytest.mark.parametrize(
+    ("enable_tool_parser_cache", "expected_constructions"),
+    [(True, 1), (False, 2)],
+)
+async def test_message_codec_applies_parser_cache_policy_across_decode_calls(
+    monkeypatch,
+    enable_tool_parser_cache,
+    expected_constructions,
+):
     from uni_agent.gateway.session.codec import MessageCodec
 
     constructions = []
-    lookups = []
-    _install_fake_vllm(monkeypatch, constructions, lookups)
+    _install_fake_vllm(monkeypatch, constructions)
     codec = MessageCodec(
         FakeTokenizer(),
         tool_parser_name="qwen3_coder",
         rollout_backend="vllm",
+        enable_tool_parser_cache=enable_tool_parser_cache,
     )
 
     await codec.decode_response([ord("x")], tools=TOOLS)
     await codec.decode_response([ord("x")], tools=_equivalent_tools())
 
-    assert len(constructions) == 1
-    assert lookups == ["qwen3_coder"]
-
-
-def test_message_codec_can_disable_parser_cache(monkeypatch):
-    from uni_agent.gateway.session.codec import MessageCodec
-
-    constructions = []
-    lookups = []
-    _install_fake_vllm(monkeypatch, constructions, lookups)
-    codec = MessageCodec(FakeTokenizer(), enable_tool_parser_cache=False)
-
-    codec._process_tool_calls_vllm("plain", TOOLS, "qwen3_coder")
-    codec._process_tool_calls_vllm("plain", TOOLS, "qwen3_coder")
-
-    assert len(constructions) == 2
-    assert lookups == ["qwen3_coder", "qwen3_coder"]
+    assert len(constructions) == expected_constructions
 
 
 def test_parser_cache_is_scoped_to_message_codec(monkeypatch):

--- a/tests/uni_agent/gateway/test_message_codec_parser_cache.py
+++ b/tests/uni_agent/gateway/test_message_codec_parser_cache.py
@@ -189,6 +189,21 @@ async def test_message_codec_reuses_vllm_parser_across_decode_calls(monkeypatch)
     assert lookups == ["qwen3_coder"]
 
 
+def test_message_codec_can_disable_parser_cache(monkeypatch):
+    from uni_agent.gateway.session.codec import MessageCodec
+
+    constructions = []
+    lookups = []
+    _install_fake_vllm(monkeypatch, constructions, lookups)
+    codec = MessageCodec(FakeTokenizer(), enable_tool_parser_cache=False)
+
+    codec._process_tool_calls_vllm("plain", TOOLS, "qwen3_coder")
+    codec._process_tool_calls_vllm("plain", TOOLS, "qwen3_coder")
+
+    assert len(constructions) == 2
+    assert lookups == ["qwen3_coder", "qwen3_coder"]
+
+
 def test_parser_cache_is_scoped_to_message_codec(monkeypatch):
     from uni_agent.gateway.session.codec import MessageCodec
 

--- a/uni_agent/framework/entry.py
+++ b/uni_agent/framework/entry.py
@@ -43,6 +43,7 @@ def build_gateway_manager(*, config, llm_client) -> GatewayManager:
         processor=model_config.processor,
         tool_parser_name=config.actor_rollout_ref.rollout.get("multi_turn", {}).get("format"),
         rollout_backend=config.actor_rollout_ref.rollout.get("name"),
+        enable_tool_parser_cache=af_cfg.get("enable_tool_parser_cache", True),
         apply_chat_template_kwargs=dict(apply_chat_template_kwargs),
         prompt_length=config.actor_rollout_ref.rollout.prompt_length,
         response_length=config.actor_rollout_ref.rollout.response_length,

--- a/uni_agent/gateway/config.py
+++ b/uni_agent/gateway/config.py
@@ -22,6 +22,9 @@ class GatewayActorConfig:
         tool_parser_name: Optional tool parser name for decoding tool calls.
         rollout_backend: Inference backend name used to select the matching
             SGLang or vLLM parser. Other backends use verl's parser registry.
+        enable_tool_parser_cache: Whether to reuse parser instances within an
+            actor-scoped codec. Disable for parsers that require request-scoped
+            instances; enabled by default for the parser-construction speedup.
         apply_chat_template_kwargs: Default kwargs passed to chat-template rendering.
         allowed_request_sampling_param_keys: Request sampling keys accepted by the
             provider adapters when merging payload sampling params.
@@ -38,6 +41,7 @@ class GatewayActorConfig:
     processor: Any | None = None
     tool_parser_name: str | None = None
     rollout_backend: str | None = None
+    enable_tool_parser_cache: bool = True
     apply_chat_template_kwargs: dict[str, Any] | None = None
     allowed_request_sampling_param_keys: set[str] | frozenset[str] | None = None
     vision_info_extractor: Callable | None = None
@@ -47,6 +51,10 @@ class GatewayActorConfig:
     enable_last_assistant_rollback: bool = True
 
     def __post_init__(self) -> None:
+        if type(self.enable_tool_parser_cache) is not bool:
+            raise ValueError(
+                f"enable_tool_parser_cache must be a bool, got {type(self.enable_tool_parser_cache).__name__}"
+            )
         if type(self.enable_last_assistant_rollback) is not bool:
             raise ValueError(
                 "enable_last_assistant_rollback must be a bool, "

--- a/uni_agent/gateway/gateway.py
+++ b/uni_agent/gateway/gateway.py
@@ -71,6 +71,7 @@ class _GatewayActor:
             vision_info_extractor_kwargs=config.vision_info_extractor_kwargs,
             tool_parser_name=config.tool_parser_name,
             rollout_backend=config.rollout_backend,
+            enable_tool_parser_cache=config.enable_tool_parser_cache,
             apply_chat_template_kwargs=config.apply_chat_template_kwargs,
         )
         self._allowed_request_sampling_param_keys = (

--- a/uni_agent/gateway/session/codec.py
+++ b/uni_agent/gateway/session/codec.py
@@ -98,6 +98,7 @@ class MessageCodec:
         vision_info_extractor_kwargs: dict[str, Any] | None = None,
         tool_parser_name: str | None = None,
         rollout_backend: str | None = None,
+        enable_tool_parser_cache: bool = True,
         apply_chat_template_kwargs: dict[str, Any] | None = None,
     ):
         self._tokenizer = tokenizer
@@ -116,12 +117,15 @@ class MessageCodec:
         )
         self._tool_parser_name = tool_parser_name
         self._rollout_backend = rollout_backend
+        self._enable_tool_parser_cache = enable_tool_parser_cache
         # Backend parser construction performs expensive setup, so reuse parsers
         # within this actor-scoped codec. SGLang/vLLM bind tool schemas at
         # construction, while verl receives schemas per extraction call; this is
         # why their cache keys differ. Keep the cache codec-scoped because parser
         # instances may retain mutable request state and dynamic schemas can grow
-        # the mapping over the codec lifetime.
+        # the mapping over the codec lifetime. Callers can disable this
+        # optimization for parser implementations that require request-scoped
+        # instances.
         self._tool_parser_cache: dict[tuple[str, ...], Any] = {}
 
     @property
@@ -280,7 +284,7 @@ class MessageCodec:
         parser_name: str,
     ) -> tuple[str, list[Any]]:
         cache_key = ("sglang", parser_name, _canonical_tools_hash(tools))
-        parser = self._tool_parser_cache.get(cache_key)
+        parser = self._tool_parser_cache.get(cache_key) if self._enable_tool_parser_cache else None
         if parser is None:
             from sglang.srt.entrypoints.openai.protocol import Function as SglFunction
             from sglang.srt.entrypoints.openai.protocol import Tool as SglTool
@@ -288,7 +292,8 @@ class MessageCodec:
 
             sglang_tools = [SglTool(type=tool["type"], function=SglFunction(**tool["function"])) for tool in tools]
             parser = FunctionCallParser(sglang_tools, parser_name)
-            self._tool_parser_cache[cache_key] = parser
+            if self._enable_tool_parser_cache:
+                self._tool_parser_cache[cache_key] = parser
 
         if not parser.has_tool_call(text):
             return text, []
@@ -304,7 +309,7 @@ class MessageCodec:
         from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionToolsParam
 
         cache_key = ("vllm", parser_name, _canonical_tools_hash(tools))
-        parser = self._tool_parser_cache.get(cache_key)
+        parser = self._tool_parser_cache.get(cache_key) if self._enable_tool_parser_cache else None
         vllm_tools = [ChatCompletionToolsParam(**tool) if isinstance(tool, dict) else tool for tool in tools]
         if parser is None:
             from vllm.tool_parsers import ToolParserManager
@@ -315,7 +320,8 @@ class MessageCodec:
                 parser = parser_cls(self._tokenizer, tools=vllm_tools)
             else:
                 parser = parser_cls(self._tokenizer)
-            self._tool_parser_cache[cache_key] = parser
+            if self._enable_tool_parser_cache:
+                self._tool_parser_cache[cache_key] = parser
 
         request = SimpleNamespace(tools=vllm_tools, tool_choice="auto", skip_special_tokens=True)
         parsed = parser.extract_tool_calls(text, request)
@@ -334,10 +340,11 @@ class MessageCodec:
         from verl.tools.schemas import OpenAIFunctionToolSchema
 
         cache_key = ("verl", parser_name)
-        parser = self._tool_parser_cache.get(cache_key)
+        parser = self._tool_parser_cache.get(cache_key) if self._enable_tool_parser_cache else None
         if parser is None:
             parser = ToolParser.get_tool_parser(parser_name, self._tokenizer)
-            self._tool_parser_cache[cache_key] = parser
+            if self._enable_tool_parser_cache:
+                self._tool_parser_cache[cache_key] = parser
 
         tool_schemas = [OpenAIFunctionToolSchema.model_validate(tool) for tool in tools]
         content, calls = await parser.extract_tool_calls(response_ids, tool_schemas)


### PR DESCRIPTION
## Summary

Add an opt-out for the Gateway tool-parser cache introduced by PR #127. The
cache remains enabled by default for parser-construction performance, while
users can disable it for parser implementations that require request-scoped
instances or retain mutable request state.

## Changes

- Add `enable_tool_parser_cache` to `GatewayActorConfig` and `MessageCodec`,
  defaulting to `true`.
- Read the option from
  `actor_rollout_ref.rollout.custom.agent_framework.enable_tool_parser_cache`.
- When disabled, SGLang, vLLM, and verl parsers are constructed for each tool
  extraction and are not inserted into the codec cache.
- Validate the option as a strict boolean and document the compatibility reason
  in the configuration and codec comments.
- Add focused tests for cache bypass, configuration propagation, defaults, and
  invalid values.

## Compatibility

- Existing configurations keep the PR #127 behavior because the default is
  `true`.
- Users with a parser whose instance is not safe to reuse can set:

  ```yaml
  actor_rollout_ref:
    rollout:
      custom:
        agent_framework:
          enable_tool_parser_cache: false
  ```

- This is an actor/codec-level setting, not a per-request option, because the
  parser cache is scoped to the model codec.

## Validation

- `PYTHONPATH=$PWD pytest -q tests/uni_agent/gateway/test_message_codec_parser_cache.py tests/uni_agent/framework/test_generate_sequences_on_cpu.py tests/uni_agent/gateway/test_gateway_actor_on_cpu.py -k 'parser_cache or build_gateway_manager_wires_gateway_config_defaults or tool_parser_cache'`: 12 passed, 69 deselected.
- `PYTHONPATH=$PWD pytest -q tests/uni_agent/gateway/test_message_codec_parser_cache.py tests/uni_agent/gateway/test_message_codec_tool_dispatch.py -k 'not qwen_vllm_parser_uses_tool_schema_for_argument_types and not vllm_parser_supports_tool_schema_constructor_contracts'`: 13 passed, 3 deselected.
- `PYTHONPATH=$PWD pytest -q tests/uni_agent/framework/test_generate_sequences_on_cpu.py`: 27 passed.
- `PYTHONPATH=$PWD pytest -q tests/uni_agent/gateway/test_gateway_actor_on_cpu.py`: 48 passed.
- `pre-commit run --all-files --show-diff-on-failure --color=always`: passed (ruff, format, mypy, compileall).

## Checklist

- [x] The PR is focused and explains why no issue is needed.
- [x] The title follows the repository format.
- [x] Tests cover the changed behavior.
- [x] Compatibility impact and configuration usage are documented.
- [x] No credentials or private data are included.
- [x] Full all-files pre-commit passes.
