### PR TITLE
[tasks] fix: align SWE prompt fixtures with image maps

### DIFF
--- a/tests/uni_agent/tasks/test_swe_prompt_preprocess.py
+++ b/tests/uni_agent/tasks/test_swe_prompt_preprocess.py
@@ -120,10 +120,12 @@ def test_swe_recipe_renders_complete_metadata_prompt(recipe_path, task_name, exp
     }
     if expects_language:
         metadata["language"] = language
+    image_prefix = "swerebench" if task_name == "swe_rebench" else "swebench"
 
     resolved = TaskConfigResolver.from_file(recipe_path).resolve(
         {
             "name": task_name,
+            "sandbox": {"image": f"{image_prefix}/test-repo:latest"},
             "prompt": [{"role": "user", "content": source_problem}],
             "metadata": metadata,
         }


### PR DESCRIPTION
## Summary

Align the PR134 SWE prompt-rendering test fixture with the canonical sandbox image contract now present on `upstream/main`.

## Changes

- Provide a `swebench/...:latest` image for SWE-bench and multilingual samples and a `swerebench/...:latest` image for SWE-ReBench samples.
- Keep the fix scoped to the test fixture; production `image_map` validation remains unchanged.

## Compatibility

- This follow-up is required after PR134 was merged together with the existing `image_map` sandbox contract from PR125. It changes no runtime behavior.

## Validation

- `PYTHONPATH="$PWD:$PWD/verl" python -m pytest tests/uni_agent/tasks/test_swe_prompt_preprocess.py -q` (`13 passed`)
- `PYTHONPATH="$PWD:$PWD/verl" python -m pytest tests/uni_agent/framework tests/uni_agent/tasks -q` (`74 passed, 3 warnings`)
- `pre-commit run --all-files --show-diff-on-failure --color=always`
- `git diff --check upstream/main...HEAD`

## Checklist

- [x] The PR is focused and linked to an issue or explains why no issue is needed.
- [x] The title follows the format above and names the layer that owns the change.
- [x] Tests cover the behavior, or the Validation section explains why they are not practical.
- [x] User-facing API, config, and workflow changes include documentation or runnable examples.
- [x] Compatibility impact and migration steps are documented.
- [x] Logs, fixtures, and examples contain no credentials or private data.
- [x] `pre-commit run --all-files --show-diff-on-failure` passes.
