### PR TITLE
[framework] feat: add trajectory postprocessor hook

### DIFF
--- a/docs/source/concepts/gateway-and-trajectories.md
+++ b/docs/source/concepts/gateway-and-trajectories.md
@@ -62,6 +62,66 @@ A finalized trajectory contains:
 
 Before writing to TransferQueue, the Agent Framework derives the full training record, including `input_ids`, attention masks, position IDs, loss masks, and sparse `rm_scores`.
 
+An optional trajectory postprocessor can filter, reorder, or replace the
+finalized trajectories before reward scoring and artifact logging. The order is:
+
+```text
+Gateway finalization
+    -> Runner trajectory_selection (all or longest)
+    -> trajectory postprocessor
+    -> reward scoring
+    -> trajectory logs and TransferQueue
+```
+
+Configure a postprocessor at the Framework level:
+
+```yaml
+actor_rollout_ref:
+  rollout:
+    custom:
+      agent_framework:
+        trajectory_postprocessor_fqn: my_recipe.trajectory.process_trajectories
+        trajectory_postprocessor_kwargs:
+          max_total_tokens: 262144  # 256K prompt + response tokens
+```
+
+The FQN is imported when the Agent Framework starts, so it must be available in
+the AgentFrameworkWorker environment. Malformed FQN or keyword-argument values
+log a warning and leave the hook disabled. A valid non-empty FQN is loaded
+eagerly and must resolve to a callable with this contract:
+
+```python
+from uni_agent.gateway.session import Trajectory
+
+
+def process_trajectories(
+    trajectories: tuple[Trajectory, ...],
+    *,
+    max_total_tokens: int = 262_144,
+) -> list[Trajectory]:
+    return [
+        trajectory
+        for trajectory in trajectories
+        if len(trajectory.prompt_ids) + len(trajectory.response_ids) <= max_total_tokens
+    ]
+```
+
+`trajectory_postprocessor_kwargs` is passed as keyword arguments. The processor
+receives a tuple and must return `list[Trajectory]`; returning an empty list
+filters the session out. An `async def` processor is
+also supported and is awaited. Returned trajectories must keep
+their token arrays aligned because unfinished masking and TransferQueue
+materialization run later.
+
+`max_total_tokens` above is defined by the example processor.
+This compact example drops oversized trajectories; a processor that
+crops them must preserve token-array alignment and valid turn boundaries. A
+processor may define different keyword arguments or none at all.
+
+The hook is disabled when `trajectory_postprocessor_fqn` is omitted or `null`.
+In that case no extension is imported or called, and finalized trajectories
+continue through the original scoring, logging, and TransferQueue path.
+
 The Gateway uses a `MessageCodec` to:
 
 - Apply the model chat template.
@@ -160,6 +220,10 @@ Important knobs include:
 - `enable_last_assistant_rollback`: reuses a chain when only its latest Assistant
   message is rewritten. Defaults to `true`; set it to `false` to preserve the
   previous split-on-rewrite behavior.
+- `trajectory_postprocessor_fqn`: optional import path for a sync or async
+  callable that postprocesses finalized trajectories before reward scoring.
+- `trajectory_postprocessor_kwargs`: optional keyword arguments passed to the
+  postprocessor.
 - `agent_runners`: Runner import paths and arguments.
 - `dispatch_mode`: inline async execution or Ray tasks.
 - `max_concurrent_sessions`: per-Runner concurrency limit.
@@ -175,6 +239,8 @@ Customize the layer that owns the behavior:
 - Implement an Agent Runner to launch a different workload against a Gateway session.
 - Add a Gateway adapter for a new model API wire format.
 - Customize Task, Agent, Tool, and Sandbox behavior through their registries.
+- Implement a trajectory postprocessor for use-case-specific filtering or
+  transformation after finalization and before scoring.
 - Customize reward scoring in the Task or a verl Reward Loop Worker.
 
 Do not put Task logic inside Gateway routes or bypass the Gateway token buffers when training-format trajectories are required.

--- a/docs/source/concepts/gateway-and-trajectories.md
+++ b/docs/source/concepts/gateway-and-trajectories.md
@@ -86,9 +86,10 @@ actor_rollout_ref:
 ```
 
 The FQN is imported when the Agent Framework starts, so it must be available in
-the AgentFrameworkWorker environment. Malformed FQN or keyword-argument values
-log a warning and leave the hook disabled. A valid non-empty FQN is loaded
-eagerly and must resolve to a callable with this contract:
+the AgentFrameworkWorker environment. A configured FQN must be a non-empty
+string, and `trajectory_postprocessor_kwargs` must be a mapping. Invalid
+explicit configuration, import failures, and non-callable targets fail during
+Framework initialization. The callable must follow this contract:
 
 ```python
 from uni_agent.gateway.session import Trajectory
@@ -108,10 +109,12 @@ def process_trajectories(
 
 `trajectory_postprocessor_kwargs` is passed as keyword arguments. The processor
 receives a tuple and must return `list[Trajectory]`; returning an empty list
-filters the session out. An `async def` processor is
-also supported and is awaited. Returned trajectories must keep
-their token arrays aligned because unfinished masking and TransferQueue
-materialization run later.
+filters the session out. An `async def` processor is also supported and is
+awaited. Returned trajectories must preserve the finalized session
+`reward_info` and keep their token arrays aligned because reward scoring,
+unfinished masking, and TransferQueue materialization run later. Use
+`dataclasses.replace` when constructing transformed trajectories so unrelated
+fields remain intact.
 
 `max_total_tokens` above is defined by the example processor.
 This compact example drops oversized trajectories; a processor that

--- a/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
+++ b/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
@@ -14,6 +14,42 @@ from verl.utils import tensordict_utils as tu
 
 _RUNNER_CALLS = []
 _TEST_INLINE_RUNNERS = {}
+_POSTPROCESSOR_CALLS = []
+_POSTPROCESSOR_EVENTS = []
+_NOT_CALLABLE_POSTPROCESSOR = 42
+
+
+def _recording_trajectory_postprocessor(trajectories, *, enabled=False, policy=None):
+    _POSTPROCESSOR_CALLS.append(
+        {
+            "trajectories": trajectories,
+            "enabled": enabled,
+            "policy": policy,
+        }
+    )
+    return list(reversed(trajectories))
+
+
+async def _async_trajectory_postprocessor(trajectories):
+    await asyncio.sleep(0)
+    return list(trajectories[-1:])
+
+
+def _ordered_trajectory_postprocessor(trajectories):
+    _POSTPROCESSOR_EVENTS.append("postprocess")
+    return list(trajectories)
+
+
+def _tuple_trajectory_postprocessor(trajectories):
+    return tuple(trajectories)
+
+
+def _invalid_item_trajectory_postprocessor(trajectories):
+    return ["not-a-trajectory"]
+
+
+def _raising_trajectory_postprocessor(trajectories):
+    raise ValueError("recipe policy failed")
 
 
 async def _config_recording_runner(*, raw_prompt, session, sample_index, marker=None, **kwargs):
@@ -84,6 +120,8 @@ async def _build_framework_with_agent_runners(
     val_n: int = 1,
     log_dir: str | None = None,
     mask_unfinished_episode: bool = False,
+    trajectory_postprocessor_fqn: str | None = None,
+    trajectory_postprocessor_kwargs: object | None = None,
 ):
     from omegaconf import OmegaConf
 
@@ -93,6 +131,10 @@ async def _build_framework_with_agent_runners(
     }
     if log_dir is not None:
         agent_framework_cfg["log_dir"] = log_dir
+    if trajectory_postprocessor_fqn is not None:
+        agent_framework_cfg["trajectory_postprocessor_fqn"] = trajectory_postprocessor_fqn
+    if trajectory_postprocessor_kwargs is not None:
+        agent_framework_cfg["trajectory_postprocessor_kwargs"] = trajectory_postprocessor_kwargs
 
     config = OmegaConf.create(
         {
@@ -870,6 +912,218 @@ async def test_framework_rejects_unknown_trajectory_selection(fake_tq):
             },
             gateway_manager=_FakeGatewayManager({}),
         )
+
+
+@pytest.mark.asyncio
+async def test_default_trajectory_postprocessor_is_identity_and_never_loads(monkeypatch, fake_tq):
+    from uni_agent.framework import framework as framework_module
+
+    original_load = framework_module.load_class_from_fqn
+
+    def fail_if_postprocessor_loaded(fqn, *, description=None):
+        if description == "trajectory postprocessor":
+            raise AssertionError("default postprocessor path must not import an extension")
+        return original_load(fqn, description=description)
+
+    monkeypatch.setattr(framework_module, "load_class_from_fqn", fail_if_postprocessor_loaded)
+    runtime = _FakeGatewayManager(
+        {
+            "session-sample-0-rollout-0": [
+                _trajectory(response_ids=[20]),
+                _trajectory(response_ids=[30]),
+            ]
+        }
+    )
+    framework = await _build_framework_with_agent_runners(
+        agent_runners={"runner": _inline_runner_config(_async_noop_runner)},
+        gateway_manager=runtime,
+    )
+
+    await framework.generate_sequences(_build_prompts(count=1, global_steps=8))
+
+    assert fake_tq.batch_puts[0]["fields"]["responses"][0].tolist() == [20]
+    assert fake_tq.batch_puts[0]["fields"]["responses"][1].tolist() == [30]
+
+
+@pytest.mark.asyncio
+async def test_trajectory_postprocessor_loads_at_start_and_receives_kwargs(monkeypatch, fake_tq):
+    from uni_agent.framework import framework as framework_module
+
+    load_calls = []
+    original_load = framework_module.load_class_from_fqn
+
+    def recording_load(fqn, *, description=None):
+        load_calls.append((fqn, description))
+        return original_load(fqn, description=description)
+
+    monkeypatch.setattr(framework_module, "load_class_from_fqn", recording_load)
+    _POSTPROCESSOR_CALLS.clear()
+    runtime = _FakeGatewayManager(
+        {
+            "session-sample-0-rollout-0": [
+                _trajectory(response_ids=[20]),
+                _trajectory(response_ids=[30]),
+            ]
+        }
+    )
+    postprocessor_fqn = f"{__name__}._recording_trajectory_postprocessor"
+    framework = await _build_framework_with_agent_runners(
+        agent_runners={"runner": _inline_runner_config(_async_noop_runner)},
+        gateway_manager=runtime,
+        trajectory_postprocessor_fqn=postprocessor_fqn,
+        trajectory_postprocessor_kwargs={"enabled": True, "policy": {"thresholds": [1, 2]}},
+    )
+
+    assert load_calls.count((postprocessor_fqn, "trajectory postprocessor")) == 1
+
+    await framework.generate_sequences(_build_prompts(count=1, global_steps=8))
+
+    assert load_calls.count((postprocessor_fqn, "trajectory postprocessor")) == 1
+    assert len(_POSTPROCESSOR_CALLS) == 1
+    call = _POSTPROCESSOR_CALLS[0]
+    assert isinstance(call["trajectories"], tuple)
+    assert call["enabled"] is True
+    assert call["policy"] == {"thresholds": [1, 2]}
+
+    assert fake_tq.batch_puts[0]["fields"]["responses"][0].tolist() == [30]
+    assert fake_tq.batch_puts[0]["fields"]["responses"][1].tolist() == [20]
+
+
+@pytest.mark.asyncio
+async def test_async_trajectory_postprocessor_is_awaited(fake_tq):
+    runtime = _FakeGatewayManager(
+        {
+            "session-sample-0-rollout-0": [
+                _trajectory(response_ids=[20]),
+                _trajectory(response_ids=[30]),
+            ]
+        }
+    )
+    framework = await _build_framework_with_agent_runners(
+        agent_runners={"runner": _inline_runner_config(_async_noop_runner)},
+        gateway_manager=runtime,
+        trajectory_postprocessor_fqn=f"{__name__}._async_trajectory_postprocessor",
+    )
+
+    await framework.generate_sequences(_build_prompts(count=1, global_steps=8))
+
+    assert fake_tq.batch_puts[0]["keys"] == ["uid-0_0_0"]
+    assert fake_tq.batch_puts[0]["fields"]["responses"][0].tolist() == [30]
+
+
+@pytest.mark.asyncio
+async def test_trajectory_postprocessor_runs_after_finalize_before_scoring_and_logging(monkeypatch, tmp_path, fake_tq):
+    class _OrderedGatewayManager(_FakeGatewayManager):
+        async def finalize_session(self, session_id: str):
+            trajectories = await super().finalize_session(session_id)
+            _POSTPROCESSOR_EVENTS.append("finalize")
+            return trajectories
+
+    _POSTPROCESSOR_EVENTS.clear()
+    runtime = _OrderedGatewayManager({"session-sample-0-rollout-0": [_trajectory()]})
+    framework = await _build_framework_with_agent_runners(
+        agent_runners={"runner": _inline_runner_config(_async_noop_runner)},
+        gateway_manager=runtime,
+        log_dir=str(tmp_path),
+        trajectory_postprocessor_fqn=f"{__name__}._ordered_trajectory_postprocessor",
+    )
+
+    def record_score(trajectories):
+        _POSTPROCESSOR_EVENTS.append("score")
+        return None
+
+    def record_summary(session_id, trajectories):
+        _POSTPROCESSOR_EVENTS.append("summary")
+
+    def record_dump(run_dir, session_id, trajectories):
+        _POSTPROCESSOR_EVENTS.append("dump")
+
+    monkeypatch.setattr(framework, "_score_from_reward_info", record_score)
+    monkeypatch.setattr(framework, "_log_trajectory_summary", record_summary)
+    monkeypatch.setattr(framework, "_dump_trajectories", record_dump)
+
+    await framework.generate_sequences(_build_prompts(count=1, global_steps=8))
+
+    assert _POSTPROCESSOR_EVENTS == ["finalize", "postprocess", "score", "summary", "dump"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("postprocessor_name", "error_type", "error_message"),
+    [
+        ("_tuple_trajectory_postprocessor", TypeError, r"must return list\[Trajectory\], got tuple"),
+        ("_invalid_item_trajectory_postprocessor", TypeError, "returned a non-Trajectory item"),
+        ("_raising_trajectory_postprocessor", ValueError, "recipe policy failed"),
+    ],
+)
+async def test_trajectory_postprocessor_reports_invalid_extensions(
+    fake_tq,
+    postprocessor_name,
+    error_type,
+    error_message,
+):
+    framework = await _build_framework_with_agent_runners(
+        agent_runners={"runner": _inline_runner_config(_async_noop_runner)},
+        gateway_manager=_FakeGatewayManager({}),
+        trajectory_postprocessor_fqn=f"{__name__}.{postprocessor_name}",
+    )
+
+    with pytest.raises(error_type, match=error_message):
+        await framework._apply_trajectory_postprocessor([_trajectory()])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("postprocessor_name", "error_type", "error_message"),
+    [
+        ("_NOT_CALLABLE_POSTPROCESSOR", TypeError, "must resolve to a callable"),
+        ("_missing_trajectory_postprocessor", AttributeError, "not found in module"),
+    ],
+)
+async def test_framework_loads_trajectory_postprocessor_eagerly(
+    fake_tq,
+    postprocessor_name,
+    error_type,
+    error_message,
+):
+    with pytest.raises(error_type, match=error_message):
+        await _build_framework_with_agent_runners(
+            agent_runners={"runner": _inline_runner_config(_async_noop_runner)},
+            gateway_manager=_FakeGatewayManager({}),
+            trajectory_postprocessor_fqn=f"{__name__}.{postprocessor_name}",
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("postprocessor_fqn", "postprocessor_kwargs", "warning_message"),
+    [
+        ("", None, "trajectory_postprocessor_fqn must be a non-empty string"),
+        ("   ", None, "trajectory_postprocessor_fqn must be a non-empty string"),
+        (123, None, "trajectory_postprocessor_fqn must be a non-empty string"),
+        (None, {"enabled": True}, "trajectory_postprocessor_fqn is not set"),
+        (f"{__name__}._recording_trajectory_postprocessor", [1], "must be a mapping"),
+    ],
+)
+async def test_framework_warns_and_disables_invalid_trajectory_postprocessor_config(
+    fake_tq,
+    caplog,
+    postprocessor_fqn,
+    postprocessor_kwargs,
+    warning_message,
+):
+    caplog.set_level(logging.WARNING, logger="uni_agent.framework.framework")
+
+    framework = await _build_framework_with_agent_runners(
+        agent_runners={"runner": _inline_runner_config(_async_noop_runner)},
+        gateway_manager=_FakeGatewayManager({}),
+        trajectory_postprocessor_fqn=postprocessor_fqn,
+        trajectory_postprocessor_kwargs=postprocessor_kwargs,
+    )
+
+    assert framework._trajectory_postprocessor is None
+    assert framework._trajectory_postprocessor_kwargs == {}
+    assert warning_message in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
+++ b/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import replace
 
 import numpy as np
 import pytest
@@ -15,18 +16,11 @@ from verl.utils import tensordict_utils as tu
 _RUNNER_CALLS = []
 _TEST_INLINE_RUNNERS = {}
 _POSTPROCESSOR_CALLS = []
-_POSTPROCESSOR_EVENTS = []
 _NOT_CALLABLE_POSTPROCESSOR = 42
 
 
-def _recording_trajectory_postprocessor(trajectories, *, enabled=False, policy=None):
-    _POSTPROCESSOR_CALLS.append(
-        {
-            "trajectories": trajectories,
-            "enabled": enabled,
-            "policy": policy,
-        }
-    )
+def _recording_trajectory_postprocessor(trajectories, *, policy=None):
+    _POSTPROCESSOR_CALLS.append((trajectories, policy))
     return list(reversed(trajectories))
 
 
@@ -35,9 +29,8 @@ async def _async_trajectory_postprocessor(trajectories):
     return list(trajectories[-1:])
 
 
-def _ordered_trajectory_postprocessor(trajectories):
-    _POSTPROCESSOR_EVENTS.append("postprocess")
-    return list(trajectories)
+def _empty_trajectory_postprocessor(_trajectories):
+    return []
 
 
 def _tuple_trajectory_postprocessor(trajectories):
@@ -48,8 +41,8 @@ def _invalid_item_trajectory_postprocessor(trajectories):
     return ["not-a-trajectory"]
 
 
-def _raising_trajectory_postprocessor(trajectories):
-    raise ValueError("recipe policy failed")
+def _dropping_reward_info_postprocessor(trajectories):
+    return [replace(trajectories[-1], reward_info={})]
 
 
 async def _config_recording_runner(*, raw_prompt, session, sample_index, marker=None, **kwargs):
@@ -915,48 +908,7 @@ async def test_framework_rejects_unknown_trajectory_selection(fake_tq):
 
 
 @pytest.mark.asyncio
-async def test_default_trajectory_postprocessor_is_identity_and_never_loads(monkeypatch, fake_tq):
-    from uni_agent.framework import framework as framework_module
-
-    original_load = framework_module.load_class_from_fqn
-
-    def fail_if_postprocessor_loaded(fqn, *, description=None):
-        if description == "trajectory postprocessor":
-            raise AssertionError("default postprocessor path must not import an extension")
-        return original_load(fqn, description=description)
-
-    monkeypatch.setattr(framework_module, "load_class_from_fqn", fail_if_postprocessor_loaded)
-    runtime = _FakeGatewayManager(
-        {
-            "session-sample-0-rollout-0": [
-                _trajectory(response_ids=[20]),
-                _trajectory(response_ids=[30]),
-            ]
-        }
-    )
-    framework = await _build_framework_with_agent_runners(
-        agent_runners={"runner": _inline_runner_config(_async_noop_runner)},
-        gateway_manager=runtime,
-    )
-
-    await framework.generate_sequences(_build_prompts(count=1, global_steps=8))
-
-    assert fake_tq.batch_puts[0]["fields"]["responses"][0].tolist() == [20]
-    assert fake_tq.batch_puts[0]["fields"]["responses"][1].tolist() == [30]
-
-
-@pytest.mark.asyncio
-async def test_trajectory_postprocessor_loads_at_start_and_receives_kwargs(monkeypatch, fake_tq):
-    from uni_agent.framework import framework as framework_module
-
-    load_calls = []
-    original_load = framework_module.load_class_from_fqn
-
-    def recording_load(fqn, *, description=None):
-        load_calls.append((fqn, description))
-        return original_load(fqn, description=description)
-
-    monkeypatch.setattr(framework_module, "load_class_from_fqn", recording_load)
+async def test_trajectory_postprocessor_applies_kwargs_before_scoring_and_tq(monkeypatch, fake_tq):
     _POSTPROCESSOR_CALLS.clear()
     runtime = _FakeGatewayManager(
         {
@@ -966,27 +918,32 @@ async def test_trajectory_postprocessor_loads_at_start_and_receives_kwargs(monke
             ]
         }
     )
-    postprocessor_fqn = f"{__name__}._recording_trajectory_postprocessor"
     framework = await _build_framework_with_agent_runners(
         agent_runners={"runner": _inline_runner_config(_async_noop_runner)},
         gateway_manager=runtime,
-        trajectory_postprocessor_fqn=postprocessor_fqn,
-        trajectory_postprocessor_kwargs={"enabled": True, "policy": {"thresholds": [1, 2]}},
+        trajectory_postprocessor_fqn=f"{__name__}._recording_trajectory_postprocessor",
+        trajectory_postprocessor_kwargs={"policy": {"thresholds": [1, 2]}},
     )
 
-    assert load_calls.count((postprocessor_fqn, "trajectory postprocessor")) == 1
+    scored_responses = []
+
+    def score_processed_trajectories(trajectories):
+        scored_responses.extend(trajectory.response_ids for trajectory in trajectories)
+        return [(0.5, {}) for _ in trajectories]
+
+    monkeypatch.setattr(framework, "_score_from_reward_info", score_processed_trajectories)
 
     await framework.generate_sequences(_build_prompts(count=1, global_steps=8))
 
-    assert load_calls.count((postprocessor_fqn, "trajectory postprocessor")) == 1
     assert len(_POSTPROCESSOR_CALLS) == 1
-    call = _POSTPROCESSOR_CALLS[0]
-    assert isinstance(call["trajectories"], tuple)
-    assert call["enabled"] is True
-    assert call["policy"] == {"thresholds": [1, 2]}
+    processed_input, policy = _POSTPROCESSOR_CALLS[0]
+    assert isinstance(processed_input, tuple)
+    assert policy == {"thresholds": [1, 2]}
+    assert scored_responses == [[30], [20]]
 
-    assert fake_tq.batch_puts[0]["fields"]["responses"][0].tolist() == [30]
-    assert fake_tq.batch_puts[0]["fields"]["responses"][1].tolist() == [20]
+    fields = fake_tq.batch_puts[0]["fields"]
+    assert [response.tolist() for response in fields["responses"]] == [[30], [20]]
+    assert [score.tolist() for score in fields["rm_scores"]] == [[0.5], [0.5]]
 
 
 @pytest.mark.asyncio
@@ -1012,52 +969,14 @@ async def test_async_trajectory_postprocessor_is_awaited(fake_tq):
 
 
 @pytest.mark.asyncio
-async def test_trajectory_postprocessor_runs_after_finalize_before_scoring_and_logging(monkeypatch, tmp_path, fake_tq):
-    class _OrderedGatewayManager(_FakeGatewayManager):
-        async def finalize_session(self, session_id: str):
-            trajectories = await super().finalize_session(session_id)
-            _POSTPROCESSOR_EVENTS.append("finalize")
-            return trajectories
-
-    _POSTPROCESSOR_EVENTS.clear()
-    runtime = _OrderedGatewayManager({"session-sample-0-rollout-0": [_trajectory()]})
-    framework = await _build_framework_with_agent_runners(
-        agent_runners={"runner": _inline_runner_config(_async_noop_runner)},
-        gateway_manager=runtime,
-        log_dir=str(tmp_path),
-        trajectory_postprocessor_fqn=f"{__name__}._ordered_trajectory_postprocessor",
-    )
-
-    def record_score(trajectories):
-        _POSTPROCESSOR_EVENTS.append("score")
-        return None
-
-    def record_summary(session_id, trajectories):
-        _POSTPROCESSOR_EVENTS.append("summary")
-
-    def record_dump(run_dir, session_id, trajectories):
-        _POSTPROCESSOR_EVENTS.append("dump")
-
-    monkeypatch.setattr(framework, "_score_from_reward_info", record_score)
-    monkeypatch.setattr(framework, "_log_trajectory_summary", record_summary)
-    monkeypatch.setattr(framework, "_dump_trajectories", record_dump)
-
-    await framework.generate_sequences(_build_prompts(count=1, global_steps=8))
-
-    assert _POSTPROCESSOR_EVENTS == ["finalize", "postprocess", "score", "summary", "dump"]
-
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("postprocessor_name", "error_type", "error_message"),
     [
         ("_tuple_trajectory_postprocessor", TypeError, r"must return list\[Trajectory\], got tuple"),
         ("_invalid_item_trajectory_postprocessor", TypeError, "returned a non-Trajectory item"),
-        ("_raising_trajectory_postprocessor", ValueError, "recipe policy failed"),
     ],
 )
 async def test_trajectory_postprocessor_reports_invalid_extensions(
-    fake_tq,
     postprocessor_name,
     error_type,
     error_message,
@@ -1073,16 +992,40 @@ async def test_trajectory_postprocessor_reports_invalid_extensions(
 
 
 @pytest.mark.asyncio
+async def test_trajectory_postprocessor_rejects_dropped_reward_info():
+    framework = await _build_framework_with_agent_runners(
+        agent_runners={"runner": _inline_runner_config(_async_noop_runner)},
+        gateway_manager=_FakeGatewayManager({}),
+        trajectory_postprocessor_fqn=f"{__name__}._dropping_reward_info_postprocessor",
+    )
+
+    with pytest.raises(ValueError, match="must preserve finalized reward_info"):
+        await framework._apply_trajectory_postprocessor([_trajectory(reward_info={"reward": 0.5, "finished": False})])
+
+
+@pytest.mark.asyncio
+async def test_framework_rejects_non_callable_trajectory_postprocessor():
+    with pytest.raises(TypeError, match="must resolve to a callable"):
+        await _build_framework_with_agent_runners(
+            agent_runners={"runner": _inline_runner_config(_async_noop_runner)},
+            gateway_manager=_FakeGatewayManager({}),
+            trajectory_postprocessor_fqn=f"{__name__}._NOT_CALLABLE_POSTPROCESSOR",
+        )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("postprocessor_name", "error_type", "error_message"),
+    ("postprocessor_fqn", "postprocessor_kwargs", "error_type", "error_message"),
     [
-        ("_NOT_CALLABLE_POSTPROCESSOR", TypeError, "must resolve to a callable"),
-        ("_missing_trajectory_postprocessor", AttributeError, "not found in module"),
+        ("   ", None, ValueError, "trajectory_postprocessor_fqn must be a non-empty string"),
+        (123, None, ValueError, "trajectory_postprocessor_fqn must be a non-empty string"),
+        (None, {"enabled": True}, ValueError, "requires trajectory_postprocessor_fqn"),
+        (f"{__name__}._recording_trajectory_postprocessor", [1], TypeError, "must be a mapping"),
     ],
 )
-async def test_framework_loads_trajectory_postprocessor_eagerly(
-    fake_tq,
-    postprocessor_name,
+async def test_framework_rejects_invalid_trajectory_postprocessor_config(
+    postprocessor_fqn,
+    postprocessor_kwargs,
     error_type,
     error_message,
 ):
@@ -1090,40 +1033,9 @@ async def test_framework_loads_trajectory_postprocessor_eagerly(
         await _build_framework_with_agent_runners(
             agent_runners={"runner": _inline_runner_config(_async_noop_runner)},
             gateway_manager=_FakeGatewayManager({}),
-            trajectory_postprocessor_fqn=f"{__name__}.{postprocessor_name}",
+            trajectory_postprocessor_fqn=postprocessor_fqn,
+            trajectory_postprocessor_kwargs=postprocessor_kwargs,
         )
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("postprocessor_fqn", "postprocessor_kwargs", "warning_message"),
-    [
-        ("", None, "trajectory_postprocessor_fqn must be a non-empty string"),
-        ("   ", None, "trajectory_postprocessor_fqn must be a non-empty string"),
-        (123, None, "trajectory_postprocessor_fqn must be a non-empty string"),
-        (None, {"enabled": True}, "trajectory_postprocessor_fqn is not set"),
-        (f"{__name__}._recording_trajectory_postprocessor", [1], "must be a mapping"),
-    ],
-)
-async def test_framework_warns_and_disables_invalid_trajectory_postprocessor_config(
-    fake_tq,
-    caplog,
-    postprocessor_fqn,
-    postprocessor_kwargs,
-    warning_message,
-):
-    caplog.set_level(logging.WARNING, logger="uni_agent.framework.framework")
-
-    framework = await _build_framework_with_agent_runners(
-        agent_runners={"runner": _inline_runner_config(_async_noop_runner)},
-        gateway_manager=_FakeGatewayManager({}),
-        trajectory_postprocessor_fqn=postprocessor_fqn,
-        trajectory_postprocessor_kwargs=postprocessor_kwargs,
-    )
-
-    assert framework._trajectory_postprocessor is None
-    assert framework._trajectory_postprocessor_kwargs == {}
-    assert warning_message in caplog.text
 
 
 @pytest.mark.asyncio
@@ -1158,18 +1070,18 @@ async def test_generate_sequences_keeps_successful_sessions_when_one_session_fai
 
 @pytest.mark.asyncio
 async def test_generate_sequences_marks_prompt_failure_when_all_sessions_fail(fake_tq):
-    """If every session for a validation prompt fails, the uid is marked
-    failed in TQ and ``generate_sequences`` raises the all-rollouts failure."""
+    """Filtering every session to empty marks the uid failed and raises."""
     runtime = _FakeGatewayManager(
         {
-            "session-sample-0-rollout-0": [],
-            "session-sample-0-rollout-1": [],
+            "session-sample-0-rollout-0": [_trajectory()],
+            "session-sample-0-rollout-1": [_trajectory()],
         }
     )
 
     framework = await _build_framework_with_agent_runners(
         agent_runners={"runner": _inline_runner_config(_async_noop_runner)},
         gateway_manager=runtime,
+        trajectory_postprocessor_fqn=f"{__name__}._empty_trajectory_postprocessor",
         n=1,
         val_n=2,
     )

--- a/uni_agent/framework/framework.py
+++ b/uni_agent/framework/framework.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
 import io
 import json
 import logging
 import os
 import random
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, replace
 from functools import partial
 from pathlib import Path
@@ -45,6 +47,9 @@ class AgentRunner(Protocol):
         sample_index: int,
         **sample_runner_kwargs: object,
     ) -> object: ...
+
+
+TrajectoryPostprocessor = Callable[..., list[Trajectory] | Awaitable[list[Trajectory]]]
 
 
 @dataclass
@@ -314,6 +319,8 @@ class OpenAICompatibleAgentFramework(AgentFramework):
         rollout_config=None,
         log_dir: str | None = None,
         mask_unfinished_episode: bool = False,
+        trajectory_postprocessor: TrajectoryPostprocessor | None = None,
+        trajectory_postprocessor_kwargs: dict[str, object] | None = None,
     ):
         self.gateway_manager = gateway_manager
         self.runner_registry = runner_registry
@@ -331,6 +338,8 @@ class OpenAICompatibleAgentFramework(AgentFramework):
         self._semaphore_loop: asyncio.AbstractEventLoop | None = None
         self._log_dir = log_dir
         self._mask_unfinished_episode = mask_unfinished_episode
+        self._trajectory_postprocessor = trajectory_postprocessor
+        self._trajectory_postprocessor_kwargs = trajectory_postprocessor_kwargs or {}
 
     @classmethod
     def from_config(
@@ -364,6 +373,34 @@ class OpenAICompatibleAgentFramework(AgentFramework):
         if type(mask_unfinished_episode) is not bool:
             raise ValueError("actor_rollout_ref.rollout.custom.agent_framework.mask_unfinished_episode must be a bool")
 
+        postprocessor_fqn = af_cfg.get("trajectory_postprocessor_fqn")
+        postprocessor_kwargs = af_cfg.get("trajectory_postprocessor_kwargs")
+        if postprocessor_kwargs is None:
+            postprocessor_kwargs = {}
+        elif OmegaConf.is_config(postprocessor_kwargs):
+            postprocessor_kwargs = OmegaConf.to_container(postprocessor_kwargs, resolve=True)
+
+        trajectory_postprocessor = None
+        trajectory_postprocessor_kwargs = {}
+        if postprocessor_fqn is not None and (not isinstance(postprocessor_fqn, str) or not postprocessor_fqn.strip()):
+            logger.warning("Ignoring trajectory postprocessor: trajectory_postprocessor_fqn must be a non-empty string")
+        elif not isinstance(postprocessor_kwargs, dict):
+            logger.warning("Ignoring trajectory postprocessor: trajectory_postprocessor_kwargs must be a mapping")
+        elif postprocessor_fqn is None:
+            if postprocessor_kwargs:
+                logger.warning(
+                    "Ignoring trajectory_postprocessor_kwargs because trajectory_postprocessor_fqn is not set"
+                )
+        else:
+            postprocessor_fqn = postprocessor_fqn.strip()
+            trajectory_postprocessor = load_class_from_fqn(
+                postprocessor_fqn,
+                description="trajectory postprocessor",
+            )
+            if not callable(trajectory_postprocessor):
+                raise TypeError(f"Trajectory postprocessor {postprocessor_fqn!r} must resolve to a callable")
+            trajectory_postprocessor_kwargs = dict(postprocessor_kwargs)
+
         return cls(
             gateway_manager=gateway_manager,
             runner_registry=runner_registry,
@@ -372,7 +409,24 @@ class OpenAICompatibleAgentFramework(AgentFramework):
             rollout_config=config.actor_rollout_ref.rollout,
             log_dir=log_dir,
             mask_unfinished_episode=mask_unfinished_episode,
+            trajectory_postprocessor=trajectory_postprocessor,
+            trajectory_postprocessor_kwargs=trajectory_postprocessor_kwargs,
         )
+
+    async def _apply_trajectory_postprocessor(
+        self,
+        trajectories: list[Trajectory],
+    ) -> list[Trajectory]:
+        """Apply the optional sync/async postprocessor and validate its result."""
+        result = self._trajectory_postprocessor(tuple(trajectories), **self._trajectory_postprocessor_kwargs)
+        if inspect.isawaitable(result):
+            result = await result
+
+        if not isinstance(result, list):
+            raise TypeError(f"trajectory postprocessor must return list[Trajectory], got {type(result).__name__}")
+        if any(not isinstance(trajectory, Trajectory) for trajectory in result):
+            raise TypeError("trajectory postprocessor returned a non-Trajectory item")
+        return result
 
     def _build_session_sampling_params(
         self,
@@ -738,6 +792,9 @@ class OpenAICompatibleAgentFramework(AgentFramework):
                 logger.exception("session %s failed (runner=%s); aborting session", session_id, runner_name)
                 await self.gateway_manager.abort_session(session_id)
                 raise
+
+            if self._trajectory_postprocessor is not None:
+                session_trajectories = await self._apply_trajectory_postprocessor(session_trajectories)
 
             if not session_trajectories:
                 return session_trajectories, sample_fields

--- a/uni_agent/framework/framework.py
+++ b/uni_agent/framework/framework.py
@@ -9,6 +9,7 @@ import logging
 import os
 import random
 from collections.abc import Awaitable, Callable
+from copy import deepcopy
 from dataclasses import dataclass, replace
 from functools import partial
 from pathlib import Path
@@ -382,16 +383,14 @@ class OpenAICompatibleAgentFramework(AgentFramework):
 
         trajectory_postprocessor = None
         trajectory_postprocessor_kwargs = {}
-        if postprocessor_fqn is not None and (not isinstance(postprocessor_fqn, str) or not postprocessor_fqn.strip()):
-            logger.warning("Ignoring trajectory postprocessor: trajectory_postprocessor_fqn must be a non-empty string")
-        elif not isinstance(postprocessor_kwargs, dict):
-            logger.warning("Ignoring trajectory postprocessor: trajectory_postprocessor_kwargs must be a mapping")
-        elif postprocessor_fqn is None:
+        if postprocessor_fqn is None:
             if postprocessor_kwargs:
-                logger.warning(
-                    "Ignoring trajectory_postprocessor_kwargs because trajectory_postprocessor_fqn is not set"
-                )
+                raise ValueError("trajectory_postprocessor_kwargs requires trajectory_postprocessor_fqn")
         else:
+            if not isinstance(postprocessor_fqn, str) or not postprocessor_fqn.strip():
+                raise ValueError("trajectory_postprocessor_fqn must be a non-empty string")
+            if not isinstance(postprocessor_kwargs, dict):
+                raise TypeError("trajectory_postprocessor_kwargs must be a mapping")
             postprocessor_fqn = postprocessor_fqn.strip()
             trajectory_postprocessor = load_class_from_fqn(
                 postprocessor_fqn,
@@ -418,6 +417,7 @@ class OpenAICompatibleAgentFramework(AgentFramework):
         trajectories: list[Trajectory],
     ) -> list[Trajectory]:
         """Apply the optional sync/async postprocessor and validate its result."""
+        expected_reward_info = deepcopy(trajectories[-1].reward_info) if trajectories else {}
         result = self._trajectory_postprocessor(tuple(trajectories), **self._trajectory_postprocessor_kwargs)
         if inspect.isawaitable(result):
             result = await result
@@ -426,6 +426,8 @@ class OpenAICompatibleAgentFramework(AgentFramework):
             raise TypeError(f"trajectory postprocessor must return list[Trajectory], got {type(result).__name__}")
         if any(not isinstance(trajectory, Trajectory) for trajectory in result):
             raise TypeError("trajectory postprocessor returned a non-Trajectory item")
+        if any(trajectory.reward_info != expected_reward_info for trajectory in result):
+            raise ValueError("trajectory postprocessor must preserve finalized reward_info")
         return result
 
     def _build_session_sampling_params(


### PR DESCRIPTION
## Summary

Add a narrow, opt-in Framework extension point for use-case-specific trajectory filtering, cropping, replacement, and ordering. The hook receives finalized Gateway trajectories after the Runner's built-in `trajectory_selection` and
runs before reward scoring, artifact logging, unfinished masking, and TransferQueue materialization.

## Changes

- Add optional `trajectory_postprocessor_fqn` and `trajectory_postprocessor_kwargs` Framework configuration.
- Resolve the callable when the Agent Framework starts. Invalid explicit configuration, import failures, and non-callable targets fail before rollout work begins.
- Call the extension as `postprocessor(tuple(trajectories), **trajectory_postprocessor_kwargs)`.
- Support synchronous and asynchronous processors.
- Require `list[Trajectory]` as the result. An empty list filters that session, and returned trajectories must preserve the finalized session `reward_info`.
- Document the callable contract, execution order, compatibility, and TransferQueue boundary.
- Add focused CPU coverage for sync and async execution, keyword forwarding, ordering before scoring and TransferQueue output, empty filtering, strict validation, and `reward_info` preservation.

## Configuration and API

```yaml
actor_rollout_ref:
  rollout:
    custom:
      agent_framework:
        trajectory_postprocessor_fqn: my_recipe.trajectory.process_trajectories
        trajectory_postprocessor_kwargs:
          max_total_tokens: 262144  # 256K prompt + response tokens
```

```python
from uni_agent.gateway.session import Trajectory


def process_trajectories(
    trajectories: tuple[Trajectory, ...],
    *,
    max_total_tokens: int = 262_144,
) -> list[Trajectory]:
    return [
        trajectory
        for trajectory in trajectories
        if len(trajectory.prompt_ids) + len(trajectory.response_ids)
        <= max_total_tokens
    ]
```

`max_total_tokens` belongs to this example processor; it is not a built-in Framework option. A processor that crops instead of filters must preserve token array alignment, valid turn boundaries, and the finalized `reward_info`. Use
`dataclasses.replace` when constructing transformed trajectories so unrelated fields remain intact.

## Compatibility

Omitting `trajectory_postprocessor_fqn`, or setting it to `null`, preserves the original path: no extension is imported or called.

A configured FQN must be a non-empty string, and its kwargs must be a mapping. Non-empty kwargs without an FQN, import failures, and non-callable targets are Framework initialization errors. Processor execution errors, invalid return values, and changes to finalized `reward_info` also fail explicitly.

## Validation

Validated on Ubuntu with Python 3.11 against `28174fdab3787d307ae3a96d32d3737b600575a0`.

```bash
python -m pytest -q tests/uni_agent/framework/test_generate_sequences_on_cpu.py
# 38 passed, 4 warnings in 33.55s

python -m ruff check uni_agent/framework/framework.py tests/uni_agent/framework/test_generate_sequences_on_cpu.py

python -m ruff format --check uni_agent/framework/framework.py tests/uni_agent/framework/test_generate_sequences_on_cpu.py
```

The focused CPU test, Ruff check, and format check passed. Third-party warnings, if any, did not cause test failures or skips.

## Checklist

- [x] Tests cover sync and async execution, keyword forwarding, ordering, empty filtering, strict configuration and result validation, and finalized `reward_info` preservation.
- [x] The configuration and callable contract are documented with an example.
- [x] Existing configurations remain unaffected unless `trajectory_postprocessor_fqn` is explicitly configured.
- [x] Logs, fixtures, and examples contain no credentials or private data.
- [x] The focused CPU test passes (`38 passed`).
- [x] The focused Ruff check and format check pass.