### PR TITLE
[sandbox] feat: run OpenYuanrong commands through base exec via _exec

### DIFF
--- a/tests/uni_agent/sandbox/test_exec_error_policy.py
+++ b/tests/uni_agent/sandbox/test_exec_error_policy.py
@@ -146,7 +146,7 @@ def test_is_timeout_error_override_is_honored_by_exec():
 
 # --------------------------- provider wiring ---------------------------
 
-_PROVIDERS = ["local", "docker", "modal", "vefaas", "seed"]
+_PROVIDERS = ["local", "docker", "modal", "vefaas", "seed", "openyuanrong"]
 
 
 @pytest.mark.parametrize("name", _PROVIDERS)
@@ -219,6 +219,15 @@ def test_modal_inherits_base_timeout_check():
     assert sb._is_timeout_error(RuntimeError("other")) is False
 
 
+def test_openyuanrong_recognizes_its_timeout():
+    from uni_agent.sandbox.openyuanrong import OpenyuanrongSandbox
+
+    sb = OpenyuanrongSandbox(image="python:3.12")
+    assert sb._is_timeout_error(RuntimeError("Command timed out after 60 seconds")) is True
+    assert sb._is_timeout_error(TimeoutError()) is True
+    assert sb._is_timeout_error(RuntimeError("other")) is False
+
+
 # --------------------------- provider is_alive() liveness ---------------------------
 
 
@@ -246,6 +255,12 @@ def test_vefaas_is_alive_false_before_start(monkeypatch):
     from uni_agent.sandbox.vefaas import VefaasSandbox
 
     assert asyncio.run(VefaasSandbox().is_alive()) is False
+
+
+def test_openyuanrong_is_alive_false_before_start():
+    from uni_agent.sandbox.openyuanrong import OpenyuanrongSandbox
+
+    assert asyncio.run(OpenyuanrongSandbox(image="python:3.12").is_alive()) is False
 
 
 def _fake_modal_sandbox(*, poll_returns=None, poll_raises: BaseException | None = None):

--- a/uni_agent/sandbox/openyuanrong.py
+++ b/uni_agent/sandbox/openyuanrong.py
@@ -261,7 +261,8 @@ class OpenyuanrongSandbox(Sandbox):
         """Run ``argv`` once via akernel ``Commands.run``."""
         sb = self._require()
         timeout_i = int(timeout) if timeout else 60
-        result = sb.commands.run(shlex.join(argv), envs=env, cwd=workdir, timeout=timeout_i)
+        # commands.run is a blocking SDK poll; run it off the event loop.
+        result = await asyncio.to_thread(sb.commands.run, shlex.join(argv), envs=env, cwd=workdir, timeout=timeout_i)
         exit_code = int(result.exit_code)
         stdout = _to_str(getattr(result, "stdout", ""))
         stderr = _to_str(getattr(result, "stderr", ""))

--- a/uni_agent/sandbox/openyuanrong.py
+++ b/uni_agent/sandbox/openyuanrong.py
@@ -205,45 +205,7 @@ class OpenyuanrongSandbox(Sandbox):
         shell = await sb.shells.create(cwd=cwd, envs=env)
         return _OpenyuanrongShell(shell)
 
-    # ----- public: data plane (commands / files / ports) -----
-    async def exec(
-        self,
-        argv: list[str],
-        *,
-        timeout: float | None = None,
-        workdir: str | None = None,
-        env: dict[str, str] | None = None,
-    ) -> ExecResult:
-        """Fully overrides base ``exec``; does not use the base error-policy wrapper.
-
-        Joins ``argv`` and delegates to :meth:`exec_shell` (Yuanrong
-        ``commands.run``). Does not call ``super().exec`` or base ``_exec``.
-        """
-        return await self.exec_shell(shlex.join(argv), timeout=timeout, workdir=workdir, env=env)
-
-    async def exec_shell(
-        self,
-        script: str,
-        *,
-        timeout: float | None = None,
-        workdir: str | None = None,
-        env: dict[str, str] | None = None,
-    ) -> ExecResult:
-        """Fully overrides base ``exec_shell``; does not use ``bash -lc`` via base.
-
-        Runs ``script`` directly through Yuanrong ``commands.run``. Does not call
-        ``super().exec_shell`` / ``exec(["bash", "-lc", script])``. Owns its own
-        timeout / alive error policy (mirrors base ``exec``, not base ``exec_shell``).
-        """
-        try:
-            return await self._run_command(script, timeout=timeout, workdir=workdir, env=env)
-        except Exception as exc:
-            if self._is_timeout_error(exc):
-                return ExecResult(exit_code=-1, stdout="", stderr=f"exec timed out after {timeout}s: {exc}")
-            if not await self.is_alive():
-                raise
-            return ExecResult(exit_code=127, stdout="", stderr=str(exc))
-
+    # ----- public: data plane (files / ports) -----
     async def read_file(self, path: str) -> bytes:
         """Read via SDK ``files.read(..., format='bytes')``."""
         data = await asyncio.to_thread(lambda: self._require().files.read(path, format="bytes"))
@@ -286,25 +248,7 @@ class OpenyuanrongSandbox(Sandbox):
         return m
 
     def _is_timeout_error(self, exc: BaseException) -> bool:
-        return type(exc).__name__ == "CommandTimeoutError" or super()._is_timeout_error(exc)
-
-    async def _run_command(
-        self,
-        cmd: str,
-        *,
-        timeout: float | None = None,
-        workdir: str | None = None,
-        env: dict[str, str] | None = None,
-    ) -> ExecResult:
-        """Run a shell command string once via ``commands.run``."""
-        sb = self._require()
-        timeout_i = int(timeout) if timeout else 60
-        result = await asyncio.to_thread(lambda: sb.commands.run(cmd, envs=env, cwd=workdir, timeout=timeout_i))
-        return ExecResult(
-            exit_code=int(getattr(result, "exit_code", -99)),
-            stdout=_to_str(getattr(result, "stdout", "")),
-            stderr=_to_str(getattr(result, "stderr", "")),
-        )
+        return "Command timed out after" in str(exc) or super()._is_timeout_error(exc)
 
     async def _exec(
         self,
@@ -314,10 +258,13 @@ class OpenyuanrongSandbox(Sandbox):
         workdir: str | None = None,
         env: dict[str, str] | None = None,
     ) -> ExecResult:
-        """Intentionally unimplemented.
-
-        Base marks ``_exec`` abstract, so this stub exists only to instantiate the
-        class. Public :meth:`exec` is fully overridden and never calls this (or
-        ``super().exec``).
-        """
-        raise NotImplementedError("OpenyuanrongSandbox overrides exec(); _exec is unused")
+        """Run ``argv`` once via akernel ``Commands.run``."""
+        sb = self._require()
+        timeout_i = int(timeout) if timeout else 60
+        result = sb.commands.run(shlex.join(argv), envs=env, cwd=workdir, timeout=timeout_i)
+        exit_code = int(result.exit_code)
+        stdout = _to_str(getattr(result, "stdout", ""))
+        stderr = _to_str(getattr(result, "stderr", ""))
+        if exit_code != 0:
+            raise RuntimeError(stderr or f"command exited with {exit_code}")
+        return ExecResult(exit_code=0, stdout=stdout, stderr=stderr)


### PR DESCRIPTION
## Summary

OpenYuanrong was overriding `exec` and `exec_shell`, so it skipped the shared error policy and ran scripts through the SDK default shell instead of `bash -c`. That made `set -o pipefail` fail on dash/`/bin/sh`.

This PR implements `_exec` only. Public `exec` / `exec_shell` come from the base class, so OpenYuanrong matches the other providers.

## Changes

- **Sandbox (`OpenyuanrongSandbox`)**: remove `exec` / `exec_shell` overrides; implement `_exec` via `Commands.run`. Non-zero results raise into the shared policy. `exec_shell` uses `bash -c`.
- **Timeouts**: treat `Commands.run` deadline expiry (`Command timed out after …`) and `TimeoutError` as timeouts (`exit_code == -1`).
- **Tests**: wire `openyuanrong` into the shared exec-policy checks (`_exec` present, timeout classification, `is_alive` before start).

## Test

sandbox.exec_shell("set -o pipefail") and quickstart/sandbox/demo.py test results:

<img width="1390" height="770" alt="image" src="https://github.com/user-attachments/assets/095c475f-e714-489e-8ae2-50c511958124" />


## PR title

Use `[area] type: summary`.

- Areas: `agents`, `framework`, `gateway`, `logging`, `sandbox`, `tasks`, `tools`, `training`, `app`, `docs`, `examples`, `ci`, `build`, `deps`, `misc`
- Types: `feat`, `fix`, `refactor`, `perf`, `test`, `docs`, `chore`, `revert`
- Separate multiple areas with comma-space: `[agents, sandbox] feat: add isolated harness execution`
- Prefix compatibility-breaking work with `[BREAKING]`: `[BREAKING][tasks, docs] refactor: replace task config schema`
- A stacked series may start with `[1/N]`: `[1/N][gateway] refactor: split protocol adapters`

## Checklist

- [x] The PR is focused and linked to an issue or explains why no issue is needed.
- [x] The title follows the format above and names the layer that owns the change.
- [x] Tests cover the behavior, or the Validation section explains why they are not practical.
- [x] User-facing API, config, and workflow changes include documentation or runnable examples.
- [x] Compatibility impact and migration steps are documented.
- [x] Logs, fixtures, and examples contain no credentials or private data.
- [x] `pre-commit run --all-files --show-diff-on-failure` passes.

No linked issue: this is a sandbox-provider alignment fix, not a tracked feature request.

Callers that used OpenYuanrong `exec_shell` now get `bash -c` (same as other providers). There is no config or parquet migration.