### PR TITLE
[BREAKING][framework, docs] feat: pass task results to trajectory postprocessors

### DIFF
--- a/docs/source/concepts/gateway-and-trajectories.md
+++ b/docs/source/concepts/gateway-and-trajectories.md
@@ -93,11 +93,13 @@ Framework initialization. The callable must follow this contract:
 
 ```python
 from uni_agent.gateway.session import Trajectory
+from uni_agent.tasks import TaskResult
 
 
 def process_trajectories(
     trajectories: tuple[Trajectory, ...],
     *,
+    task_result: TaskResult,
     max_total_tokens: int = 262_144,
 ) -> list[Trajectory]:
     return [
@@ -107,19 +109,24 @@ def process_trajectories(
     ]
 ```
 
-`trajectory_postprocessor_kwargs` is passed as keyword arguments. The processor
-receives a tuple and must return `list[Trajectory]`; returning an empty list
-filters the session out. An `async def` processor is also supported and is
-awaited. Returned trajectories must preserve the finalized session
-`reward_info` and keep their token arrays aligned because reward scoring,
-unfinished masking, and TransferQueue materialization run later. Use
-`dataclasses.replace` when constructing transformed trajectories so unrelated
-fields remain intact.
+The processor receives a trajectory tuple and must return `list[Trajectory]`;
+returning an empty list filters the session out. An `async def` processor is
+also supported and is awaited. Returned trajectories must preserve the finalized
+session `finished`, `reward_score`, and `reward_metrics` fields and keep their
+token arrays aligned because reward scoring, unfinished masking, and
+TransferQueue materialization run later. Use `dataclasses.replace` when
+constructing transformed trajectories so unrelated fields remain intact.
 
+The Framework automatically passes a deep copy of the Runner's `TaskResult` to
+the postprocessor as the `task_result` keyword argument. Use `task_result.extra_info`
+to access task context. Modifying this copy does not affect the original result
+or later scoring. `trajectory_postprocessor_kwargs` supplies additional keyword
+arguments; do not include `task_result` in this configuration.
+
+A processor may define additional keyword arguments or just accept `task_result`.
 `max_total_tokens` above is defined by the example processor.
 This compact example drops oversized trajectories; a processor that
-crops them must preserve token-array alignment and valid turn boundaries. A
-processor may define different keyword arguments or none at all.
+crops them must preserve token-array alignment and valid turn boundaries.
 
 The hook is disabled when `trajectory_postprocessor_fqn` is omitted or `null`.
 In that case no extension is imported or called, and finalized trajectories
@@ -180,13 +187,13 @@ The result fields have separate contracts:
 - `reward` is the Runner's scalar outcome reward. A streaming Worker receives it as scorer input and decides the final score.
 - `accuracy` becomes the Runner-provided `acc` validation metric.
 - `finished` is a tri-state episode fact, not a validation metric.
-- `extra_info` may contain structured scorer input. A streaming Worker receives it as `extra_info["runner_reward_info"]["reward_context"]`; it is never aggregated directly as a validation metric.
+- `extra_info` is available to postprocessors through the copied `TaskResult` and may contain structured scorer input. A streaming Worker receives it as `extra_info["runner_reward_info"]["reward_context"]`; it is never aggregated directly as a validation metric.
 
 The names at the two boundaries are intentional: `Trajectory.reward_metrics` is
 the Framework's internal field, while VERL's Worker response calls the same
 output channel `reward_extra_info` when it is serialized under
 `extra_fields["reward_extra_info"]`. `TaskResult.extra_info` is a separate
-Runner-to-scorer context channel and is not copied into either metrics field.
+context channel and is not copied into either metrics field.
 
 Runner and Worker metrics are not merged in streaming mode. The Worker's
 `reward_extra_info` is the complete final metric/metadata set returned by the

--- a/docs/source/concepts/task-and-reward.md
+++ b/docs/source/concepts/task-and-reward.md
@@ -152,11 +152,16 @@ TaskResult(
 Custom Tasks may use any evaluation method, but the built-in Agent Runner currently
 expects `TaskResult.reward` to be a scalar outcome reward. `TaskResult.accuracy`
 becomes the validation metric `acc`; `extra_info` becomes the structured
-`runner_reward_info.reward_context` payload and is not aggregated as a metric. When streaming Reward Loop
-Worker handles are available, the Framework passes the complete Runner result
-under `extra_info["runner_reward_info"]` to a configured custom scorer. Without
-such a scorer, a non-`None` Runner reward is used directly and the Worker is
-consulted only when the Runner did not return a reward. Custom Agent Runners return `TaskResult` when they provide episode
+`runner_reward_info.reward_context` payload and is not aggregated as a metric.
+A trajectory postprocessor receives a deep copy of `TaskResult` as the
+`task_result` keyword argument. It can inspect or modify this copy without
+affecting subsequent scoring. Returned trajectories must preserve their
+`finished`, `reward_score`, and `reward_metrics` fields.
+When streaming Reward Loop Worker handles are available, the Framework passes
+the complete Runner result under `extra_info["runner_reward_info"]` to a
+configured custom scorer. Without such a scorer, a non-`None` Runner reward is
+used directly and the Worker is consulted only when the Runner did not return
+a reward. Custom Agent Runners return `TaskResult` when they provide episode
 annotations. A trajectory-only Runner may return `None`, which the Framework
 normalizes to an empty `TaskResult()` before trajectory scoring.
 

--- a/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
+++ b/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import types
+from copy import deepcopy
 from dataclasses import replace
 
 import numpy as np
@@ -21,34 +22,39 @@ _POSTPROCESSOR_CALLS = []
 _NOT_CALLABLE_POSTPROCESSOR = 42
 
 
-def _recording_trajectory_postprocessor(trajectories, *, policy=None):
+def _recording_trajectory_postprocessor(trajectories, *, task_result, policy=None):
     _POSTPROCESSOR_CALLS.append((trajectories, policy))
     return list(reversed(trajectories))
 
 
-async def _async_trajectory_postprocessor(trajectories):
+async def _async_trajectory_postprocessor(trajectories, *, task_result):
+    assert task_result == TaskResult()
     await asyncio.sleep(0)
     return list(trajectories[-1:])
 
 
-def _recording_reward_postprocessor(trajectories):
-    _POSTPROCESSOR_CALLS.append(tuple(trajectories))
+def _mutating_task_result_postprocessor(trajectories, *, task_result):
+    _POSTPROCESSOR_CALLS.append((trajectories, task_result))
+    task_result.reward = -1.0
+    task_result.accuracy = -1.0
+    task_result.finished = not task_result.finished
+    task_result.extra_info["nested"]["values"].append(-1)
     return list(trajectories)
 
 
-def _empty_trajectory_postprocessor(_trajectories):
+def _empty_trajectory_postprocessor(_trajectories, *, task_result):
     return []
 
 
-def _tuple_trajectory_postprocessor(trajectories):
+def _tuple_trajectory_postprocessor(trajectories, *, task_result):
     return tuple(trajectories)
 
 
-def _invalid_item_trajectory_postprocessor(trajectories):
+def _invalid_item_trajectory_postprocessor(trajectories, *, task_result):
     return ["not-a-trajectory"]
 
 
-def _dropping_finalized_field_postprocessor(trajectories, *, field):
+def _dropping_finalized_field_postprocessor(trajectories, *, task_result, field):
     replacement = {} if field == "reward_metrics" else None
     return [replace(trajectories[-1], **{field: replacement})]
 
@@ -624,32 +630,39 @@ async def test_runner_reward_is_used_without_custom_scorer_even_when_worker_exis
 @pytest.mark.cpu
 @pytest.mark.level0
 @pytest.mark.asyncio
-async def test_postprocessor_sees_runner_annotations_before_scoring():
+@pytest.mark.parametrize("reward", [0.75, None], ids=["runner-reward", "no-reward"])
+async def test_postprocessor_task_result_is_isolated_from_runner_and_tq(reward, fake_tq):
     _POSTPROCESSOR_CALLS.clear()
+    task_result = TaskResult(
+        reward=reward,
+        accuracy=0.5,
+        finished=False,
+        extra_info={"nested": {"values": [1]}, "tags": {"test"}},
+    )
+    original = deepcopy(task_result)
 
     async def result_runner(**kwargs):
-        return TaskResult(reward=0.75, accuracy=0.5, finished=False)
+        return task_result
 
     framework = await _build_framework_with_agent_runners(
         agent_runners={"runner": _inline_runner_config(result_runner)},
         gateway_manager=_FakeGatewayManager({"session-sample-0-rollout-0": [_trajectory()]}),
-        trajectory_postprocessor_fqn=f"{__name__}._recording_reward_postprocessor",
+        trajectory_postprocessor_fqn=f"{__name__}._mutating_task_result_postprocessor",
     )
 
-    await framework._run_agent_episode(
-        sample_fields={"raw_prompt": [], "uid": "uid-0"},
-        sample_index=0,
-        session_index=0,
-        global_steps=7,
-        runner_name="runner",
-        runner_config=framework.runner_registry["runner"],
-        sampling_params={},
-    )
+    await framework.generate_sequences(_build_prompts(count=1, global_steps=7))
 
-    processed = _POSTPROCESSOR_CALLS[0]
-    assert [(trajectory.reward_score, trajectory.reward_metrics, trajectory.finished) for trajectory in processed] == [
-        (0.75, {"acc": 0.5}, False)
+    processed, copied_result = _POSTPROCESSOR_CALLS[0]
+    assert copied_result is not task_result
+    assert copied_result.extra_info["nested"]["values"] == [1, -1]
+    assert copied_result.extra_info["tags"] == original.extra_info["tags"]
+    assert task_result == original
+    assert [(traj.reward_score, traj.reward_metrics, traj.finished) for traj in processed] == [
+        (reward, {"acc": 0.5}, False)
     ]
+    fields = fake_tq.batch_puts[0]["fields"]
+    assert tu.get(fields, "extra_fields")[0]["reward_extra_info"] == {"acc": 0.5}
+    assert fields["rm_scores"][0].sum().item() == (reward or 0.0)
 
 
 @pytest.mark.cpu
@@ -673,7 +686,7 @@ async def test_reward_worker_processes_runner_reward_info_and_owns_final_metrics
             reward=0.5,
             accuracy=1.0,
             finished=True,
-            extra_info={"case_id": "case-1"},
+            extra_info={"case_id": "case-1", "nested": {"values": [1]}},
         )
 
     worker = _Worker()
@@ -683,6 +696,7 @@ async def test_reward_worker_processes_runner_reward_info_and_owns_final_metrics
         gateway_manager=runtime,
         reward_loop_worker_handles=[worker],
         reward_config={"custom_reward_function": {"path": "pkg://custom_reward.py"}},
+        trajectory_postprocessor_fqn=f"{__name__}._mutating_task_result_postprocessor",
     )
 
     trajectories, _ = await framework._run_agent_episode(
@@ -701,7 +715,7 @@ async def test_reward_worker_processes_runner_reward_info_and_owns_final_metrics
             "runner_reward_info": {
                 "reward": 0.5,
                 "metrics": {"acc": 1.0},
-                "reward_context": {"case_id": "case-1"},
+                "reward_context": {"case_id": "case-1", "nested": {"values": [1]}},
             },
         }
     ]
@@ -1536,7 +1550,7 @@ async def test_trajectory_postprocessor_reports_invalid_extensions(
     )
 
     with pytest.raises(error_type, match=error_message):
-        await framework._apply_trajectory_postprocessor([_trajectory()])
+        await framework._apply_trajectory_postprocessor([_trajectory()], TaskResult())
 
 
 @pytest.mark.cpu
@@ -1553,7 +1567,7 @@ async def test_trajectory_postprocessor_rejects_dropped_finalized_fields(field):
 
     with pytest.raises(ValueError, match="must preserve finalized reward fields"):
         await framework._apply_trajectory_postprocessor(
-            [_trajectory(reward_score=0.5, reward_metrics={"acc": 1.0}, finished=False)]
+            [_trajectory(reward_score=0.5, reward_metrics={"acc": 1.0}, finished=False)], TaskResult()
         )
 
 

--- a/uni_agent/framework/framework.py
+++ b/uni_agent/framework/framework.py
@@ -430,6 +430,7 @@ class GatewayAgentFramework(AgentFramework):
     async def _apply_trajectory_postprocessor(
         self,
         trajectories: list[Trajectory],
+        task_result: TaskResult,
     ) -> list[Trajectory]:
         """Apply the optional sync/async postprocessor and validate its result."""
         expected_reward_fields = (
@@ -441,7 +442,9 @@ class GatewayAgentFramework(AgentFramework):
             if trajectories
             else (None, None, {})
         )
-        result = self._trajectory_postprocessor(tuple(trajectories), **self._trajectory_postprocessor_kwargs)
+        result = self._trajectory_postprocessor(
+            tuple(trajectories), task_result=deepcopy(task_result), **self._trajectory_postprocessor_kwargs
+        )
         if inspect.isawaitable(result):
             result = await result
 
@@ -857,20 +860,20 @@ class GatewayAgentFramework(AgentFramework):
             # they filter or reorder trajectories.  These fields are the
             # Framework-owned trajectory representation of the session result;
             # scorer metadata remains a separate Worker output channel.
+            task_metrics = {} if task_result.accuracy is None else {"acc": task_result.accuracy}
             if session_trajectories:
-                runner_metrics = {} if task_result.accuracy is None else {"acc": task_result.accuracy}
                 session_trajectories = [
                     replace(
                         trajectory,
                         finished=task_result.finished,
                         reward_score=task_result.reward,
-                        reward_metrics=dict(runner_metrics),
+                        reward_metrics=dict(task_metrics),
                     )
                     for trajectory in session_trajectories
                 ]
 
             if self._trajectory_postprocessor is not None:
-                session_trajectories = await self._apply_trajectory_postprocessor(session_trajectories)
+                session_trajectories = await self._apply_trajectory_postprocessor(session_trajectories, task_result)
 
             if not session_trajectories:
                 session_trace.finish(
@@ -897,17 +900,9 @@ class GatewayAgentFramework(AgentFramework):
                 annotations = None
                 reward_source = None
 
-            task_metrics = {} if task_result.accuracy is None else {"acc": task_result.accuracy}
             if annotations is None:
                 logger.info("session %s: Framework produced no reward; rm_scores remain zero", session_id)
-                result_trajectories = [
-                    replace(
-                        traj,
-                        finished=task_result.finished,
-                        reward_metrics=dict(task_metrics),
-                    )
-                    for traj in session_trajectories
-                ]
+                result_trajectories = session_trajectories
             else:
                 logger.info("session %s: scored via %s", session_id, reward_source)
                 result_trajectories = [


### PR DESCRIPTION
﻿## Summary

Trajectory postprocessors need task context such as verifier details to select or transform trajectories. Pass a deep copy of the Runner's `TaskResult` directly to each postprocessor as the `task_result` keyword argument. Context stays separate from validation metrics, and modifying the copy does not change the original Runner result or subsequent Worker input.

## Changes

- Deep-copy `TaskResult` once when invoking the configured postprocessor; support both sync and async hooks.
- Keep Runner `reward_metrics` limited to canonical `acc`. Do not forward `extra_info` into metrics or apply JSON/64 KiB filtering to postprocessor context.
- Preserve the original scorer input contract, including `runner_reward_info.reward_context`.
- Reuse the canonical metrics within the episode and retain validated postprocessed trajectories directly when no scoring result is available.
- Update existing tests to cover mutation isolation for scalar fields and nested data, structured context, unchanged Worker input, and the absence of task context in TQ reward metrics.

## Compatibility

Existing postprocessors must accept the new keyword argument, even if unused:

```python
def process_trajectories(trajectories, *, task_result, **kwargs):
    metadata = task_result.extra_info
    return list(trajectories)
```

The Framework supplies `task_result`; do not configure it in `trajectory_postprocessor_kwargs`. The result must support deep copying. Copy failures propagate rather than falling back to the original object. Returned trajectories must still preserve `finished`, `reward_score`, and `reward_metrics`. The hook remains optional, and no task-result copy is made when it is disabled.

## Validation

- `python -m pytest tests/uni_agent/framework/test_generate_sequences_on_cpu.py -q`: **62 passed**, one third-party Ray deprecation warning.
- `uvx --from pre-commit pre-commit run --all-files --show-diff-on-failure`: **passed** (Ruff lint/format, mypy, compileall).
- `mkdocs build --strict`: **passed**, using the repository's documentation dependency ranges and a temporary output directory.
- `git diff --check`: **passed**.

Local tests ran on Windows with Python 3.13 and installed dependencies; they do not replace the repository's Python 3.11/3.12 CI runs.

