### PR TITLE
[examples] fix: keep SWE image path when mapping mini-swe-agent registries

### DIFF
--- a/examples/mini_swe_agent/README.md
+++ b/examples/mini_swe_agent/README.md
@@ -139,7 +139,7 @@ touching the training script:
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `sandbox.image_map` | `swebench/**:latest` → `swr.cn-east-3.myhuaweicloud.com/openyuanrong/**:latest` (and `swerebench/**`) | Maps canonical SWE image refs to the sandbox registry at run time |
+| `sandbox.image_map` | `swebench/**` → `swr.cn-east-3.myhuaweicloud.com/openyuanrong/swebench/**` (and `swerebench/**`) | Prefixes canonical SWE image refs with the sandbox registry; keeps `swebench/` / `swerebench/` and the source tag |
 | `sandbox.sandbox_kwargs.mounts[].image_url` | `swr.cn-east-3.myhuaweicloud.com/openyuanrong/mini-swe-agent-tool:latest` | Sidecar tool image mounted at `/opt/mini-swe-agent` |
 | `sandbox.sandbox_kwargs.proxy_port` | `38197` | Sandbox-internal reverse-tunnel port — **single source of truth** |
 | `sandbox.sandbox_kwargs.cpu/memory/…` | provider defaults | Sandbox resource sizes (pass through to the openyuanrong SDK) |

--- a/examples/mini_swe_agent/task_config_mini_swe_agent.yaml
+++ b/examples/mini_swe_agent/task_config_mini_swe_agent.yaml
@@ -24,10 +24,10 @@
     provider: openyuanrong
     runtime_timeout: 7200
     image_map:
-      - from: "swebench/**:latest"
-        to: "swr.cn-east-3.myhuaweicloud.com/openyuanrong/**:latest"
-      - from: "swerebench/**:latest"
-        to: "swr.cn-east-3.myhuaweicloud.com/openyuanrong/**:latest"
+      - from: "swebench/**"
+        to: "swr.cn-east-3.myhuaweicloud.com/openyuanrong/swebench/**"
+      - from: "swerebench/**"
+        to: "swr.cn-east-3.myhuaweicloud.com/openyuanrong/swerebench/**"
     sandbox_kwargs:
       proxy_port: 38197
       mounts:
@@ -46,10 +46,10 @@
     provider: openyuanrong
     runtime_timeout: 7200
     image_map:
-      - from: "swebench/**:latest"
-        to: "swr.cn-east-3.myhuaweicloud.com/openyuanrong/**:latest"
-      - from: "swerebench/**:latest"
-        to: "swr.cn-east-3.myhuaweicloud.com/openyuanrong/**:latest"
+      - from: "swebench/**"
+        to: "swr.cn-east-3.myhuaweicloud.com/openyuanrong/swebench/**"
+      - from: "swerebench/**"
+        to: "swr.cn-east-3.myhuaweicloud.com/openyuanrong/swerebench/**"
     sandbox_kwargs:
       proxy_port: 38197
       mounts:


### PR DESCRIPTION
## Summary
Restore the mini-swe-agent `image_map` to the old OpenYuanrong prefix behavior: prepend the registry host and keep `swebench/` / `swerebench/` plus the source tag.

## Changes

- Rewrite Task Config `image_map` so `swebench/**` maps to `swr.cn-east-3.myhuaweicloud.com/openyuanrong/swebench/**` (and the same for `swerebench/**`).
- Update the recipe README to match the new mapping.

## Test plan
- [ ] Confirm a SWE parquet image such as `swebench/sweb.eval.x86_64.astropy_1776_astropy-13033` becomes `swr.cn-east-3.myhuaweicloud.com/openyuanrong/swebench/sweb.eval.x86_64.astropy_1776_astropy-13033`.
- [ ] Confirm an already-prefixed tool image is unchanged.


Made with [Cursor](https://cursor.com)