### PR TITLE
[examples, sandbox] fix: map SWE parquet images onto OpenYuanrong SWR paths

### DIFF
--- a/docs/source/concepts/sandbox.md
+++ b/docs/source/concepts/sandbox.md
@@ -47,7 +47,7 @@ sandbox:
 
 `**` copies the instance-specific path, so `swebench/sweb.eval.x86_64.astropy_1776_astropy-13033` becomes `<your-registry>/swe-bench-verified/sweb.eval.x86_64.astropy_1776_astropy-13033:v2`.
 
-List as many rules as you need; the first matching `from` is used. Omit `image_map` when the sandbox can pull the dataset image as written.
+List as many rules as you need; the first matching `from` is used. Images that match none of the rules are left unchanged.
 
 ## Lifecycle
 

--- a/examples/mini_swe_agent/task_config_mini_swe_agent.yaml
+++ b/examples/mini_swe_agent/task_config_mini_swe_agent.yaml
@@ -24,10 +24,8 @@
     provider: openyuanrong
     runtime_timeout: 7200
     image_map:
-      - from: "swebench/**"
-        to: "swr.cn-east-3.myhuaweicloud.com/openyuanrong/swebench/**"
-      - from: "swerebench/**"
-        to: "swr.cn-east-3.myhuaweicloud.com/openyuanrong/swerebench/**"
+      - from: "swerebench/sweb.eval.x86_64.**"
+        to: "swr.cn-east-3.myhuaweicloud.com/openyuanrong/swe-rebench/**:latest"
     sandbox_kwargs:
       proxy_port: 38197
       mounts:
@@ -47,9 +45,7 @@
     runtime_timeout: 7200
     image_map:
       - from: "swebench/**"
-        to: "swr.cn-east-3.myhuaweicloud.com/openyuanrong/swebench/**"
-      - from: "swerebench/**"
-        to: "swr.cn-east-3.myhuaweicloud.com/openyuanrong/swerebench/**"
+        to: "swr.cn-east-3.myhuaweicloud.com/openyuanrong/swe-bench-verified/**:v2"
     sandbox_kwargs:
       proxy_port: 38197
       mounts:

--- a/uni_agent/sandbox/base.py
+++ b/uni_agent/sandbox/base.py
@@ -148,10 +148,7 @@ class SandboxConfig(BaseModel):
             if (mapped := rule.try_map(self.image)) is not None:
                 self.image = mapped
                 return self
-        if any(rule._match(self.image, rule.to) is not None for rule in self.image_map):
-            return self
-        froms = ", ".join(repr(m.from_) for m in self.image_map)
-        raise ValueError(f"image_map from {froms} does not match image {self.image!r}")
+        return self
 
 
 @runtime_checkable


### PR DESCRIPTION
## Summary

Point mini-swe-agent `image_map` at the real OpenYuanrong SWR SWE images, and leave unmatched `sandbox.image` values unchanged instead of raising.

## Changes

- `swe_rebench`: `swerebench/sweb.eval.x86_64.**` → `swr.cn-east-3.myhuaweicloud.com/openyuanrong/swe-rebench/**:latest` (example: `cekit__cekit-532` → `.../swe-rebench/cekit_1776_cekit-532:latest`).
- `swe_bench`: `swebench/**` → `swr.cn-east-3.myhuaweicloud.com/openyuanrong/swe-bench-verified/**:v2` (keeps `sweb.eval.x86_64.` and tags `:v2`).
- `SandboxConfig`: if no `image_map` rule matches, keep the original image.
- Docs: unmatched images are left unchanged.

## Test plan

- `swerebench/sweb.eval.x86_64.cekit_1776_cekit-532` maps to `swr.cn-east-3.myhuaweicloud.com/openyuanrong/swe-rebench/cekit_1776_cekit-532:latest`.
- `swebench/sweb.eval.x86_64.astropy_1776_astropy-13033` maps to `swr.cn-east-3.myhuaweicloud.com/openyuanrong/swe-bench-verified/sweb.eval.x86_64.astropy_1776_astropy-13033:v2`.
