### PR TITLE
[build] fix: read version from nested verl package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ ignore_errors = false
 include-package-data = true
 
 [tool.setuptools.dynamic]
-version = {file = "verl/version/version"}
+version = {file = "verl/verl/version/version"}
 
 [tool.setuptools.package-dir]
 "" = "."


### PR DESCRIPTION
## Summary

Fix package builds that silently fell back to version `0.0.0` because the configured dynamic-version file did not exist in the pinned `verl` submodule layout.

Fixes #148.

## Changes

- Point setuptools at `verl/verl/version/version`, where the pinned submodule stores its version.

## Validation

- `python -m build --sdist --wheel --outdir <temporary-directory>`
  - Built `uni_agent-0.9.0.dev0.tar.gz`.
  - Built `uni_agent-0.9.0.dev0-py3-none-any.whl`.
  - Wheel `METADATA` contains `Version: 0.9.0.dev0`.
- `python -m pytest -q tests/special_sanity`
  - 15 passed, 19 subtests passed.
- `git diff --check`

## Compatibility

No API, dependency, service, or runtime behavior changes. The only visible change is that package metadata now uses the pinned `verl` version instead of the unintended setuptools fallback `0.0.0`.

## Checklist

- [x] The PR is focused and linked to an issue or explains why no issue is needed.
- [x] The title follows the required format and names the owning layer.
- [x] Validation covers the behavior.
- [x] Compatibility impact is documented.
- [x] Logs and examples contain no credentials or private data.
- [ ] `pre-commit run --all-files --show-diff-on-failure` passes (not run because the repository's fixing hooks would modify unrelated files; focused build, special-sanity, and diff checks are listed above).