### PR TITLE
[framework] fix: emit reward=0 trajectory for failed validation sessions

### DIFF
--- a/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
+++ b/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
@@ -1045,7 +1045,8 @@ async def test_framework_rejects_invalid_trajectory_postprocessor_config(
 
 @pytest.mark.asyncio
 async def test_generate_sequences_keeps_successful_sessions_when_one_session_fails(fake_tq):
-    """A failed rollout session aborts only that session; other successful
+    """A failed train session aborts only that session and emits a reward=0
+    dummy so it stays in the ``reward/mean`` denominator; other successful
     sessions for the same prompt are still finalized and written to TQ."""
     runtime = _FakeGatewayManager(
         {
@@ -1067,10 +1068,92 @@ async def test_generate_sequences_keeps_successful_sessions_when_one_session_fai
 
     await framework.generate_sequences(_build_prompts(count=1, global_steps=8))
 
-    assert fake_tq.batch_puts[0]["keys"] == ["uid-0_0_0"]
+    # Successful session writes its real trajectory ...
+    success_batch = next(b for b in fake_tq.batch_puts if b["keys"] == ["uid-0_0_0"])
+    assert success_batch["partition_id"] == "train"
+    assert success_batch["fields"]["responses"][0].tolist() == [20, 21]
+
+    # ... and the failed session writes a masked reward=0 dummy (response_mask=0).
+    dummy_batch = next(b for b in fake_tq.batch_puts if b["keys"] == ["uid-0_1_0"])
+    assert dummy_batch["partition_id"] == "train"
+    assert dummy_batch["fields"]["responses"][0].tolist() == [0]
+    assert dummy_batch["fields"]["response_mask"][0].tolist() == [0]
+    assert dummy_batch["fields"]["rm_scores"][0].tolist() == [0.0]
+    assert dummy_batch["tags"][0]["materialization_reason"] == "session_failed"
+
     assert fake_tq.puts == [{"key": "uid-0", "partition_id": "train", "tag": {"status": "finished"}}]
     assert len(runtime.aborted_sessions) == 1
     assert runtime.aborted_sessions[0].startswith("session-sample-0-rollout-1-")
+
+
+@pytest.mark.asyncio
+async def test_val_failure_writes_reward_zero_trajectory_to_keep_denominator_honest(fake_tq):
+    """A failed val session is aborted (its partial output discarded) and a
+    masked reward=0 dummy is written to the val TQ in its place, so the sample
+    stays in the ``reward/mean@1`` denominator as a zero instead of vanishing
+    and inflating the reported score.
+
+    Mirrors the partial-failure case the fix targets: one session succeeds with
+    a real reward, one crashes mid-rollout — both land in the val TQ and the
+    uid is marked finished so the val scorer still reads it. The dummy carries
+    ``response_mask=0`` so it adds no gradient; val and train handle failures
+    the same way (see the train test above), keeping critic and val consistent.
+    """
+    runtime = _FakeGatewayManager(
+        {
+            # Successful session: real reward, finished.
+            "session-sample-0-rollout-0": [
+                _trajectory(
+                    response_ids=[20, 21],
+                    reward_info={"reward": 0.8, "finished": True},
+                )
+            ],
+            # Failed session: gateway may have produced a partial trajectory, but
+            # the failure path aborts (discards it) and writes a dummy instead.
+            "session-sample-0-rollout-1": [
+                _trajectory(
+                    response_ids=[30, 31, 32],
+                    response_mask=[1, 1, 1],
+                    reward_info={"acc": 0.4, "reward": 0.9, "finished": True},
+                    num_turns=2,
+                )
+            ],
+        }
+    )
+
+    async def agent_runner(*, session, **kwargs):
+        if session.session_id.startswith("session-sample-0-rollout-1-"):
+            raise RuntimeError("runner crashed mid-rollout")
+
+    framework = await _build_framework_with_agent_runners(
+        agent_runners={"runner": _inline_runner_config(agent_runner)},
+        gateway_manager=runtime,
+        n=2,
+        val_n=2,
+    )
+
+    await framework.generate_sequences(_build_prompts(count=1, global_steps=None, validate=True))
+
+    # The successful session's real-reward trajectory ...
+    success_batch = next(b for b in fake_tq.batch_puts if b["keys"] == ["uid-0_0_0"])
+    assert success_batch["partition_id"] == "val"
+    assert success_batch["fields"]["responses"][0].tolist() == [20, 21]
+    assert success_batch["fields"]["rm_scores"][0].tolist() == pytest.approx([0.0, 0.8])
+
+    # ... and the failed session's masked reward=0 dummy both land in the val TQ.
+    dummy_batch = next(b for b in fake_tq.batch_puts if b["keys"] == ["uid-0_1_0"])
+    assert dummy_batch["partition_id"] == "val"
+    assert dummy_batch["fields"]["responses"][0].tolist() == [0]
+    assert dummy_batch["fields"]["response_mask"][0].tolist() == [0]
+    assert dummy_batch["fields"]["rm_scores"][0].tolist() == [0.0]
+    assert dummy_batch["tags"][0]["materialization_reason"] == "session_failed"
+
+    # The failed session was aborted (partial output discarded, not salvaged).
+    assert any(sid.startswith("session-sample-0-rollout-1-") for sid in runtime.aborted_sessions)
+    assert all(not sid.startswith("session-sample-0-rollout-1-") for sid in runtime.finalized_sessions)
+
+    # Partial failure still marks the uid finished so the val scorer reads it.
+    assert fake_tq.puts == [{"key": "uid-0", "partition_id": "val", "tag": {"status": "finished"}}]
 
 
 @pytest.mark.asyncio
@@ -1140,7 +1223,18 @@ async def test_generate_sequences_keeps_other_prompts_when_one_prompt_fails(fake
 
     await framework.generate_sequences(_build_prompts(count=2, global_steps=11))
 
-    assert [put["keys"] for put in fake_tq.batch_puts] == [["uid-1_0_0"]]
+    # The failed prompt emits a masked reward=0 dummy; the other prompt's
+    # successful session still writes its real trajectory. Order is not fixed
+    # (prompts run concurrently), so look each up by key.
+    dummy_batch = next(b for b in fake_tq.batch_puts if b["keys"] == ["uid-0_0_0"])
+    assert dummy_batch["partition_id"] == "train"
+    assert dummy_batch["fields"]["response_mask"][0].tolist() == [0]
+    assert dummy_batch["fields"]["rm_scores"][0].tolist() == [0.0]
+    assert dummy_batch["tags"][0]["materialization_reason"] == "session_failed"
+
+    success_batch = next(b for b in fake_tq.batch_puts if b["keys"] == ["uid-1_0_0"])
+    assert success_batch["fields"]["responses"][0].tolist() == [20, 21]
+
     assert sorted(fake_tq.puts, key=lambda put: put["key"]) == [
         {"key": "uid-0", "partition_id": "train", "tag": {"status": "failure"}},
         {"key": "uid-1", "partition_id": "train", "tag": {"status": "finished"}},

--- a/uni_agent/framework/framework.py
+++ b/uni_agent/framework/framework.py
@@ -183,6 +183,13 @@ def _select_session_trajectories(
     return [trajectory]
 
 
+# Inert placeholder token id for failed-session dummy trajectories. Its value is
+# semantically irrelevant: the dummy carries ``response_mask=0`` so it is never
+# trained (policy/value) and only its non-zero ``response_length`` matters for
+# keeping the failed sample in the val ``reward/mean`` denominator as a zero.
+_DUMMY_TOKEN_ID = 0
+
+
 _TQ_NESTED_SEQUENCE_FIELDS = {
     "prompts",
     "responses",
@@ -599,6 +606,15 @@ class OpenAICompatibleAgentFramework(AgentFramework):
             if isinstance(outcome, Exception):
                 failed_sessions += 1
                 failure_reasons.append(_short_failure_reason(outcome))
+                # The session was aborted inside _run_session; emit a reward=0
+                # dummy so the failed sample stays in the reward/mean denominator
+                # as a zero instead of vanishing and inflating the reported score.
+                await self._write_failure_dummy_trajectory(
+                    session_index=session_index,
+                    sample_fields=sample_fields,
+                    global_steps=global_steps,
+                    partition_id=partition_id,
+                )
                 continue
             # Propagate control-flow exceptions such as CancelledError/SystemExit;
             # only ordinary Exceptions are treated as isolated rollout failures.
@@ -813,6 +829,8 @@ class OpenAICompatibleAgentFramework(AgentFramework):
                 raise
             except Exception:
                 logger.exception("session %s failed (runner=%s); aborting session", session_id, runner_name)
+                # Tear down the live session; the caller emits a reward=0 dummy
+                # so the failed sample stays in the reward/mean denominator.
                 await self.gateway_manager.abort_session(session_id)
                 session_trace.finish(
                     runner_name=runner_name,
@@ -865,6 +883,53 @@ class OpenAICompatibleAgentFramework(AgentFramework):
                 finished=result_trajectories[0].reward_info.get("finished") if result_trajectories else None,
             )
             return result_trajectories, sample_fields
+
+    async def _write_failure_dummy_trajectory(
+        self,
+        *,
+        session_index: int,
+        sample_fields: dict[str, object],
+        global_steps: int | None,
+        partition_id: str,
+    ) -> None:
+        """Emit a reward=0 placeholder trajectory for a failed session.
+
+        A failed rollout's partial output has undefined correctness, so the
+        session was aborted inside ``_run_session`` and the caller emits a
+        minimal dummy here instead: one prompt + one response token with
+        ``response_mask=0`` and ``reward=0``. The mask keeps it out of the
+        policy/value gradient (train/critic), while its non-zero
+        ``response_length`` keeps it in the val ``reward/mean`` denominator as
+        a zero — failed samples no longer vanish and inflate the reported
+        score. Uniform across val and train so critic and val stay consistent.
+
+        Best-effort: a TQ write error is logged and never masks the original
+        session failure.
+        """
+        dummy = Trajectory(
+            prompt_ids=[_DUMMY_TOKEN_ID],
+            response_ids=[_DUMMY_TOKEN_ID],
+            response_mask=[0],
+            reward_info={"reward": 0.0, "finished": False},
+            reward_score=0.0,
+            num_turns=0,
+            extra_fields={"materialization_reason": "session_failed"},
+        )
+        try:
+            await self._write_session_trajectories_to_tq(
+                uid=str(sample_fields.get("uid", "")),
+                session_index=session_index,
+                trajectories=[dummy],
+                sample_fields=sample_fields,
+                global_steps=global_steps,
+                partition_id=partition_id,
+            )
+        except Exception:  # noqa: BLE001 - best-effort telemetry
+            logger.warning(
+                "failed to write failure dummy trajectory for uid=%s session=%s",
+                sample_fields.get("uid", ""),
+                session_index,
+            )
 
     async def _cancel_runner_task(self, object_ref, session_id: str) -> None:
         """Cancel a dispatched runner Ray task after its session timed out.


### PR DESCRIPTION
## Summary

Failed validation sessions (runner exception / timeout / sandbox failure) previously called abort_session, producing no trajectory in the val TransferQueue. reward/mean@1 averages only non-aborted sequences (aborted_mask = response_length == 0 in verl/trainer/ppo/metric_utils.py), so a failed session that had produced partial tokens vanished from the denominator and inflated the reported val reward. This PR finalizes such sessions instead, emitting their partial output as reward=0 / finished=False trajectories so they count as zeros in the val mean. Train-side failure handling is unchanged.

## Changes

Thread partition_id through _run_session_with_concurrency_limit → _run_session so the failure branch can tell val from train.
For val-only failures, replace abort_session with _finalize_failed_validation_session: finalize whatever the gateway already produced, rewrite each trajectory to reward_score=0.0 + reward_info={..., "reward": 0.0, "finished": False}, write to the val TQ.
Apply _select_session_trajectories(..., trajectory_selection) before writing, mirroring the success path — a length-split multi-chain session writes the same trajectory count a success would (the val mean is per-sequence).
Merge (not overwrite) reward_info to preserve runner-posted diagnostics (acc, materialization_reason); only reward/finished are forced.
Best-effort throughout: finalize_session and the TQ write are each try/except-wrapped and never mask the original failure; CancelledError is a BaseException, caught by the earlier except so cancellation still aborts.

## PR title

Use `[area] type: summary`.

- Areas: `agents`, `framework`, `gateway`, `logging`, `sandbox`, `tasks`, `tools`, `training`, `app`, `docs`, `examples`, `ci`, `build`, `deps`, `misc`
- Types: `feat`, `fix`, `refactor`, `perf`, `test`, `docs`, `chore`, `revert`
- Separate multiple areas with comma-space: `[agents, sandbox] feat: add isolated harness execution`
- Prefix compatibility-breaking work with `[BREAKING]`: `[BREAKING][tasks, docs] refactor: replace task config schema`
- A stacked series may start with `[1/N]`: `[1/N][gateway] refactor: split protocol adapters`

## Checklist

- [ ] The PR is focused and linked to an issue or explains why no issue is needed.
- [ ] The title follows the format above and names the layer that owns the change.
- [ ] Tests cover the behavior, or the Validation section explains why they are not practical.
- [ ] User-facing API, config, and workflow changes include documentation or runnable examples.
- [ ] Compatibility impact and migration steps are documented.
- [ ] Logs, fixtures, and examples contain no credentials or private data.
- [ ] `pre-commit run --all-files --show-diff-on-failure` passes.
