### PR TITLE
[ci] refactor: add cpu and level label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           pip install pytest pytest-cov
           export PYTHONPATH="${PYTHONPATH}:${GITHUB_WORKSPACE}"
-          pytest tests/ --cov=./ --cov-report=xml --cov-report=term
+          pytest tests/uni_agent/ -m="cpu and level0" --cov=./uni_agent/ --cov-report=xml --cov-report=term
 
       # 5. Upload coverage to Codecov
       - name: Upload coverage to Codecov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,9 @@ uni_agent = ["version/*"]
 
 [tool.pytest.ini_options]
 markers = [
-    "cpu: mark cpu backedn",
-    "level0: mark level0 case",
+    "cpu: run on cpu backend",
+    "gpu: run on gpu backend",
+    "npu: run on npu backend",
+    "level0: mark level0 case, always run in CI",
+    "level1: mark level1 case, full test, not included in CI"
 ]

--- a/tests/uni_agent/agents/test_claude_code_agent.py
+++ b/tests/uni_agent/agents/test_claude_code_agent.py
@@ -50,6 +50,8 @@ def _agent() -> ClaudeCodeAgent:
     return ClaudeCodeAgent(ClaudeCodeConfig())
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_ensure_claude_skips_install_when_already_available():
     sandbox = _FakeSandbox(probe_results=[0])
 
@@ -59,6 +61,8 @@ def test_ensure_claude_skips_install_when_already_available():
     assert sandbox.calls[0]["script"].startswith("command -v claude")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_ensure_claude_installs_and_rechecks_path():
     sandbox = _FakeSandbox(probe_results=[1, 0])
 
@@ -73,6 +77,8 @@ def test_ensure_claude_installs_and_rechecks_path():
     assert sandbox.calls[2]["timeout"] == 600
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_ensure_claude_uses_native_installer_when_npm_is_missing():
     sandbox = _FakeSandbox(probe_results=[1, 0], npm_available=False)
 
@@ -87,6 +93,8 @@ def test_ensure_claude_uses_native_installer_when_npm_is_missing():
     assert sandbox.calls[2]["timeout"] == 600
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_ensure_claude_surfaces_install_failure():
     sandbox = _FakeSandbox(probe_results=[1], install_exit_code=1, install_stderr="npm failed")
 
@@ -94,6 +102,8 @@ def test_ensure_claude_surfaces_install_failure():
         asyncio.run(_agent()._ensure_claude(sandbox))
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_ensure_claude_surfaces_native_install_failure():
     sandbox = _FakeSandbox(
         probe_results=[1],
@@ -106,6 +116,8 @@ def test_ensure_claude_surfaces_native_install_failure():
         asyncio.run(_agent()._ensure_claude(sandbox))
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_ensure_claude_requires_binary_on_path_after_install():
     sandbox = _FakeSandbox(probe_results=[1, 1])
 
@@ -113,6 +125,8 @@ def test_ensure_claude_requires_binary_on_path_after_install():
         asyncio.run(_agent()._ensure_claude(sandbox))
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_run_forwards_workdir():
     config = ClaudeCodeConfig(
         model=ModelConfig(
@@ -161,6 +175,8 @@ def test_run_forwards_workdir():
     assert sandbox.exec_calls[0]["env"]["CLAUDE_CODE_DISABLE_TERMINAL_TITLE"] == "1"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_run_accepts_user_only_message_without_rewriting():
     config = ClaudeCodeConfig(
         model=ModelConfig(base_url="http://gateway:8000/v1", model_name="policy"),
@@ -182,6 +198,8 @@ def test_run_accepts_user_only_message_without_rewriting():
     assert sandbox.exec_calls[0]["argv"][2] == prompt
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_run_requires_exactly_one_user_message():
     config = ClaudeCodeConfig(
         model=ModelConfig(base_url="http://gateway:8000/v1", model_name="policy"),
@@ -197,6 +215,8 @@ def test_run_requires_exactly_one_user_message():
         )
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize(
     ("enable_web_tools", "enable_subagents", "expected_disallowed"),
     [
@@ -222,6 +242,8 @@ def test_claude_argv_controls_web_tools_and_subagents_independently(
     assert set(disallowed_tools) == expected_disallowed
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize(("enable_subagents", "expected_model"), [(False, None), (True, "policy")])
 def test_claude_env_pins_enabled_subagents_to_policy_model(enable_subagents, expected_model):
     config = ClaudeCodeConfig(
@@ -234,6 +256,8 @@ def test_claude_env_pins_enabled_subagents_to_policy_model(enable_subagents, exp
     assert env.get("CLAUDE_CODE_SUBAGENT_MODEL") == expected_model
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_claude_argv_can_keep_slash_commands_enabled():
     config = ClaudeCodeConfig(
         model=ModelConfig(model_name="policy"),
@@ -245,6 +269,8 @@ def test_claude_argv_can_keep_slash_commands_enabled():
     assert "--disable-slash-commands" not in argv
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_run_reports_nonzero_process_exit():
     config = ClaudeCodeConfig(
         model=ModelConfig(base_url="http://gateway:8000/v1", model_name="policy"),
@@ -265,6 +291,8 @@ def test_run_reports_nonzero_process_exit():
     assert result.info["exit_code"] == 2
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_claude_env_uses_placeholders_for_session_gateway():
     config = ClaudeCodeConfig(model=ModelConfig(base_url="http://gateway:8000/v1", model_name="policy"))
 

--- a/tests/uni_agent/agents/test_mini_swe_agent_agent.py
+++ b/tests/uni_agent/agents/test_mini_swe_agent_agent.py
@@ -61,6 +61,8 @@ def _decode_task_config(cmd: str) -> dict:
 # --------------------------- helpers ---------------------------
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_build_agent_command_pipes_config_and_invokes_tool_python():
     cmd = build_agent_command(
         config_b64="Zm9v",
@@ -76,6 +78,8 @@ def test_build_agent_command_pipes_config_and_invokes_tool_python():
     assert "/opt/miniconda3/envs/testbed/bin" in cmd
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_build_agent_command_honors_overrides():
     cmd = build_agent_command(
         config_b64="",
@@ -87,10 +91,14 @@ def test_build_agent_command_honors_overrides():
     assert "CONDA_DEFAULT_ENV=myenv" in cmd
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_parse_agent_result_empty_is_error():
     assert parse_agent_result("") == {"exit_status": "error", "submission": ""}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_parse_agent_result_picks_last_json_line_ignoring_litellm_noise():
     stdout = "litellm warning: something\nrandom noise\n" + json.dumps(
         {"exit_status": "Submitted", "submission": "diff"}
@@ -98,11 +106,15 @@ def test_parse_agent_result_picks_last_json_line_ignoring_litellm_noise():
     assert parse_agent_result(stdout) == {"exit_status": "Submitted", "submission": "diff"}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_parse_agent_result_single_json_object():
     result = parse_agent_result(json.dumps({"exit_status": "error", "submission": ""}))
     assert result["exit_status"] == "error"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_parse_agent_result_unparseable_is_error():
     assert parse_agent_result("totally not json at all") == {"exit_status": "error", "submission": ""}
 
@@ -110,18 +122,24 @@ def test_parse_agent_result_unparseable_is_error():
 # --------------------------- validation ---------------------------
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_missing_base_url_raises():
     agent = MiniSweAgentAgent(MiniSweAgentConfig(tool_python=_TOOL_PYTHON, run_agent_script=_RUN_AGENT_SCRIPT))
     with pytest.raises(ValueError, match="base_url"):
         asyncio.run(agent.run(sandbox=_FakeSandbox(), messages=[{"role": "user", "content": "fix the bug"}]))
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_missing_user_message_raises():
     agent = _agent()
     with pytest.raises(ValueError, match="requires a 'user' message"):
         asyncio.run(agent.run(sandbox=_FakeSandbox(), messages=[{"role": "system", "content": "sys"}]))
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_too_many_messages_raises():
     agent = _agent()
     messages = [{"role": "system", "content": "s"}, {"role": "user", "content": "u"}, {"role": "user", "content": "u2"}]
@@ -132,6 +150,8 @@ def test_too_many_messages_raises():
 # --------------------------- happy path ---------------------------
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_run_pipes_config_and_parses_stdout_into_result():
     stdout = "mini-swe-agent noisy log line\n" + json.dumps(
         {"exit_status": "Submitted", "submission": "diff --git a/...", "model_stats": {"api_calls": 3}}
@@ -165,6 +185,8 @@ def test_run_pipes_config_and_parses_stdout_into_result():
     assert result.transcript == messages
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_run_marks_unfinished_when_not_submitted():
     sandbox = _FakeSandbox(stdout=json.dumps({"exit_status": "error", "submission": ""}))
     agent = _agent()
@@ -173,6 +195,8 @@ def test_run_marks_unfinished_when_not_submitted():
     assert result.info["exit_status"] == "error"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_run_passes_base_url_through_unchanged():
     sandbox = _FakeSandbox(stdout=json.dumps({"exit_status": "Submitted", "submission": "diff"}))
     # A tunnel-rewritten base_url (what run_task injects) is forwarded verbatim.

--- a/tests/uni_agent/agents/test_model_config.py
+++ b/tests/uni_agent/agents/test_model_config.py
@@ -1,6 +1,10 @@
+import pytest
+
 from uni_agent.agents.base import ModelConfig
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_unconfigured_sampling_params_delegate_to_endpoint():
     model = ModelConfig()
 
@@ -10,6 +14,8 @@ def test_unconfigured_sampling_params_delegate_to_endpoint():
     assert model.sampling_params() == {}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_explicit_sampling_params_are_forwarded():
     model = ModelConfig(temperature=0.2, top_p=0.8, top_k=-1)
 

--- a/tests/uni_agent/agents/test_react_agent.py
+++ b/tests/uni_agent/agents/test_react_agent.py
@@ -94,10 +94,14 @@ def _agent() -> ReActAgent:
     return ReActAgent(ReActConfig(model=model, tools=[], max_steps=1))
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_agent_result_defaults_to_unreported_completion():
     assert AgentResult().finished is None
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_model_forwards_finish_reason(monkeypatch):
     model = OpenAICompatibleChatModel(
@@ -123,6 +127,8 @@ async def test_model_forwards_finish_reason(monkeypatch):
     assert generation_info["finish_reason"] == "length"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize(
     ("termination_reason", "expected"),
     [
@@ -150,6 +156,8 @@ async def test_react_reports_completion(monkeypatch, termination_reason: str, ex
     assert toolbox.calls == [("shell", {"command": "cd -- /testbed"})]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_length_finish_reason_is_unfinished():
     agent = _agent()
@@ -160,6 +168,8 @@ async def test_length_finish_reason_is_unfinished():
     assert reason == "token_limit"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_length_exhausted_empty_response_ends_the_episode():
     # What the Gateway returns once the session's response budget is spent: an
@@ -173,6 +183,8 @@ async def test_length_exhausted_empty_response_ends_the_episode():
     assert reason == "token_limit"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_total_tokens_tracks_current_context_size():
     agent = _agent()
@@ -186,6 +198,8 @@ async def test_total_tokens_tracks_current_context_size():
     assert info["total_tokens"] == 102
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_plain_text_without_tool_call_finishes_episode():
     agent = _agent()
@@ -198,6 +212,8 @@ async def test_plain_text_without_tool_call_finishes_episode():
     assert [message["role"] for message in transcript] == ["assistant"]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_failed_finish_tool_does_not_finish():
     agent = _agent()
@@ -226,6 +242,8 @@ async def test_failed_finish_tool_does_not_finish():
     assert info["errors"] == 1
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_truncated_tool_call_is_not_dispatched():
     # The Gateway reports tool_calls, never length, whenever it parsed a tool call
@@ -261,6 +279,8 @@ def _per_turn_capped_agent(*, max_tokens_per_turn: int, max_total_tokens: int | 
     return ReActAgent(ReActConfig(model=model, tools=[], max_steps=2))
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_per_turn_cap_truncation_ends_the_episode():
     agent = _per_turn_capped_agent(max_tokens_per_turn=8)
@@ -273,6 +293,8 @@ async def test_per_turn_cap_truncation_ends_the_episode():
     assert reason == "token_limit"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_max_tokens_is_clamped_to_the_remaining_episode_budget():
     agent = _per_turn_capped_agent(max_tokens_per_turn=8, max_total_tokens=105)

--- a/tests/uni_agent/deployment/test_host_runtime.py
+++ b/tests/uni_agent/deployment/test_host_runtime.py
@@ -32,6 +32,8 @@ async def runtime():
         await rt.close()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_sequential_commands_keep_session_state(runtime: HostRuntime) -> None:
     """Persistent session: state from one command must be visible in the next."""
@@ -43,6 +45,8 @@ async def test_sequential_commands_keep_session_state(runtime: HostRuntime) -> N
     assert r2.output.strip() == "bar"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_concurrent_commands_are_serialized(runtime: HostRuntime) -> None:
     """Concurrent run_in_session calls must not interleave their stdout/stdin."""
@@ -55,6 +59,8 @@ async def test_concurrent_commands_are_serialized(runtime: HostRuntime) -> None:
         assert r.exit_code == 0
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_timeout_does_not_pollute_next_command(runtime: HostRuntime) -> None:
     """After a timeout, the next command must see a clean stdout stream."""
@@ -68,6 +74,8 @@ async def test_timeout_does_not_pollute_next_command(runtime: HostRuntime) -> No
     assert r.output.strip() == "recovered"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_interrupt_unblocks_running_command(runtime: HostRuntime) -> None:
     """BashInterruptAction must be deliverable while another command holds
@@ -93,6 +101,8 @@ async def test_interrupt_unblocks_running_command(runtime: HostRuntime) -> None:
     assert r.output.strip() == "after_interrupt"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_interrupt_kills_entire_pipeline(runtime: HostRuntime) -> None:
     """A pipeline (e.g. `sleep 30 | cat | cat`) spawns multiple processes
@@ -116,6 +126,8 @@ async def test_interrupt_kills_entire_pipeline(runtime: HostRuntime) -> None:
     assert r.output.strip() == "still_alive"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_dead_session_raises_instead_of_silent_rebuild(runtime: HostRuntime) -> None:
     """If the bash process exits, the next call must surface the failure so

--- a/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
+++ b/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
@@ -157,6 +157,8 @@ async def _build_framework_with_agent_runners(
     )
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize(
     (
         "data_config",
@@ -376,6 +378,8 @@ def _install_fake_score(monkeypatch, *, score_from_sample_fields=None, default_s
     monkeypatch.setattr(GatewayAgentFramework, "_score_trajectories", fake_score)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_agent_runners_registry_materializes_runners_and_selects_by_agent_name(fake_tq):
     """Function and class runners keep per-runner kwargs, and each prompt's
@@ -429,6 +433,8 @@ async def test_agent_runners_registry_materializes_runners_and_selects_by_agent_
     assert all("gateway_manager" not in call["kwargs"] for call in calls)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 @pytest.mark.parametrize("dispatch_mode", ["inline_async", "ray_task"])
 async def test_framework_and_runner_logs_share_one_session_directory(tmp_path, fake_tq, dispatch_mode):
@@ -471,6 +477,8 @@ async def test_framework_and_runner_logs_share_one_session_directory(tmp_path, f
         assert "session session-sample-0-rollout-0-" in task_log.read_text()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_validation_logs_omit_global_step_directory(tmp_path, fake_tq):
     runtime = _FakeGatewayManager({"session-sample-0-rollout-0": [_trajectory()]})
@@ -493,6 +501,8 @@ async def test_validation_logs_omit_global_step_directory(tmp_path, fake_tq):
     assert tu.get(batch["fields"], "global_steps") == [None]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_validation_logs_keep_provided_global_step(tmp_path, fake_tq):
     runtime = _FakeGatewayManager({"session-sample-0-rollout-0": [_trajectory()]})
@@ -514,6 +524,8 @@ async def test_validation_logs_keep_provided_global_step(tmp_path, fake_tq):
     assert tu.get(batch["fields"], "global_steps") == [12]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_training_requires_global_steps(fake_tq):
     framework = await _build_framework_with_agent_runners(
@@ -525,6 +537,8 @@ async def test_training_requires_global_steps(fake_tq):
         await framework.generate_sequences(_build_prompts(count=1, global_steps=None))
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("validate", "do_sample", "expected_sampling_params"),
@@ -587,6 +601,8 @@ async def test_framework_binds_sampling_defaults_to_gateway_sessions(
     assert [kwargs["sampling_params"] for kwargs in runtime.created_session_kwargs] == [expected_sampling_params]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_generate_sequences_writes_tq_schema_for_each_session(monkeypatch, fake_tq):
     """Full ``generate_sequences`` path writes one TQ batch per successful
@@ -695,6 +711,8 @@ async def test_generate_sequences_writes_tq_schema_for_each_session(monkeypatch,
     assert "multi_modal_data" not in fields.keys()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_generate_sequences_masks_unfinished_trajectory_without_dropping_it(fake_tq):
     runtime = _FakeGatewayManager(
@@ -733,6 +751,8 @@ async def test_generate_sequences_masks_unfinished_trajectory_without_dropping_i
     assert fake_tq.puts == [{"key": "uid-0", "partition_id": "train", "tag": {"status": "finished"}}]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_unfinished_trajectory_remains_trainable_when_masking_is_disabled(fake_tq):
     runtime = _FakeGatewayManager(
@@ -760,6 +780,8 @@ async def test_unfinished_trajectory_remains_trainable_when_masking_is_disabled(
     assert "finished" not in batch["fields"].keys()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_masking_keeps_trajectory_trainable_when_completion_metadata_is_missing(fake_tq):
     runtime = _FakeGatewayManager(
@@ -786,6 +808,8 @@ async def test_masking_keeps_trajectory_trainable_when_completion_metadata_is_mi
     assert batch["fields"]["loss_mask"][0].tolist() == [1, 0]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_generate_sequences_reports_unfinished_episode_count(fake_tq, caplog):
     # A session materializing two trajectories is still one episode: completion is
@@ -811,6 +835,8 @@ async def test_generate_sequences_reports_unfinished_episode_count(fake_tq, capl
     assert "num_unfinished_episodes=1" in caplog.text
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_framework_rejects_non_boolean_masking_config():
     with pytest.raises(ValueError, match="mask_unfinished_episode must be a bool"):
@@ -821,6 +847,8 @@ async def test_framework_rejects_non_boolean_masking_config():
         )
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_align_routed_experts_preserves_backend_dtype():
     aligned = _align_routed_experts(np.array([[[256, 511]]], dtype=np.uint16), seq_len=2)
 
@@ -829,6 +857,8 @@ def test_align_routed_experts_preserves_backend_dtype():
     assert aligned.tolist() == [[[256, 511]], [[0, 0]]]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_generate_sequences_batches_length_trajectory_before_normal_trajectory(fake_tq):
     """Keep length metadata in tags when mixed trajectories share one TQ batch."""
@@ -860,6 +890,8 @@ async def test_generate_sequences_batches_length_trajectory_before_normal_trajec
     assert batch["fields"]["responses"][1].tolist() == [21]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_generate_sequences_selects_longest_model_token_trajectory(fake_tq):
     runtime = _FakeGatewayManager(
@@ -898,6 +930,8 @@ async def test_generate_sequences_selects_longest_model_token_trajectory(fake_tq
     assert batch["fields"]["num_turns"].tolist() == [2]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_framework_rejects_unknown_trajectory_selection(fake_tq):
     with pytest.raises(ValueError, match="Unknown trajectory selection"):
@@ -912,6 +946,8 @@ async def test_framework_rejects_unknown_trajectory_selection(fake_tq):
         )
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_trajectory_postprocessor_applies_kwargs_before_scoring_and_tq(monkeypatch, fake_tq):
     _POSTPROCESSOR_CALLS.clear()
@@ -951,6 +987,8 @@ async def test_trajectory_postprocessor_applies_kwargs_before_scoring_and_tq(mon
     assert [score.tolist() for score in fields["rm_scores"]] == [[0.5], [0.5]]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_async_trajectory_postprocessor_is_awaited(fake_tq):
     runtime = _FakeGatewayManager(
@@ -973,6 +1011,8 @@ async def test_async_trajectory_postprocessor_is_awaited(fake_tq):
     assert fake_tq.batch_puts[0]["fields"]["responses"][0].tolist() == [30]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("postprocessor_name", "error_type", "error_message"),
@@ -996,6 +1036,8 @@ async def test_trajectory_postprocessor_reports_invalid_extensions(
         await framework._apply_trajectory_postprocessor([_trajectory()])
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_trajectory_postprocessor_rejects_dropped_reward_info():
     framework = await _build_framework_with_agent_runners(
@@ -1008,6 +1050,8 @@ async def test_trajectory_postprocessor_rejects_dropped_reward_info():
         await framework._apply_trajectory_postprocessor([_trajectory(reward_info={"reward": 0.5, "finished": False})])
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_framework_rejects_non_callable_trajectory_postprocessor():
     with pytest.raises(TypeError, match="must resolve to a callable"):
@@ -1018,6 +1062,8 @@ async def test_framework_rejects_non_callable_trajectory_postprocessor():
         )
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("postprocessor_fqn", "postprocessor_kwargs", "error_type", "error_message"),
@@ -1043,6 +1089,8 @@ async def test_framework_rejects_invalid_trajectory_postprocessor_config(
         )
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_generate_sequences_keeps_successful_sessions_when_one_session_fails(fake_tq):
     """A failed rollout session aborts only that session; other successful
@@ -1073,6 +1121,8 @@ async def test_generate_sequences_keeps_successful_sessions_when_one_session_fai
     assert runtime.aborted_sessions[0].startswith("session-sample-0-rollout-1-")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_generate_sequences_marks_prompt_failure_when_all_sessions_fail(fake_tq):
     """Filtering every session to empty marks the uid failed and raises."""
@@ -1098,6 +1148,8 @@ async def test_generate_sequences_marks_prompt_failure_when_all_sessions_fail(fa
     assert fake_tq.puts == [{"key": "uid-0", "partition_id": "val", "tag": {"status": "failure"}}]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_generate_sequences_omits_missing_rollout_log_probs(fake_tq):
     """Missing backend logprobs are omitted while reward scores remain zero-filled."""
@@ -1117,6 +1169,8 @@ async def test_generate_sequences_omits_missing_rollout_log_probs(fake_tq):
     assert "rollout_log_probs" not in fields
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_generate_sequences_keeps_other_prompts_when_one_prompt_fails(fake_tq):
     """Prompt-level failures are isolated: one uid can fail while another uid
@@ -1155,6 +1209,8 @@ async def test_generate_sequences_keeps_other_prompts_when_one_prompt_fails(fake
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_score_trajectories_merges_final_reward_info_into_reward_extra_info():
     """Reward scoring dispatches only the final trajectory to the worker and
@@ -1230,6 +1286,8 @@ async def test_score_trajectories_merges_final_reward_info_into_reward_extra_inf
     ]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 @pytest.mark.parametrize("termination", ["timeout", "parent_cancel"])
 async def test_ray_task_termination_cancels_runner_and_aborts_session(monkeypatch, fake_tq, termination):

--- a/tests/uni_agent/framework/test_multi_modal_postprocess_on_cpu.py
+++ b/tests/uni_agent/framework/test_multi_modal_postprocess_on_cpu.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import pytest
 import torch
 
 from tests.uni_agent.support import FakeProcessor
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_compute_multi_modal_inputs_returns_empty_dict_without_processor():
     """Without a processor, multimodal postprocess is a no-op and returns an
     empty field map even when raw image data is present."""
@@ -15,6 +18,8 @@ def test_compute_multi_modal_inputs_returns_empty_dict_without_processor():
     assert compute_multi_modal_inputs(None, input_ids, {"images": ["image://a.png"]}) == {}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_compute_multi_modal_inputs_returns_image_tensors_and_images_seqlens():
     """Image inputs are converted through the processor while generated
     ``input_ids`` and ``attention_mask`` are stripped from the TQ payload."""
@@ -37,6 +42,8 @@ def test_compute_multi_modal_inputs_returns_image_tensors_and_images_seqlens():
     assert "mm_token_type_ids" in multi_modal_inputs
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_compute_position_ids_uses_text_path_without_multimodal_inputs():
     """Text-only samples use VERL's mask-based path when a processor exists
     but this sample has no multimodal fields."""
@@ -52,6 +59,8 @@ def test_compute_position_ids_uses_text_path_without_multimodal_inputs():
     assert position_ids.tolist() == [[0, 0, 1, 2]]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_compute_position_ids_returns_multimodal_shape_with_processor():
     """With multimodal processor outputs, position ids combine the text row
     with the processor-provided vision RoPE rows."""

--- a/tests/uni_agent/framework/test_task_config_merge.py
+++ b/tests/uni_agent/framework/test_task_config_merge.py
@@ -9,10 +9,14 @@ from uni_agent.tasks import TaskConfig, TaskConfigResolver, get_task
 _LOCAL_SANDBOX = {"provider": "local"}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_task_config_has_no_logging_runtime_fields():
     assert "log_dir" not in TaskConfig.model_fields
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_sample_config_overrides_file_defaults_and_runtime_endpoint_wins():
     file_defaults = {
         "name": "swe_bench",
@@ -86,6 +90,8 @@ def test_sample_config_overrides_file_defaults_and_runtime_endpoint_wins():
     assert parsed.agent.model.base_url == "http://gateway:8000/sessions/1/v1"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_model_fallbacks_do_not_override_task_config_defaults():
     resolved = TaskConfigResolver(
         {
@@ -120,6 +126,8 @@ def test_model_fallbacks_do_not_override_task_config_defaults():
     assert model.top_k == 42
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_task_prompt_without_template_passes_through_unchanged():
     messages = [
         {"role": "system", "content": "Existing instructions"},
@@ -137,6 +145,8 @@ def test_task_prompt_without_template_passes_through_unchanged():
     assert config.prompt == messages
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_task_prompt_template_renders_multiple_metadata_fields():
     config = TaskConfig(
         sandbox=_LOCAL_SANDBOX,
@@ -162,6 +172,8 @@ def test_task_prompt_template_renders_multiple_metadata_fields():
     ]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_task_prompt_template_allows_no_placeholders():
     config = TaskConfig(
         sandbox=_LOCAL_SANDBOX,
@@ -173,6 +185,8 @@ def test_task_prompt_template_allows_no_placeholders():
     assert config.prompt == [{"role": "user", "content": "Static recipe prompt"}]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_prompt_template_is_input_only_across_task_config_serialization():
     config = TaskConfig(
         sandbox=_LOCAL_SANDBOX,
@@ -188,6 +202,8 @@ def test_prompt_template_is_input_only_across_task_config_serialization():
     assert TaskConfig.model_validate(dumped).prompt == config.prompt
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize(
     ("prompt_template", "metadata", "error"),
     [
@@ -221,6 +237,8 @@ def test_task_prompt_template_rejects_invalid_metadata_formatting(prompt_templat
         )
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize(
     ("prompt_template", "error"),
     [
@@ -239,6 +257,8 @@ def test_task_prompt_template_rejects_incompatible_template_messages(prompt_temp
         )
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_recipe_prompt_template_overrides_sample_template_and_uses_metadata():
     recipe_template = [
         {"role": "system", "content": "Recipe instructions"},

--- a/tests/uni_agent/framework/test_task_runner.py
+++ b/tests/uni_agent/framework/test_task_runner.py
@@ -11,24 +11,34 @@ from uni_agent.gateway.session import SessionHandle
 from uni_agent.tasks import TaskConfig, TaskResult
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_rewrite_gateway_url_replaces_host_with_tunnel_port():
     assert _rewrite_gateway_url("http://gateway.example:40169/sessions/abc/v1", 38197) == (
         "http://127.0.0.1:38197/sessions/abc/v1"
     )
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_rewrite_gateway_url_custom_proxy_port():
     assert _rewrite_gateway_url("http://gateway:8000/v1", 4242) == "http://127.0.0.1:4242/v1"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_extract_upstream_returns_host_port():
     assert _extract_upstream("http://gateway.example:40169/sessions/abc/v1") == "gateway.example:40169"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_extract_upstream_none_without_port():
     assert _extract_upstream("http://gateway/v1") is None
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_inject_gateway_tunnel_rewrites_upstream_and_base_url():
     task = {
         "sandbox": {"provider": "openyuanrong", "sandbox_kwargs": {"proxy_port": 38197, "image": "x"}},
@@ -43,18 +53,24 @@ def test_inject_gateway_tunnel_rewrites_upstream_and_base_url():
     assert merged["agent"]["step_limit"] == 10
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_inject_gateway_tunnel_raises_without_port():
     task = {"sandbox": {"provider": "openyuanrong", "sandbox_kwargs": {"proxy_port": 38197}}}
     with pytest.raises(ValueError, match="cannot derive gateway tunnel upstream"):
         _inject_gateway_tunnel(task, "http://gateway.example/v1")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_inject_gateway_tunnel_rejects_non_yuanrong_sandbox():
     task = {"sandbox": {"provider": "local", "sandbox_kwargs": {"proxy_port": 38197}}}
     with pytest.raises(ValueError, match="supported only on 'openyuanrong'"):
         _inject_gateway_tunnel(task, "http://gateway.example:40169/v1")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_task_result_positional_field_order():
     result = TaskResult(0.5, 1.0, False, {"reason": "limit"})
 
@@ -64,6 +80,8 @@ def test_task_result_positional_field_order():
     assert result.extra_info == {"reason": "limit"}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_reward_info_omits_unknown_agent_completion():
     result = TaskResult(reward=0.5, accuracy=1.0)
 
@@ -73,6 +91,8 @@ def test_reward_info_omits_unknown_agent_completion():
     }
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize("finished", [True, False])
 def test_reward_info_forwards_agent_completion(finished):
     result = TaskResult(reward=0.0, finished=finished)
@@ -83,6 +103,8 @@ def test_reward_info_forwards_agent_completion(finished):
     }
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_reward_info_rejects_non_boolean_agent_completion():
     result = TaskResult(reward=0.0, finished=0)  # type: ignore[arg-type]
 
@@ -90,6 +112,8 @@ def test_reward_info_rejects_non_boolean_agent_completion():
         _reward_info_from_result(result)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_run_task_binds_raw_prompt_to_sample_task_config(monkeypatch, tmp_path):
     config_path = tmp_path / "tasks.yaml"

--- a/tests/uni_agent/gateway/adapters/test_anthropic_adapter.py
+++ b/tests/uni_agent/gateway/adapters/test_anthropic_adapter.py
@@ -9,6 +9,8 @@ ALLOWED_SAMPLING_KEYS = frozenset({"temperature", "top_p", "top_k", "max_tokens"
 BASE = dict(base_sampling_params={}, allowed_sampling_keys=ALLOWED_SAMPLING_KEYS)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_system_string_becomes_first_message():
     """Top-level Anthropic system text becomes the leading internal system
     message and max_tokens is forwarded into sampling params."""
@@ -20,6 +22,8 @@ def test_system_string_becomes_first_message():
     assert req["sampling_params"]["max_tokens"] == 16
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_user_text_image_text_order_preserved():
     """Mixed Anthropic user text/image blocks lower to OpenAI-compatible parts
     without reordering the multimodal content."""
@@ -46,6 +50,8 @@ def test_user_text_image_text_order_preserved():
     ]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_assistant_tool_use_to_tool_calls_dict_args():
     """Anthropic assistant tool_use blocks become internal OpenAI-style
     tool_calls while preserving dict arguments."""
@@ -67,6 +73,8 @@ def test_assistant_tool_use_to_tool_calls_dict_args():
     assert tc["function"]["arguments"] == {"q": "x"}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_malformed_anthropic_content_blocks_rejected():
     """Malformed or unsupported Anthropic content blocks fail at the adapter
     boundary before the session codec sees corrupted history."""
@@ -107,6 +115,8 @@ def test_malformed_anthropic_content_blocks_rejected():
             anthropic_to_internal(payload, **BASE)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_user_tool_result_text_becomes_tool_message():
     """A text-only Anthropic tool_result lowers to an internal tool message with
     the original tool_use_id."""
@@ -132,6 +142,8 @@ def test_user_tool_result_text_becomes_tool_message():
     assert req["messages"][0]["content"] == "found"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_malformed_tool_result_blocks_rejected():
     """Tool results without a usable id or with unsupported nested blocks are
     rejected instead of corrupting tool-return history."""
@@ -169,6 +181,8 @@ def test_malformed_tool_result_blocks_rejected():
             anthropic_to_internal(payload, **BASE)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_tool_result_image_appends_user_message():
     """Tool-result images are preserved as a following user image message while
     text remains in the correlated tool message."""
@@ -201,6 +215,8 @@ def test_tool_result_image_appends_user_message():
     assert req["messages"][1]["content"][0]["type"] == "image_url"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_tool_result_image_only_preserves_empty_tool_message():
     """Image-only tool_result content still emits an empty tool message sentinel
     before the downgraded user image message."""
@@ -232,6 +248,8 @@ def test_tool_result_image_only_preserves_empty_tool_message():
     assert req["messages"][1]["content"][0]["type"] == "image_url"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_anthropic_request_control_fields_lower_or_reject():
     """Small Anthropic request-level controls stay adapter-owned: unsupported
     tool choices are rejected, while stop_sequences lowers to sampling stop."""
@@ -248,6 +266,8 @@ def test_anthropic_request_control_fields_lower_or_reject():
     assert req["sampling_params"]["stop"] == ["</s>"]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_mid_list_system_folded_into_user():
     """Mid-conversation system reminders are folded into user content so chat
     templates never see a system role after the first message."""
@@ -270,6 +290,8 @@ def test_mid_list_system_folded_into_user():
     assert not any(m.get("content") == "<system-reminder>\nreminder\n</system-reminder>" for m in req["messages"])
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_mid_list_system_before_tool_result_does_not_cross_tool_message():
     """A system reminder before a tool_result folds into the prior user message
     and does not break the assistant/tool message adjacency."""
@@ -306,6 +328,8 @@ def test_mid_list_system_before_tool_result_does_not_cross_tool_message():
     )
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_billing_header_stripped_from_system():
     """Claude Code billing headers embedded in system text are stripped before
     prompt construction."""
@@ -320,6 +344,8 @@ def test_billing_header_stripped_from_system():
     assert req["messages"][0] == {"role": "system", "content": "Be concise."}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_provider_specific_tool_metadata_lowers_to_template_function_schema():
     """Provider-specific Anthropic tool metadata is ignored while the tool name
     remains available to the local chat template as an OpenAI function schema."""
@@ -341,6 +367,8 @@ def test_provider_specific_tool_metadata_lowers_to_template_function_schema():
     assert req["tools"] == [{"type": "function", "function": {"name": "web_search", "parameters": {}}}]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_tool_input_schema_passes_through_json_schema():
     """Anthropic JSON schema is copied into OpenAI function parameters without
     gateway-specific parser normalization."""
@@ -368,6 +396,8 @@ def test_tool_input_schema_passes_through_json_schema():
     assert "enum" not in params["properties"]["target"]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_tool_input_schema_anyof_preserves_heterogeneous_branches_without_inferred_type():
     """Heterogeneous anyOf branches keep their distinct JSON types instead of
     being collapsed into a compatibility hint for a specific parser."""
@@ -390,6 +420,8 @@ def test_tool_input_schema_anyof_preserves_heterogeneous_branches_without_inferr
     }
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_thinking_block_dropped_with_warning(caplog):
     """Inbound Anthropic thinking blocks are dropped with a warning while
     neighboring assistant text remains in the prompt history."""
@@ -411,6 +443,8 @@ def test_thinking_block_dropped_with_warning(caplog):
     assert any("thinking" in r.message for r in caplog.records)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_unsupported_system_and_redacted_thinking_blocks_rejected():
     """System non-text blocks and encrypted redacted_thinking blocks are rejected
     because neither has a faithful local template representation."""
@@ -440,6 +474,8 @@ def test_unsupported_system_and_redacted_thinking_blocks_rejected():
         )
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_anthropic_build_response_text():
     """A text GenerationOutcome serializes to the Anthropic Messages response
     shape with end_turn stop reason and usage counts."""
@@ -462,6 +498,8 @@ def test_anthropic_build_response_text():
     assert body["usage"] == {"input_tokens": 3, "output_tokens": 1}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_anthropic_build_response_tool_use():
     """Internal OpenAI-style tool_calls serialize back to Anthropic tool_use
     blocks and map finish_reason to tool_use."""
@@ -486,6 +524,8 @@ def test_anthropic_build_response_tool_use():
     assert body["stop_reason"] == "tool_use"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_anthropic_build_response_length_maps_to_max_tokens():
     """Internal length finish reasons are exposed as Anthropic max_tokens stop
     reasons."""
@@ -504,6 +544,8 @@ def test_anthropic_build_response_length_maps_to_max_tokens():
     assert body["stop_reason"] == "max_tokens"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_anthropic_build_response_normalizes_tool_use_input():
     """Tool parser arguments are normalized for Anthropic clients: JSON-string
     objects become dicts and invalid strings become empty input."""
@@ -528,6 +570,8 @@ def test_anthropic_build_response_normalizes_tool_use_input():
         assert tu["input"] == expected_input
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_anthropic_stream_event_sequence():
     """A synthesized text response follows the Anthropic Messages SSE event
@@ -562,6 +606,8 @@ async def test_anthropic_stream_event_sequence():
     assert "event: message_stop" in text
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_anthropic_stream_response_emits_tool_use_delta():
     """A synthesized tool-call response emits Anthropic tool_use start data and

--- a/tests/uni_agent/gateway/adapters/test_openai_adapter.py
+++ b/tests/uni_agent/gateway/adapters/test_openai_adapter.py
@@ -5,6 +5,8 @@ import pytest
 ALLOWED_SAMPLING_KEYS = frozenset({"temperature", "top_p", "top_k", "max_tokens", "stop"})
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_openai_build_response_shape():
     """A completed internal outcome serializes to the basic OpenAI chat
     completion envelope with ids, model, choices, and token usage."""
@@ -27,6 +29,8 @@ def test_openai_build_response_shape():
     assert body["model"] == "m"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_openai_stream_response_emits_compatible_sse_chunks():
     """A completed internal outcome is synthesized into OpenAI-compatible SSE
@@ -77,6 +81,8 @@ async def test_openai_stream_response_emits_compatible_sse_chunks():
     }
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_openai_to_internal_normalizes_messages_sampling_and_tools():
     """OpenAI wire requests lower to the internal shape: sampling params use the
     gateway allowlist, JSON tool arguments are parsed, malformed argument

--- a/tests/uni_agent/gateway/test_debug_launcher.py
+++ b/tests/uni_agent/gateway/test_debug_launcher.py
@@ -12,6 +12,8 @@ from examples.gateway import debug_launcher
 from uni_agent.gateway.session import SessionHandle, Trajectory
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_trajectory_to_record_is_json_serializable_and_preserves_fields():
     """Trajectory output records keep every training-visible field and can be
     written as plain JSON."""
@@ -56,6 +58,8 @@ def test_trajectory_to_record_is_json_serializable_and_preserves_fields():
     }
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_write_trajectories_jsonl_writes_expected_file(tmp_path):
     """Finalized trajectories are written under the session output directory as
     one JSON record per line with stable trajectory indexes."""
@@ -83,6 +87,8 @@ def test_write_trajectories_jsonl_writes_expected_file(tmp_path):
     assert records[1]["trajectory"]["response_logprobs"] == [-0.2]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_write_session_metadata_json_writes_run_context_without_trajectories(tmp_path):
     """Session metadata is written even when no trajectories were captured so a
     failed smoke still leaves inspectable run context."""
@@ -116,6 +122,8 @@ def test_write_session_metadata_json_writes_run_context_without_trajectories(tmp
     assert record["debug_snapshot_path"].endswith("debug_snapshot.json")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_write_debug_snapshot_json_writes_message_history_and_session_state(tmp_path):
     """Debug snapshots preserve normalized conversation state separately from
     token-level trajectories for post-run diagnosis."""
@@ -138,6 +146,8 @@ def test_write_debug_snapshot_json_writes_message_history_and_session_state(tmp_
     assert record["message_history"] == [{"role": "user", "content": "hi"}]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_capture_debug_snapshot_preserves_multiple_active_chains():
     chains = [
         SimpleNamespace(
@@ -163,6 +173,8 @@ def test_capture_debug_snapshot_preserves_multiple_active_chains():
     assert "multiple chains" in snapshot["note"]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_provider_urls_strips_v1_for_anthropic_and_keeps_openai_base_url():
     """The printed Anthropic base URL omits /v1 for Claude Code while the
     OpenAI-compatible URL keeps the session-scoped /v1 suffix."""
@@ -179,6 +191,8 @@ def test_provider_urls_strips_v1_for_anthropic_and_keeps_openai_base_url():
     }
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_build_claude_env_removes_auth_and_proxy_vars_and_sets_expected_vars():
     """Claude Code smoke env construction removes conflicting auth/proxy
     variables and injects the local gateway Anthropic endpoint."""
@@ -210,6 +224,8 @@ def test_build_claude_env_removes_auth_and_proxy_vars_and_sets_expected_vars():
     assert env["NO_PROXY"] == "10.1.2.3,127.0.0.1,localhost"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_parse_args_minimal_and_openai_required_args_validation(tmp_path):
     """The fake backend has minimal CLI requirements, while openai-completions
     requires backend URL, backend model, and tokenizer path."""
@@ -254,6 +270,8 @@ def test_parse_args_minimal_and_openai_required_args_validation(tmp_path):
     assert args.tokenizer == "/tmp/tokenizer"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_real_tokenizer_wrapper_flattens_encoding_template_results():
     """Real tokenizer wrappers flatten tokenizers Encoding objects returned by
     apply_chat_template while delegating other tokenizer methods."""
@@ -275,6 +293,8 @@ def test_real_tokenizer_wrapper_flattens_encoding_template_results():
     assert wrapper.decode([1, 2, 3]) == "decoded"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_build_claude_command(tmp_path):
     """One-shot Claude Code smoke uses the bare, non-persistent CLI mode with
     captured debug output, prompt text output, and the requested frontend model."""
@@ -295,6 +315,8 @@ def test_build_claude_command(tmp_path):
     assert command[command.index("--model") + 1] == "claude-sonnet-4-5"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_openai_completions_backend_generate_sends_prompt_token_ids_and_parses_token_ids_logprobs(
     monkeypatch,
@@ -375,6 +397,8 @@ async def test_openai_completions_backend_generate_sends_prompt_token_ids_and_pa
     assert output.stop_reason == "length"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_openai_completions_backend_requires_token_ids(monkeypatch):
     """A completions backend response without token_ids is rejected because
@@ -410,6 +434,8 @@ async def test_openai_completions_backend_requires_token_ids(monkeypatch):
         await backend.generate(request_id="s1", prompt_ids=[1], sampling_params={})
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_openai_completions_backend_http_error_includes_request_id_and_body(monkeypatch):
     """HTTP errors from the completions backend include the gateway request id,
@@ -449,6 +475,8 @@ async def test_openai_completions_backend_http_error_includes_request_id_and_bod
         await backend.generate(request_id="s1", prompt_ids=[1], sampling_params={})
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_run_claude_once_records_timeout_metadata(monkeypatch, tmp_path):
     """A timed-out one-shot Claude subprocess records timeout metadata and
@@ -476,6 +504,8 @@ async def test_run_claude_once_records_timeout_metadata(monkeypatch, tmp_path):
     assert Path(metadata["stderr_path"]).read_text() == "slow"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_wait_for_manual_finalize_accepts_enter_from_tty_stdin():
     """Manual launcher mode can be finalized with Enter instead of requiring a
@@ -505,6 +535,8 @@ async def test_wait_for_manual_finalize_accepts_enter_from_tty_stdin():
     assert trigger == "stdin"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_run_debug_session_once_fake_creates_finalizes_and_writes_trajectories(
     monkeypatch,
@@ -589,6 +621,8 @@ async def test_run_debug_session_once_fake_creates_finalizes_and_writes_trajecto
     assert debug_snapshot["active_chains"][0]["message_history"] == debug_snapshot["message_history"]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_async_main_returns_nonzero_when_claude_fails(monkeypatch, tmp_path):
     """The CLI exits with Claude's non-zero return code when one-shot Claude

--- a/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
+++ b/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
@@ -42,6 +42,8 @@ def ray_runtime():
     ray.shutdown()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize("response_length", [0, -1])
 def test_gateway_actor_config_rejects_non_positive_response_length(response_length):
     from uni_agent.gateway.config import GatewayActorConfig
@@ -50,6 +52,8 @@ def test_gateway_actor_config_rejects_non_positive_response_length(response_leng
         GatewayActorConfig(tokenizer=FakeTokenizer(), response_length=response_length)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize("prompt_length", [0, -1])
 def test_gateway_actor_config_rejects_non_positive_prompt_length(prompt_length):
     from uni_agent.gateway.config import GatewayActorConfig
@@ -58,6 +62,8 @@ def test_gateway_actor_config_rejects_non_positive_prompt_length(prompt_length):
         GatewayActorConfig(tokenizer=FakeTokenizer(), prompt_length=prompt_length)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize("field", ["enable_last_assistant_rollback", "enable_tool_parser_cache"])
 @pytest.mark.parametrize("value", ["true", 1, None])
 def test_gateway_actor_config_rejects_non_bool_options(field, value):
@@ -67,12 +73,16 @@ def test_gateway_actor_config_rejects_non_bool_options(field, value):
         GatewayActorConfig(tokenizer=FakeTokenizer(), **{field: value})
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_gateway_actor_config_enables_last_assistant_rollback_by_default():
     from uni_agent.gateway.config import GatewayActorConfig
 
     assert GatewayActorConfig(tokenizer=FakeTokenizer()).enable_last_assistant_rollback is True
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_actor_forwards_last_assistant_rollback_to_session():
     from uni_agent.gateway.config import GatewayActorConfig
@@ -102,6 +112,8 @@ async def test_gateway_actor_forwards_last_assistant_rollback_to_session():
     assert state["rollback_count"] == 1
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_actor_max_tokens_clamped_to_remaining_trajectory_capacity():
     """Clamp ``max_tokens`` to total capacity minus the selected chain context."""
@@ -144,6 +156,8 @@ async def test_gateway_actor_max_tokens_clamped_to_remaining_trajectory_capacity
         await actor.shutdown()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_actor_exhausted_trajectory_closes_without_backend_call():
     from uni_agent.gateway.config import GatewayActorConfig
@@ -181,6 +195,8 @@ async def test_gateway_actor_exhausted_trajectory_closes_without_backend_call():
         await actor.shutdown()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_actor_rejects_invalid_session_max_tokens_before_backend_call():
     from fastapi import HTTPException
@@ -205,6 +221,8 @@ async def test_gateway_actor_rejects_invalid_session_max_tokens_before_backend_c
         await actor.shutdown()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_actor_continuation_budget_exhausted_materializes_length_stop():
     """When a continuation request exceeds the selected chain trajectory capacity,
@@ -257,6 +275,8 @@ async def test_gateway_actor_continuation_budget_exhausted_materializes_length_s
         await actor.shutdown()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_backend_value_error_raises_400():
     """Backend ``ValueError`` (e.g. prompt-too-long litellm vLLM errors)
@@ -282,6 +302,8 @@ async def test_backend_value_error_raises_400():
         await actor.shutdown()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_unknown_session_raises_404():
     """A chat request targeting a session_id that was never created is rejected
@@ -304,6 +326,8 @@ async def test_unknown_session_raises_404():
         await actor.shutdown()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_prefix_canonicalization_ignores_provider_ids_and_normalizes_arguments():
     """Drop provider IDs and normalize arguments without mutating the message."""
     from uni_agent.gateway.session.codec import MessageCodec
@@ -364,6 +388,8 @@ def test_prefix_canonicalization_ignores_provider_ids_and_normalizes_arguments()
         ) is expect_equal
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_config_chat_template_kwargs_forwarded(monkeypatch):
     """Codec-level chat-template kwargs are copied and forwarded."""
@@ -405,6 +431,8 @@ async def test_config_chat_template_kwargs_forwarded(monkeypatch):
         await actor.shutdown()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_actor_get_session_state_reports_default_chain_tips():
     from uni_agent.gateway.config import GatewayActorConfig
@@ -449,6 +477,8 @@ async def test_gateway_actor_get_session_state_reports_default_chain_tips():
     assert len(trajectories) == 2
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_unsupported_capabilities_rejected_with_400():
     """OpenAI capabilities that the gateway does not support (``n > 1``,
@@ -481,6 +511,8 @@ async def test_unsupported_capabilities_rejected_with_400():
         await actor.shutdown()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_provider_stream_true_returns_sse():
     """OpenAI and Anthropic requests with stream=true return provider-shaped
@@ -515,6 +547,8 @@ async def test_provider_stream_true_returns_sse():
         await actor.shutdown()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_openai_chat_completion_response_uses_request_model_or_unknown():
     """The route passes the request model into the OpenAI response envelope and
@@ -549,6 +583,8 @@ async def test_openai_chat_completion_response_uses_request_model_or_unknown():
         await actor.shutdown()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_tool_choice_none_skips_tool_injection_and_parser(monkeypatch):
     """When ``tool_choice="none"``, tools are cleared before encoding so the
@@ -594,6 +630,8 @@ async def test_tool_choice_none_skips_tool_injection_and_parser(monkeypatch):
         await actor.shutdown()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_actor_forwards_image_data_on_initial_multimodal_request(ray_runtime):
     """On the first turn of a multimodal session, ``image_data`` extracted
@@ -667,6 +705,8 @@ async def test_gateway_actor_forwards_image_data_on_initial_multimodal_request(r
     assert trajectories[0].multi_modal_data == {"images": ["image://a.png"]}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_actor_reward_info_endpoint_attaches_metadata_on_finalize(ray_runtime):
     """The per-session reward_info endpoint stores metadata returned on finalize."""
@@ -702,6 +742,8 @@ async def test_gateway_actor_reward_info_endpoint_attaches_metadata_on_finalize(
     assert trajectories[0].reward_info == {"score": 1.0, "label": "A"}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_actor_continuation_reuses_accumulated_media_context(ray_runtime):
     """On a prefix-continuation turn, the accumulated media from the initial
@@ -764,6 +806,8 @@ async def test_gateway_actor_continuation_reuses_accumulated_media_context(ray_r
     assert trajectories[0].multi_modal_data == {"images": ["image://a.png"]}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_actor_multimodal_reference_change_splits_trajectory(ray_runtime):
     """When a follow-up request changes the image reference (different URL),
@@ -824,6 +868,8 @@ async def test_gateway_actor_multimodal_reference_change_splits_trajectory(ray_r
     assert len(trajectories) == 2
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_actor_continuation_with_tool_returned_image_appends_media(monkeypatch):
     """When a tool-call continuation brings a new image (e.g. a zoomed crop),
@@ -937,6 +983,8 @@ async def test_gateway_actor_continuation_with_tool_returned_image_appends_media
     assert second_call["prompt_ids"] == expected_prompt_ids
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("session_id", "first_payload", "second_payload"),
@@ -996,6 +1044,8 @@ async def test_gateway_actor_context_change_splits_trajectory(ray_runtime, sessi
     assert len(trajectories) == 2
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("backend_kwargs", "session_id", "request_extra"),
@@ -1066,6 +1116,8 @@ async def test_gateway_actor_allowlist_filters_sampling_params(ray_runtime, back
     assert response.status_code == 200
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 @pytest.mark.parametrize("provider", ["openai", "anthropic"])
 async def test_gateway_actor_session_sampling_defaults_are_isolated_and_request_overridable(provider):
@@ -1141,6 +1193,8 @@ async def test_gateway_actor_session_sampling_defaults_are_isolated_and_request_
     ]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_actor_continuation_preserves_prompt_and_generation_masks(ray_runtime):
     """Token-truth: on a continuation turn, the incremental interstitial tokens
@@ -1189,6 +1243,8 @@ async def test_gateway_actor_continuation_preserves_prompt_and_generation_masks(
     assert trajectories[0].response_mask[-len("SECOND") :] == [1] * len("SECOND")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_actor_parallel_same_session_requests_by_default():
     from uni_agent.gateway.config import GatewayActorConfig
@@ -1219,6 +1275,8 @@ async def test_gateway_actor_parallel_same_session_requests_by_default():
     ]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_actor_rejects_malformed_requests_with_bad_request(ray_runtime):
     """Malformed request payloads (empty messages, bad types, invalid
@@ -1285,6 +1343,8 @@ async def test_gateway_actor_rejects_malformed_requests_with_bad_request(ray_run
         assert detail_fragment in body["error"]["message"]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_actor_backend_failure_does_not_commit_partial_state(ray_runtime):
     """Commit-on-success isolation: when the backend raises an error, the
@@ -1312,6 +1372,8 @@ async def test_gateway_actor_backend_failure_does_not_commit_partial_state(ray_r
     assert state["has_active_trajectory"] is False
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_actor_backend_failure_after_tool_mismatch_does_not_split(ray_runtime):
     """When the first turn succeeds but the second turn causes a backend
@@ -1363,6 +1425,8 @@ async def test_gateway_actor_backend_failure_after_tool_mismatch_does_not_split(
     assert trajectories[0].response_ids == [ord(char) for char in "FIRST"]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_actor_tool_call_decode_returns_openai_format(monkeypatch):
     """When tool_parser_name is set and model outputs tool call tokens,
@@ -1446,6 +1510,8 @@ async def test_gateway_actor_tool_call_decode_returns_openai_format(monkeypatch)
     assert 1 in trajectories[0].response_mask
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_anthropic_messages_end_to_end():
     """The Anthropic Messages route lowers a simple request, runs one
@@ -1469,6 +1535,8 @@ async def test_anthropic_messages_end_to_end():
         await actor.shutdown()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_anthropic_and_openai_produce_identical_trajectory():
     """An Anthropic request and its equivalent OpenAI request yield identical
@@ -1503,6 +1571,8 @@ async def test_anthropic_and_openai_produce_identical_trajectory():
         await actor.shutdown()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_anthropic_tool_turn_round_trip_extends_not_reencodes(monkeypatch):
     """A real Anthropic tool_result round trip extends the existing trajectory."""
@@ -1562,6 +1632,8 @@ async def test_anthropic_tool_turn_round_trip_extends_not_reencodes(monkeypatch)
         await actor.shutdown()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_anthropic_error_envelope_shape():
     """Malformed Anthropic requests return Anthropic-shaped error bodies rather
@@ -1588,6 +1660,8 @@ async def test_anthropic_error_envelope_shape():
         await actor.shutdown()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_provider_malformed_json_uses_error_envelope():
     """Invalid JSON is reported through the matching provider error envelope."""
@@ -1625,6 +1699,8 @@ async def test_provider_malformed_json_uses_error_envelope():
         await actor.shutdown()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_unhandled_exception_uses_provider_error_envelope(monkeypatch):
     """Unhandled route exceptions still produce provider-shaped error bodies,

--- a/tests/uni_agent/gateway/test_gateway_manager_on_cpu.py
+++ b/tests/uni_agent/gateway/test_gateway_manager_on_cpu.py
@@ -42,6 +42,8 @@ class _FakeGateway:
         return _FakeRemoteMethod(self._create)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_manager_balances_concurrent_session_creation():
     """Concurrently created sessions must spread evenly across gateways. The
@@ -68,6 +70,8 @@ async def test_gateway_manager_balances_concurrent_session_creation():
     assert [len(g.created) for g in gateways] == counts
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_gateway_manager_rejects_zero_gateway_count():
     """``GatewayManager`` raises ``ValueError`` when ``gateway_count=0``, rather
     than silently spawning a half-initialized manager."""
@@ -82,6 +86,8 @@ def test_gateway_manager_rejects_zero_gateway_count():
         )
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_manager_round_robins_actors_across_alive_nodes(ray_runtime, monkeypatch):
     """gateway_count > 1 should distribute actors across alive CPU nodes round-robin."""
@@ -129,6 +135,8 @@ async def test_gateway_manager_round_robins_actors_across_alive_nodes(ray_runtim
     # No shutdown call needed: stub actors have no real Ray state.
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_manager_finalizes_each_session_on_its_owning_gateway(ray_runtime):
     """create/finalize must route every session back to the same owning gateway
@@ -173,6 +181,8 @@ async def test_gateway_manager_finalizes_each_session_on_its_owning_gateway(ray_
     await manager.shutdown()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_manager_default_chains_config_to_http_finalizes_subagent_before_updated_main(
     ray_runtime,
@@ -252,6 +262,8 @@ async def test_gateway_manager_default_chains_config_to_http_finalizes_subagent_
         await manager.shutdown()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_gateway_manager_allows_concurrent_http_requests_within_one_session(ray_runtime):
     """Two HTTP requests must reach backend generation concurrently and both materialize."""

--- a/tests/uni_agent/gateway/test_message_codec_continuous_token.py
+++ b/tests/uni_agent/gateway/test_message_codec_continuous_token.py
@@ -156,6 +156,8 @@ def _messages(arguments):
     return user, assistant, tool
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize(
     ("model_name", "requires_user", "thinking_prompt"),
     [
@@ -202,6 +204,8 @@ def test_incremental_encode_matches_full_qwen_template(
     assert appended_text.startswith("\n<|im_start|>user\n<tool_response>\nObservation:\nresult")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize(
     ("model_name", "requires_user", "thinking_prompt"),
     [
@@ -272,6 +276,8 @@ def test_incremental_encode_matches_full_qwen_template_for_multiple_tools(
     assert appended_text.count("<tool_response>") == 2
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize(
     ("model_name", "requires_user", "thinking_prompt"),
     [
@@ -318,6 +324,8 @@ def test_incremental_user_encode_appends_qwen_turn(
     assert appended_text == expected_append
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_incremental_encode_rejects_assistant_after_first_message():
     codec = MessageCodec(
         _QwenTemplateTokenizer(
@@ -336,6 +344,8 @@ def test_incremental_encode_rejects_assistant_after_first_message():
         )
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_incremental_assistant_user_encode_matches_full_after_generation_prompt_rollback():
     tokenizer = _QwenTemplateTokenizer(
         "Qwen/Qwen3.5-4B",
@@ -367,6 +377,8 @@ def test_incremental_assistant_user_encode_matches_full_after_generation_prompt_
     assert result_ids == expected_ids
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize(
     ("model_name", "requires_user", "thinking_prompt"),
     [
@@ -414,6 +426,8 @@ def test_incremental_assistant_tool_encode_matches_full_after_generation_prompt_
     assert result_ids == expected_ids
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_qwen35_processor_incremental_encode_matches_full_template():
     tokenizer = _QwenTemplateTokenizer(
         "Qwen/Qwen3.5-4B",
@@ -444,6 +458,8 @@ def test_qwen35_processor_incremental_encode_matches_full_template():
     assert runtime_ids + incremental_ids == expected_ids
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_qwen35_processor_assistant_tool_encode_matches_full_after_generation_prompt_rollback():
     tokenizer = _QwenTemplateTokenizer(
         "Qwen/Qwen3.5-4B",

--- a/tests/uni_agent/gateway/test_message_codec_initialization.py
+++ b/tests/uni_agent/gateway/test_message_codec_initialization.py
@@ -7,6 +7,8 @@ class _UnstableGenerationPromptTokenizer:
         return [10, 20] if not add_generation_prompt else [99, 30, 40]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_initialize_generation_prompt_returns_generation_suffix():
     from tests.uni_agent.support import FakeTokenizer
     from uni_agent.gateway.session import codec as codec_module
@@ -14,6 +16,8 @@ def test_initialize_generation_prompt_returns_generation_suffix():
     assert codec_module.initialize_generation_prompt(FakeTokenizer()) == [ord(char) for char in "assistant:"]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_initialize_generation_prompt_rejects_non_prefix_template():
     from uni_agent.gateway.session import codec as codec_module
 

--- a/tests/uni_agent/gateway/test_message_codec_parser_cache.py
+++ b/tests/uni_agent/gateway/test_message_codec_parser_cache.py
@@ -136,6 +136,8 @@ def _install_fake_verl(monkeypatch, lookups):
     monkeypatch.setitem(sys.modules, "verl.tools.schemas", schemas_module)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_sglang_parser_cache_reuses_equivalent_tool_schemas(monkeypatch):
     from uni_agent.gateway.session.codec import MessageCodec
 
@@ -155,6 +157,8 @@ def test_sglang_parser_cache_reuses_equivalent_tool_schemas(monkeypatch):
     assert len(constructions) == 1
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_vllm_parser_cache_separates_tool_schemas(monkeypatch):
     from uni_agent.gateway.session.codec import MessageCodec
 
@@ -169,6 +173,8 @@ def test_vllm_parser_cache_separates_tool_schemas(monkeypatch):
     assert len(constructions) == 2
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("enable_tool_parser_cache", "expected_constructions"),
@@ -196,6 +202,8 @@ async def test_message_codec_applies_parser_cache_policy_across_decode_calls(
     assert len(constructions) == expected_constructions
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_parser_cache_is_scoped_to_message_codec(monkeypatch):
     from uni_agent.gateway.session.codec import MessageCodec
 
@@ -208,6 +216,8 @@ def test_parser_cache_is_scoped_to_message_codec(monkeypatch):
     assert len(constructions) == 2
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_verl_parser_cache_ignores_tool_schema(monkeypatch):
     from uni_agent.gateway.session.codec import MessageCodec

--- a/tests/uni_agent/gateway/test_message_codec_tool_dispatch.py
+++ b/tests/uni_agent/gateway/test_message_codec_tool_dispatch.py
@@ -27,6 +27,8 @@ def _ids(text: str) -> list[int]:
     return [ord(char) for char in text]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_qwen_vllm_parser_uses_tool_schema_for_argument_types():
     from uni_agent.gateway.session.codec import MessageCodec
 
@@ -48,6 +50,8 @@ def test_qwen_vllm_parser_uses_tool_schema_for_argument_types():
     assert json.loads(calls[0].arguments) == {"query": "docs", "limit": 2}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize(
     "constructor_accepts_tools",
     [False, True],
@@ -101,6 +105,8 @@ def test_vllm_parser_supports_tool_schema_constructor_contracts(monkeypatch, con
         assert "tools" not in seen
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_tool_call_dispatch_uses_sglang_for_sglang_rollout(monkeypatch):
     from uni_agent.gateway.session.codec import MessageCodec
@@ -129,6 +135,8 @@ async def test_tool_call_dispatch_uses_sglang_for_sglang_rollout(monkeypatch):
     assert seen["sglang"] == ("raw", TOOLS, "hermes")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_tool_call_dispatch_uses_vllm_for_vllm_rollout_with_name_mapping(monkeypatch):
     from uni_agent.gateway.session.codec import MessageCodec
@@ -157,6 +165,8 @@ async def test_tool_call_dispatch_uses_vllm_for_vllm_rollout_with_name_mapping(m
     assert seen["vllm"] == ("raw", TOOLS, "qwen3_xml")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_tool_call_dispatch_uses_verl_for_other_rollout_backends(monkeypatch):
     from uni_agent.gateway.session.codec import MessageCodec
@@ -183,6 +193,8 @@ async def test_tool_call_dispatch_uses_verl_for_other_rollout_backends(monkeypat
     assert seen["verl"] == (_ids(text), TOOLS, "hermes")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_tool_call_dispatch_surfaces_selected_parser_failure_without_fallback(monkeypatch):
     from uni_agent.gateway.session.codec import MessageCodec
@@ -203,6 +215,8 @@ async def test_tool_call_dispatch_surfaces_selected_parser_failure_without_fallb
     assert isinstance(exc_info.value.__cause__, ModuleNotFoundError)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_selected_parser_empty_result_is_not_an_error(monkeypatch):
     from uni_agent.gateway.session.codec import MessageCodec
@@ -230,6 +244,8 @@ async def test_selected_parser_empty_result_is_not_an_error(monkeypatch):
     assert calls == []
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_verl_parser_parses_hermes_envelope():
     from uni_agent.gateway.session.codec import MessageCodec
@@ -242,6 +258,8 @@ async def test_verl_parser_parses_hermes_envelope():
     assert json.loads(calls[0].arguments) == {"query": "docs", "limit": 2}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_decode_response_uses_gateway_dispatcher_for_tool_calls(monkeypatch):
     from uni_agent.gateway.session.codec import MessageCodec

--- a/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
+++ b/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
@@ -64,6 +64,8 @@ def _session(
     )
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize("response_length", [0, -1])
 def test_gateway_session_rejects_non_positive_response_length(response_length):
     """Reject non-positive session response budgets during construction."""
@@ -71,6 +73,8 @@ def test_gateway_session_rejects_non_positive_response_length(response_length):
         _session("invalid-response-length", response_length=response_length)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize("prompt_length", [0, -1])
 def test_gateway_session_rejects_non_positive_prompt_length(prompt_length):
     """Reject non-positive session prompt capacity during construction."""
@@ -78,6 +82,8 @@ def test_gateway_session_rejects_non_positive_prompt_length(prompt_length):
         _session("invalid-prompt-length", prompt_length=prompt_length)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_gateway_session_enables_last_assistant_rollback_by_default():
     session = GatewaySession(
         SessionHandle(session_id="rollback-default"),
@@ -195,6 +201,8 @@ def _assert_active_chain_tip_hashes_match_history(session: GatewaySession) -> No
         assert state["active_chain_tip_hashes"][chain.chain_id] == expected_tip_hash
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_linear_conversation_stays_single_chain():
     """Continue a linear conversation on one active chain and trajectory."""
@@ -218,6 +226,8 @@ async def test_multiple_chains_linear_conversation_stays_single_chain():
     assert chain_trajectories[0].reward_info == {"label": "linear"}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_subagent_system_split_returns_to_main_chain():
     """Split subagent history into a sibling and later resume the main chain."""
@@ -251,6 +261,8 @@ async def test_multiple_chains_subagent_system_split_returns_to_main_chain():
     assert trajectories[1].response_mask[-len("Apple") :] == [1] * len("Apple")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_context_compaction_starts_new_chain():
     """Start a new chain when compacted context no longer matches a stored prefix."""
@@ -274,6 +286,8 @@ async def test_multiple_chains_context_compaction_starts_new_chain():
     assert all(t.response_mask == [1] * len(t.response_ids) for t in trajectories)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_first_assistant_rewrite_reuses_chain_without_stale_response():
     """Replace a first assistant in place when no earlier response tokens exist."""
@@ -308,6 +322,8 @@ async def test_first_assistant_rewrite_reuses_chain_without_stale_response():
     assert chain.buffer.response_logprobs == [0.0] * len(incremental_ids) + [-0.1] * len("FIXED")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_first_assistant_rollback_failure_preserves_original_chain():
     """Keep the original first-turn chain when replacement generation fails."""
@@ -329,6 +345,8 @@ async def test_first_assistant_rollback_failure_preserves_original_chain():
     assert _decode_response_ids(session.active_chains[0].buffer.response_ids) == "FORMAT_ERROR"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_first_assistant_rollback_drops_chain_when_replacement_exceeds_capacity():
     """Drop the empty-prefix chain when the replacement prompt cannot fit."""
@@ -358,6 +376,8 @@ async def test_first_assistant_rollback_drops_chain_when_replacement_exceeds_cap
     assert await session.finalize() == []
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_first_assistant_rewrite_with_assistant_tool_context_reuses_chain():
     """Replace a first-turn assistant/tool context in the existing chain."""
@@ -380,6 +400,8 @@ async def test_first_assistant_rewrite_with_assistant_tool_context_reuses_chain(
     assert chain.buffer.response_ids[-len("FIXED") :] == _ids("FIXED")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_later_assistant_rollback_removes_only_the_response_side_gp():
     """Preserve earlier trainable output while removing the latest stale GP."""
@@ -414,6 +436,8 @@ async def test_later_assistant_rollback_removes_only_the_response_side_gp():
     )
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_later_user_rollback_deduplicates_incremental_turn_separator():
     """Keep one turn separator when incremental encoding restores the retained boundary."""
@@ -454,6 +478,8 @@ async def test_later_user_rollback_deduplicates_incremental_turn_separator():
     )
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_later_assistant_rollback_rejects_misaligned_assistant_prefix():
     """Fail closed when the stored turn separator no longer matches the codec."""
@@ -480,6 +506,8 @@ async def test_later_assistant_rollback_rejects_misaligned_assistant_prefix():
         await _run(session, backend, rewrite_messages)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_last_assistant_rollback_splits_when_history_changes_before_boundary():
     """Split when request drift starts before the latest assistant boundary."""
@@ -513,6 +541,8 @@ async def test_last_assistant_rollback_splits_when_history_changes_before_bounda
     assert _decode_response_ids(chains_by_id[2].buffer.response_ids) == "A3"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_last_assistant_rollback_ambiguous_deepest_boundary_splits_over_shallower_exact():
     """Do not fall back to a shallower exact chain when the deepest rewrite is ambiguous."""
@@ -541,6 +571,8 @@ async def test_last_assistant_rollback_ambiguous_deepest_boundary_splits_over_sh
     assert _decode_response_ids(chains_by_id[4].buffer.response_ids) == "FIXED"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_last_assistant_rollback_ignores_shallower_candidate_for_unique_deepest_boundary():
     """Rollback the unique deepest match even when a shallower rewrite also matches."""
@@ -569,6 +601,8 @@ async def test_last_assistant_rollback_ignores_shallower_candidate_for_unique_de
     assert "A2" not in deep_text
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_last_assistant_rollback_excludes_reserved_candidate():
     """Do not select an in-flight chain as a rollback target."""
@@ -591,6 +625,8 @@ async def test_last_assistant_rollback_excludes_reserved_candidate():
     assert _decode_response_ids(chains_by_id[2].buffer.response_ids) == "FIXED"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_last_assistant_rollback_prefers_longer_service_chain_over_exact_short_chain():
     """Rollback the deeper live chain instead of continuing its exact prefix sibling."""
@@ -622,6 +658,8 @@ async def test_last_assistant_rollback_prefers_longer_service_chain_over_exact_s
     assert "A2" not in long_chain_text
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_last_assistant_rollback_tie_prefers_exact_chain_without_drop():
     """Continue the exact chain when its service value ties a rollback candidate."""
@@ -646,6 +684,8 @@ async def test_last_assistant_rollback_tie_prefers_exact_chain_without_drop():
     assert _decode_response_ids(chains_by_id[2].buffer.response_ids).endswith("A2")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_chain_prefix_hash_match_accepts_empty_history_for_any_request():
     """Document the current empty-history wildcard behavior without changing it."""
     session = _session("empty-history-prefix")
@@ -661,6 +701,8 @@ def test_chain_prefix_hash_match_accepts_empty_history_for_any_request():
     )
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_later_assistant_rollback_rejects_misaligned_stored_logprobs():
     """Fail loudly instead of slicing a chain whose token truth is already corrupt."""
@@ -682,6 +724,8 @@ async def test_later_assistant_rollback_rejects_misaligned_stored_logprobs():
         await _run(session, backend, rewrite_messages)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_last_assistant_rollback_disabled_splits_rewritten_assistant():
     """Allow explicit opt-out so rewritten assistants still split trajectories."""
@@ -701,6 +745,8 @@ async def test_last_assistant_rollback_disabled_splits_rewritten_assistant():
     assert _decode_response_ids(chains_by_id[2].buffer.response_ids) == "FIXED"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_repeated_same_prompt_creates_siblings_and_continues_latest():
     """Create siblings for repeated prompts and continue the most recently updated one."""
@@ -731,6 +777,8 @@ async def test_multiple_chains_repeated_same_prompt_creates_siblings_and_continu
     assert 0 in trajectories[-1].response_mask
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_distinct_sibling_continuation_matches_older_assistant_prefix():
     """Select an older sibling when its assistant prefix uniquely matches the request."""
@@ -767,6 +815,8 @@ async def test_multiple_chains_distinct_sibling_continuation_matches_older_assis
     assert decoded == ["NEWER", "OLDERuser:continue older sibling\nassistant:CONT"]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_reserved_siblings_fall_back_before_starting_new_chain():
     """Reserve matching siblings newest-first, then full-encode when all are busy."""
@@ -806,6 +856,8 @@ async def test_multiple_chains_reserved_siblings_fall_back_before_starting_new_c
     assert new_chain.buffer.response_mask == [1] * len("NEW")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_parallel_different_chains_commit_in_place():
     """Commit parallel generations in place when they target distinct live chains."""
@@ -843,6 +895,8 @@ async def test_multiple_chains_parallel_different_chains_commit_in_place():
     assert any(text.startswith("SUB1") and text.endswith("SUB2") for text in decoded)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_parallel_new_siblings_reuse_session_request_id():
     """Retain concurrent first-turn siblings while reusing the sticky session id."""
@@ -863,6 +917,8 @@ async def test_multiple_chains_parallel_new_siblings_reuse_session_request_id():
     assert sorted(_decode_response_ids(trajectory.response_ids) for trajectory in trajectories) == ["A", "B", "C"]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_tools_gate_chain_reuse():
     """Start a sibling chain when a continuation changes the available tools."""
@@ -886,6 +942,8 @@ async def test_multiple_chains_tools_gate_chain_reuse():
     assert [_decode_response_ids(t.response_ids) for t in trajectories] == ["SEARCH", "LOOKUP"]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_committed_assistant_tip_hash_round_trips_through_echoed_request():
     """Match a continuation that echoes the canonical committed assistant message."""
@@ -921,6 +979,8 @@ async def test_multiple_chains_committed_assistant_tip_hash_round_trips_through_
     assert 0 in trajectories[0].response_mask
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_backend_failure_releases_reserved_chain_for_retry():
     """Release an existing-chain reservation when backend generation fails."""
@@ -945,6 +1005,8 @@ async def test_multiple_chains_backend_failure_releases_reserved_chain_for_retry
     assert 0 in trajectories[0].response_mask
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_new_chain_backend_failure_does_not_leave_partial_chain():
     """Avoid creating partial state when a new-chain backend request fails."""
@@ -971,6 +1033,8 @@ async def test_multiple_chains_new_chain_backend_failure_does_not_leave_partial_
     assert trajectories[0].response_mask == [1] * len("MAIN")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_length_exhaustion_closes_selected_chain_and_orders_it_last():
     """Close and order the selected chain when its trajectory capacity is exhausted."""
@@ -1002,6 +1066,8 @@ async def test_multiple_chains_length_exhaustion_closes_selected_chain_and_order
     assert trajectories[1].extra_fields["materialization_reason"] == "max_trajectory_length"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_exactly_exhausted_chain_closes_without_backend_call():
     """Close an exhausted chain even when the repeated request has no incremental tail."""
@@ -1028,6 +1094,8 @@ async def test_multiple_chains_exactly_exhausted_chain_closes_without_backend_ca
     assert trajectories[0].extra_fields["materialization_reason"] == "max_trajectory_length"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_length_exhaustion_orders_before_later_fresh_chain():
     """Order a closed length trajectory before a later normal trajectory."""
@@ -1056,6 +1124,8 @@ async def test_multiple_chains_length_exhaustion_orders_before_later_fresh_chain
     assert trajectories[1].extra_fields == {}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_exactly_exhausted_chain_skips_new_media_extraction():
     """Do not parse unused incremental media after trajectory capacity is full."""
@@ -1093,6 +1163,8 @@ async def test_multiple_chains_exactly_exhausted_chain_skips_new_media_extractio
     assert trajectories[0].extra_fields == {"materialization_reason": "max_trajectory_length"}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_does_not_enforce_response_length_without_prompt_length():
     """Do not treat response_length alone as a response-only token budget."""
@@ -1104,6 +1176,8 @@ async def test_multiple_chains_does_not_enforce_response_length_without_prompt_l
     assert "max_tokens" not in backend.calls[0]["sampling_params"]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_uses_total_trajectory_capacity_instead_of_response_only_budget():
     """Allow response tokens to use unused prompt capacity across turns."""
@@ -1129,6 +1203,8 @@ async def test_multiple_chains_uses_total_trajectory_capacity_instead_of_respons
     assert _decode_response_ids(trajectories[0].response_ids).endswith("SECOND")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_closes_when_continuation_fills_total_trajectory_capacity():
     """Count prompt, generated, and continuation-context tokens against one capacity."""
@@ -1157,6 +1233,8 @@ async def test_multiple_chains_closes_when_continuation_fills_total_trajectory_c
     assert trajectories[0].extra_fields == {"materialization_reason": "max_trajectory_length"}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_returns_length_when_initial_context_fills_total_trajectory_capacity():
     """Return a normal length stop when a fresh prompt leaves no generation room."""
@@ -1179,6 +1257,8 @@ async def test_multiple_chains_returns_length_when_initial_context_fills_total_t
     assert await session.finalize() == []
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_multimodal_media_stays_chain_local():
     """Keep image media isolated between independently selected chains."""
@@ -1216,6 +1296,8 @@ async def test_multiple_chains_multimodal_media_stays_chain_local():
     assert trajectories[1].multi_modal_data == {"images": ["image://main-a.png"]}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_video_media_stays_chain_local():
     """Keep video media and metadata isolated between sibling chains."""
@@ -1255,6 +1337,8 @@ async def test_multiple_chains_video_media_stays_chain_local():
     assert trajectories[1].multi_modal_data == {"videos": [main_video]}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize(
     ("media_kind", "message_factory", "extractor", "sent_url", "unsent_url", "backend_field", "trajectory_key"),
     [
@@ -1319,6 +1403,8 @@ async def test_multiple_chains_length_exhaustion_does_not_materialize_unsent_med
     assert trajectories[0].extra_fields["materialization_reason"] == "max_trajectory_length"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_abort_clears_length_materialized_trajectories():
     """Clear length-materialized trajectories when the session is aborted."""
@@ -1351,6 +1437,8 @@ async def test_multiple_chains_abort_clears_length_materialized_trajectories():
         await session.finalize()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 @pytest.mark.parametrize("terminal_action", ["finalize", "abort"])
 async def test_multiple_chains_terminal_state_rejects_late_commit(terminal_action):
@@ -1384,6 +1472,8 @@ async def test_multiple_chains_terminal_state_rejects_late_commit(terminal_actio
     assert session.snapshot_state()["active_chain_ids"] == []
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_oversized_split_returns_length_without_closing_reserved_chain():
     """Return a length stop without closing the chain reserved by another request."""
@@ -1427,6 +1517,8 @@ async def test_multiple_chains_oversized_split_returns_length_without_closing_re
     assert decoded[0].endswith("CONT")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_decode_failure_releases_reserved_chain_for_retry(monkeypatch):
     """Release an existing-chain reservation when response decoding fails."""
@@ -1454,6 +1546,8 @@ async def test_multiple_chains_decode_failure_releases_reserved_chain_for_retry(
     assert _decode_response_ids(trajectories[0].response_ids).endswith("SECOND")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_cancelled_generation_releases_reserved_chain_for_retry():
     """Release an existing-chain reservation when generation is cancelled."""
@@ -1480,6 +1574,8 @@ async def test_multiple_chains_cancelled_generation_releases_reserved_chain_for_
     assert _decode_response_ids(trajectories[0].response_ids).endswith("RETRY")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_prefix_content_change_does_not_reuse_chain_and_hashes_match_history():
     """Split on changed prefix content and keep stored hashes aligned with history."""
@@ -1505,6 +1601,8 @@ async def test_multiple_chains_prefix_content_change_does_not_reuse_chain_and_ha
     assert all(t.response_mask == [1] * len(t.response_ids) for t in trajectories)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_message_prefix_hashes_canonicalize_json_tool_call_arguments():
     """Canonicalize JSON-equivalent tool arguments before computing prefix hashes."""
     session = _session("hash-tool-arguments")
@@ -1533,6 +1631,8 @@ def test_message_prefix_hashes_canonicalize_json_tool_call_arguments():
     assert raw_a != raw_b
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_message_prefix_hashes_ignore_renamed_and_swapped_tool_call_ids():
     """Ignore call IDs, including whole renames and exchanged result IDs."""
     session = _session("hash-tool-call-ids")
@@ -1567,6 +1667,8 @@ def test_message_prefix_hashes_ignore_renamed_and_swapped_tool_call_ids():
     assert original == swapped_results
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 @pytest.mark.parametrize("rewrite_fresh_tool_result_id", [False, True], ids=["matching-id", "rewritten-fresh-id"])
 async def test_multiple_chains_tool_call_echo_reuses_chain_despite_fresh_tool_result_id(
@@ -1620,6 +1722,8 @@ async def test_multiple_chains_tool_call_echo_reuses_chain_despite_fresh_tool_re
     assert 0 in trajectories[0].response_mask
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_tool_call_id_rewrite_reuses_chain(monkeypatch):
     """Reuse a chain when committed tool-call IDs are rewritten."""
@@ -1675,6 +1779,8 @@ async def test_multiple_chains_tool_call_id_rewrite_reuses_chain(monkeypatch):
     assert 0 in trajectories[0].response_mask
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_requested_response_logprobs_stay_aligned():
     """Collect requested logprobs and zero-fill continuation context tokens."""
@@ -1698,6 +1804,8 @@ async def test_multiple_chains_requested_response_logprobs_stay_aligned():
     assert 0.0 in trajectory.response_logprobs
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_unrequested_response_logprobs_are_ignored():
     """Ignore backend logprobs unless the effective sampling params request them."""
@@ -1709,6 +1817,8 @@ async def test_multiple_chains_unrequested_response_logprobs_are_ignored():
     assert trajectory.response_logprobs is None
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("backend_logprobs", "error_match"),
@@ -1737,6 +1847,8 @@ async def test_multiple_chains_requested_response_logprobs_reject_invalid_backen
     assert state["num_trajectories"] == 0
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_multiple_chains_invalid_continuation_logprobs_release_chain_for_retry():
     """Keep the selected chain unchanged and reusable after logprob validation fails."""
@@ -1767,6 +1879,8 @@ async def test_multiple_chains_invalid_continuation_logprobs_release_chain_for_r
     assert len(trajectory.response_logprobs) == len(trajectory.response_ids)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_weight_versions_span_every_generation_in_a_chain():
     """Report the full weight-version span a multi-turn chain was generated across."""
@@ -1787,6 +1901,8 @@ async def test_weight_versions_span_every_generation_in_a_chain():
     assert trajectory.extra_fields["max_global_steps"] == 5
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_weight_versions_stay_independent_across_split_chains():
     """Keep each chain's version span separate when a request splits a new chain."""
@@ -1808,6 +1924,8 @@ async def test_weight_versions_stay_independent_across_split_chains():
     assert spans == {"BASE": (3, 3), "FRESH": (7, 7)}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_weight_versions_absent_when_backend_omits_them():
     """Omit the version keys rather than materializing None for version-less backends."""

--- a/tests/uni_agent/logging/test_redaction.py
+++ b/tests/uni_agent/logging/test_redaction.py
@@ -8,6 +8,8 @@ from uni_agent.logging.handlers import _formatter
 from uni_agent.logging.redaction import _redact_sensitive_text
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize(
     ("message", "secret"),
     [
@@ -26,11 +28,15 @@ def test_redact_sensitive_text_hides_endpoint_and_credentials(message, secret):
     assert "<redacted>" in redacted
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_redaction_preserves_non_secret_model_names():
     message = "model=ark-code-latest"
     assert _redact_sensitive_text(message) == message
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_shared_formatter_redacts_rendered_log_arguments():
     record = logging.LogRecord(
         name="uni_agent.test",

--- a/tests/uni_agent/sandbox/test_docker_sandbox.py
+++ b/tests/uni_agent/sandbox/test_docker_sandbox.py
@@ -14,6 +14,8 @@ def _ok(stdout: str = "") -> ExecResult:
     return ExecResult(exit_code=0, stdout=stdout, stderr="")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_registry_builds_docker_sandbox_from_config():
     config = SandboxConfig(
         provider="docker",
@@ -33,6 +35,8 @@ def test_registry_builds_docker_sandbox_from_config():
     assert DockerSandbox.exec is Sandbox.exec
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_start_requires_local_image_and_builds_detached_run(monkeypatch):
     sandbox = DockerSandbox(
         image="example:local",
@@ -70,6 +74,8 @@ def test_start_requires_local_image_and_builds_detached_run(monkeypatch):
     assert sandbox._container_name == "agent-test"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_start_pulls_missing_image_through_docker_run(monkeypatch):
     sandbox = DockerSandbox(image="registry.example.com/agent:latest", container_name="agent-test")
     calls: list[tuple[str, ...]] = []
@@ -98,6 +104,8 @@ def test_start_pulls_missing_image_through_docker_run(monkeypatch):
     ]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_start_rejects_missing_local_image(monkeypatch):
     sandbox = DockerSandbox(image="missing:local", pull_policy="never")
 
@@ -111,11 +119,15 @@ def test_start_rejects_missing_local_image(monkeypatch):
     assert sandbox._container_name is None
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_rejects_unknown_pull_policy():
     with pytest.raises(ValueError, match="pull_policy"):
         DockerSandbox(pull_policy="sometimes")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_exec_forwards_workdir_environment_and_argv(monkeypatch):
     sandbox = DockerSandbox(image="example:local")
     sandbox._container_name = "agent-test"
@@ -156,6 +168,8 @@ def test_exec_forwards_workdir_environment_and_argv(monkeypatch):
     ]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_stop_is_idempotent_and_checks_liveness(monkeypatch):
     sandbox = DockerSandbox(image="example:local")
     sandbox._container_name = "agent-test"
@@ -182,6 +196,8 @@ def test_stop_is_idempotent_and_checks_liveness(monkeypatch):
     ]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_upload_and_download_use_docker_cp(monkeypatch, tmp_path: Path):
     sandbox = DockerSandbox(image="example:local")
     sandbox._container_name = "agent-test"

--- a/tests/uni_agent/sandbox/test_exec_error_policy.py
+++ b/tests/uni_agent/sandbox/test_exec_error_policy.py
@@ -56,6 +56,8 @@ class _FakeSandbox(Sandbox):
 # --------------------------- exec() error policy ---------------------------
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_success_passes_through_and_forwards_args():
     sb = _FakeSandbox(result=ExecResult(exit_code=0, stdout="hi", stderr=""))
     res = asyncio.run(sb.exec(["echo", "hi"], timeout=7, workdir="/w", env={"A": "1"}))
@@ -63,6 +65,8 @@ def test_success_passes_through_and_forwards_args():
     assert sb.calls == [{"argv": ["echo", "hi"], "timeout": 7, "workdir": "/w", "env": {"A": "1"}}]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize("exc", [asyncio.TimeoutError(), TimeoutError("slow")])
 def test_timeout_becomes_exit_code_minus_one(exc):
     sb = _FakeSandbox(error=exc)
@@ -72,6 +76,8 @@ def test_timeout_becomes_exit_code_minus_one(exc):
     assert "exec timed out after 5" in res.stderr
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_non_timeout_error_downgrades_to_127_when_alive():
     sb = _FakeSandbox(error=RuntimeError("no such file"), alive=True)
     res = asyncio.run(sb.exec(["missing-bin"]))
@@ -80,6 +86,8 @@ def test_non_timeout_error_downgrades_to_127_when_alive():
     assert res.stderr == "no such file"  # exact backend message, verbatim
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_non_timeout_error_reraises_when_sandbox_dead():
     boom = RuntimeError("backend gone")
     sb = _FakeSandbox(error=boom, alive=False)
@@ -88,6 +96,8 @@ def test_non_timeout_error_reraises_when_sandbox_dead():
     assert excinfo.value is boom  # the original infra fault, re-raised unchanged
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_timeout_wins_over_liveness_even_when_dead():
     # A timeout is classified before the liveness check, so it never re-raises.
     sb = _FakeSandbox(error=TimeoutError(), alive=False)
@@ -95,6 +105,8 @@ def test_timeout_wins_over_liveness_even_when_dead():
     assert res.exit_code == -1
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_exec_shell_wraps_in_non_login_bash():
     sb = _FakeSandbox(result=ExecResult(exit_code=0, stdout="", stderr=""))
     asyncio.run(sb.exec_shell("echo hi", timeout=3, workdir="/tmp"))
@@ -121,6 +133,8 @@ class _NoIsAlive(Sandbox):
         raise RuntimeError("kaboom")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_base_is_alive_defaults_true_so_errors_downgrade():
     sb = _NoIsAlive()
     assert asyncio.run(sb.is_alive()) is True
@@ -137,6 +151,8 @@ class _CustomTimeoutSandbox(_FakeSandbox):
         return isinstance(exc, _CustomTimeout) or super()._is_timeout_error(exc)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_is_timeout_error_override_is_honored_by_exec():
     sb = _CustomTimeoutSandbox(error=_CustomTimeout("slow"))
     res = asyncio.run(sb.exec(["x"], timeout=9))
@@ -149,6 +165,8 @@ def test_is_timeout_error_override_is_honored_by_exec():
 _PROVIDERS = ["local", "docker", "modal", "vefaas", "openyuanrong"]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize("name", _PROVIDERS)
 def test_provider_implements_private_exec_and_shares_public_exec(name):
     cls = get_sandbox_cls(name)
@@ -157,6 +175,8 @@ def test_provider_implements_private_exec_and_shares_public_exec(name):
     assert cls.exec is Sandbox.exec
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_local_file_operations_use_host_filesystem(tmp_path):
     from uni_agent.sandbox.local import LocalSandbox
 
@@ -185,6 +205,8 @@ def _named_exc(name: str) -> Exception:
     return type(name, (Exception,), {})()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_vefaas_recognizes_its_timeout_by_name(monkeypatch):
     monkeypatch.setenv("VEFAAS_FUNCTION_ID", "fid")
     monkeypatch.setenv("VEFAAS_FUNCTION_ROUTE", "route")
@@ -196,6 +218,8 @@ def test_vefaas_recognizes_its_timeout_by_name(monkeypatch):
     assert sb._is_timeout_error(RuntimeError("other")) is False
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_modal_inherits_base_timeout_check():
     from uni_agent.sandbox.modal import ModalSandbox
 
@@ -205,6 +229,8 @@ def test_modal_inherits_base_timeout_check():
     assert sb._is_timeout_error(RuntimeError("other")) is False
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_openyuanrong_recognizes_its_timeout():
     from uni_agent.sandbox.openyuanrong import OpenyuanrongSandbox
 
@@ -217,18 +243,24 @@ def test_openyuanrong_recognizes_its_timeout():
 # --------------------------- provider is_alive() liveness ---------------------------
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_modal_is_alive_false_before_start():
     from uni_agent.sandbox.modal import ModalSandbox
 
     assert asyncio.run(ModalSandbox().is_alive()) is False
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_docker_is_alive_false_before_start():
     from uni_agent.sandbox.docker import DockerSandbox
 
     assert asyncio.run(DockerSandbox().is_alive()) is False
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_vefaas_is_alive_false_before_start(monkeypatch):
     monkeypatch.setenv("VEFAAS_FUNCTION_ID", "fid")
     monkeypatch.setenv("VEFAAS_FUNCTION_ROUTE", "route")
@@ -237,6 +269,8 @@ def test_vefaas_is_alive_false_before_start(monkeypatch):
     assert asyncio.run(VefaasSandbox().is_alive()) is False
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_openyuanrong_is_alive_false_before_start():
     from uni_agent.sandbox.openyuanrong import OpenyuanrongSandbox
 
@@ -258,6 +292,8 @@ def _fake_modal_sandbox(*, poll_returns=None, poll_raises: BaseException | None 
     return _Sandbox()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_modal_is_alive_true_while_task_running():
     from uni_agent.sandbox.modal import ModalSandbox
 
@@ -266,6 +302,8 @@ def test_modal_is_alive_true_while_task_running():
     assert asyncio.run(sb.is_alive()) is True
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_modal_is_alive_false_when_terminated():
     from uni_agent.sandbox.modal import ModalSandbox
 
@@ -274,6 +312,8 @@ def test_modal_is_alive_false_when_terminated():
     assert asyncio.run(sb.is_alive()) is False
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_modal_is_alive_false_and_swallows_poll_errors():
     from uni_agent.sandbox.modal import ModalSandbox
 
@@ -285,6 +325,8 @@ def test_modal_is_alive_false_and_swallows_poll_errors():
 # --------------------------- veFaaS multi-function selection ---------------------------
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_vefaas_single_function_pair(monkeypatch):
     monkeypatch.setenv("VEFAAS_FUNCTION_ID", "fid")
     monkeypatch.setenv("VEFAAS_FUNCTION_ROUTE", "route")
@@ -294,6 +336,8 @@ def test_vefaas_single_function_pair(monkeypatch):
     assert (sb._function_id, sb._function_route) == ("fid", "route")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_vefaas_multi_function_pairs_by_index(monkeypatch):
     # Comma-separated ids/routes pair up one-to-one; whitespace is trimmed.
     monkeypatch.setenv("VEFAAS_FUNCTION_ID", "fid1, fid2 ,fid3")
@@ -316,6 +360,8 @@ def test_vefaas_multi_function_pairs_by_index(monkeypatch):
     assert seen == expected
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_vefaas_mismatched_pair_counts_raise(monkeypatch):
     monkeypatch.setenv("VEFAAS_FUNCTION_ID", "fid1,fid2")
     monkeypatch.setenv("VEFAAS_FUNCTION_ROUTE", "route1")
@@ -325,6 +371,8 @@ def test_vefaas_mismatched_pair_counts_raise(monkeypatch):
         VefaasSandbox()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_vefaas_missing_function_env_raises(monkeypatch):
     monkeypatch.delenv("VEFAAS_FUNCTION_ID", raising=False)
     monkeypatch.setenv("VEFAAS_FUNCTION_ROUTE", "route")
@@ -334,6 +382,8 @@ def test_vefaas_missing_function_env_raises(monkeypatch):
         VefaasSandbox()
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_vefaas_install_command_downloads_then_execs():
     from uni_agent.sandbox.vefaas import _install_command
 

--- a/tests/uni_agent/tasks/test_inference_task_routing.py
+++ b/tests/uni_agent/tasks/test_inference_task_routing.py
@@ -5,6 +5,8 @@ import pytest
 from uni_agent.tasks import TaskConfigResolver
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_resolver_loads_every_named_entry(tmp_path):
     config_path = tmp_path / "tasks.yaml"
     config_path.write_text(
@@ -29,6 +31,8 @@ def test_resolver_loads_every_named_entry(tmp_path):
     assert resolver.defaults_by_name["task_a"]["agent"]["model"]["temperature"] == 0.2
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_resolver_routes_by_name_and_applies_sample_and_runtime_overrides():
     defaults = {
         "task_a": {
@@ -83,6 +87,8 @@ def test_resolver_routes_by_name_and_applies_sample_and_runtime_overrides():
     assert resolved["agent"]["model"]["api_key"] == "runtime-key"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_resolver_rejects_missing_route():
     resolver = TaskConfigResolver({"other": {"name": "other"}})
     with pytest.raises(ValueError, match="no Task Config for sample task 'missing'"):

--- a/tests/uni_agent/tasks/test_parallel_infer_api.py
+++ b/tests/uni_agent/tasks/test_parallel_infer_api.py
@@ -6,6 +6,8 @@ from examples.inference import parallel_infer_api
 from examples.inference.parallel_infer_api import _allocate_worker_concurrency
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize(
     ("total_concurrency", "num_workers", "expected"),
     [
@@ -21,6 +23,8 @@ def test_allocate_worker_concurrency_preserves_global_limit(total_concurrency, n
     assert sum(limits) == total_concurrency
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_standalone_inference_binds_top_level_source_prompt(monkeypatch, tmp_path):
     config_path = tmp_path / "tasks.yaml"
     config_path.write_text(

--- a/tests/uni_agent/tasks/test_swe_prompt_preprocess.py
+++ b/tests/uni_agent/tasks/test_swe_prompt_preprocess.py
@@ -28,6 +28,8 @@ class _FakeDataset:
         return _FakeDataset([function(deepcopy(row)) for row in self.rows])
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize(
     ("module", "build_name", "row"),
     [
@@ -94,6 +96,8 @@ def test_swe_preprocess_emits_source_prompt_without_nested_rendered_prompt(monke
         assert task_config["metadata"]["language"] == "C"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize(
     ("recipe_path", "task_name", "expects_submit", "expects_language"),
     [

--- a/tests/uni_agent/test_rlinsight_adapter.py
+++ b/tests/uni_agent/test_rlinsight_adapter.py
@@ -26,6 +26,8 @@ def _capture_trace_span(monkeypatch: pytest.MonkeyPatch):
     return captured
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_report_span_merges_identity_and_normalizes_attributes(monkeypatch: pytest.MonkeyPatch) -> None:
     captured = _capture_trace_span(monkeypatch)
     token = rlinsight_adapter._set_trace_identity({"uid": "u1", "sample": "7"})
@@ -44,6 +46,8 @@ def test_report_span_merges_identity_and_normalizes_attributes(monkeypatch: pyte
     assert attributes["payload"] == '{"turn": 1}'
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_task_span_reports_identity_and_result(monkeypatch: pytest.MonkeyPatch) -> None:
     captured = _capture_trace_span(monkeypatch)
     tools_kwargs = {
@@ -70,6 +74,8 @@ def test_task_span_reports_identity_and_result(monkeypatch: pytest.MonkeyPatch) 
     assert attributes["reward_posted"] is True
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_generation_span_success_uses_chain_lane(monkeypatch: pytest.MonkeyPatch) -> None:
     captured = _capture_trace_span(monkeypatch)
     monkeypatch.setattr(
@@ -108,6 +114,8 @@ def test_generation_span_success_uses_chain_lane(monkeypatch: pytest.MonkeyPatch
     assert attributes["finish_reason"] == "stop"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_old_verl_missing_optional_apis_degrades_to_warnings(monkeypatch: pytest.MonkeyPatch, caplog) -> None:
     class OldVerlLogger:
         pass

--- a/tests/uni_agent/tools/test_edit_file_arguments.py
+++ b/tests/uni_agent/tools/test_edit_file_arguments.py
@@ -14,11 +14,15 @@ def _parse_view_range(value):
     ).view_range
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize("value", ([51, 63], "[51, 63]", "  [51, 63]\n"))
 def test_view_range_accepts_list_and_json_encoded_list(value):
     assert _parse_view_range(value) == [51, 63]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize(
     "value",
     (
@@ -33,6 +37,8 @@ def test_view_range_rejects_invalid_json_shape_or_elements(value):
         _parse_view_range(value)
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_view_range_schema_remains_an_integer_array():
     schema = EditFileTool(object()).schema()
     view_range_schema = schema["function"]["parameters"]["properties"]["view_range"]

--- a/tests/uni_agent/tools/test_shell_channel.py
+++ b/tests/uni_agent/tools/test_shell_channel.py
@@ -19,6 +19,8 @@ class RecordingBackend:
         self.writes.append((path, content))
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_start_command_keeps_large_payload_out_of_tmux_argv():
     backend = RecordingBackend()
@@ -40,6 +42,8 @@ async def test_start_command_keeps_large_payload_out_of_tmux_argv():
     assert len(injected_line) < 1_000
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_interrupt_returns_when_ctrl_c_finishes_command(monkeypatch: pytest.MonkeyPatch):
     backend = RecordingBackend()
@@ -61,6 +65,8 @@ async def test_interrupt_returns_when_ctrl_c_finishes_command(monkeypatch: pytes
     assert [call[-1] for call in send_keys_calls] == ["C-c"]
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_interrupt_suspends_and_kills_job_when_ctrl_c_fails(monkeypatch: pytest.MonkeyPatch):
     backend = RecordingBackend()
@@ -87,6 +93,8 @@ async def test_interrupt_suspends_and_kills_job_when_ctrl_c_fails(monkeypatch: p
     assert "kill -KILL %+" in fallback_line
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
 async def test_run_marks_timeout_even_when_interrupt_reports_an_exit_code(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/uni_agent/tools/test_toolbox_call_errors.py
+++ b/tests/uni_agent/tools/test_toolbox_call_errors.py
@@ -84,6 +84,8 @@ def _toolbox() -> Toolbox:
 # --------------------------- Toolbox.call: error returns ---------------------------
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_unknown_tool_returns_format_hint():
     result = asyncio.run(_toolbox().call("does_not_exist", "{}"))
     assert result.status == "format_error"
@@ -91,6 +93,8 @@ def test_unknown_tool_returns_format_hint():
     assert "Allowed functions should be one of:" in result.text
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize(
     "raw, needle",
     [
@@ -106,12 +110,16 @@ def test_bad_arguments_return_format_hint(raw, needle):
     assert needle in result.text
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_tool_error_is_caught_and_tagged():
     result = asyncio.run(_toolbox().call("boom", "{}"))
     assert result.status == "error"
     assert result.text == "Error: kaboom"
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_unexpected_exception_propagates():
     # A non-ToolError (tool bug / infra fault) is NOT swallowed into an observation;
     # it propagates so the caller ends/buckets the episode instead of feeding it back.
@@ -119,6 +127,8 @@ def test_unexpected_exception_propagates():
         asyncio.run(_toolbox().call("kaboom", "{}"))
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize("raw", ["{}", "", None, '{"a": 1}', {"a": 1}])
 def test_valid_arguments_run_the_tool(raw):
     result = asyncio.run(_toolbox().call("echo", raw))
@@ -126,6 +136,8 @@ def test_valid_arguments_run_the_tool(raw):
     assert result.text.startswith("args=")
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_arguments_are_validated_and_coerced_before_dispatch():
     result = asyncio.run(
         _toolbox().call(
@@ -137,6 +149,8 @@ def test_arguments_are_validated_and_coerced_before_dispatch():
     assert json.loads(result.text) == {"limit": 2, "mode": "fast", "query": "docs"}
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize(
     ("arguments", "needle"),
     [
@@ -153,6 +167,8 @@ def test_schema_validation_errors_are_returned_as_format_observations(arguments,
     assert needle in result.text
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_timeout_is_forwarded_to_the_tool():
     result = asyncio.run(_toolbox().call("echo", "{}", timeout=12.5))
     assert "timeout=12.5" in result.text
@@ -161,6 +177,8 @@ def test_timeout_is_forwarded_to_the_tool():
 # --------------------------- status classification ---------------------------
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.parametrize(
     "name, raw, expected_status",
     [
@@ -180,11 +198,15 @@ def test_call_status(name, raw, expected_status):
 # --------------------------- to_observation() ---------------------------
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_to_observation_prepends_the_label():
     assert ToolResult(text="hello").to_observation() == "Observation:\nhello"
     assert ToolResult().to_observation() == "Observation:\n"  # no text channel -> just the label
 
 
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_to_observation_clips_over_max_length():
     text = "x" * 50
     clipped = ToolResult(text=text).to_observation(max_length=10)


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes and why.
-->

## Changes

<!-- List the key changes. -->

- Add cpu and level labal

- Only calculate coverage from uni_agent folder

## PR title

Use `[area] type: summary`.

- Areas: `agents`, `framework`, `gateway`, `logging`, `sandbox`, `tasks`, `tools`, `training`, `app`, `docs`, `examples`, `ci`, `build`, `deps`, `misc`
- Types: `feat`, `fix`, `refactor`, `perf`, `test`, `docs`, `chore`, `revert`
- Separate multiple areas with comma-space: `[agents, sandbox] feat: add isolated harness execution`
- Prefix compatibility-breaking work with `[BREAKING]`: `[BREAKING][tasks, docs] refactor: replace task config schema`
- A stacked series may start with `[1/N]`: `[1/N][gateway] refactor: split protocol adapters`

## Checklist

- [x] The PR is focused and linked to an issue or explains why no issue is needed.
- [x] The title follows the format above and names the layer that owns the change.
- [x] Tests cover the behavior, or the Validation section explains why they are not practical.
- [x] User-facing API, config, and workflow changes include documentation or runnable examples.
- [x] Compatibility impact and migration steps are documented.
- [x] Logs, fixtures, and examples contain no credentials or private data.
- [x] `pre-commit run --all-files --show-diff-on-failure` passes.
