### PR TITLE
[WIP][framework, tasks, gateway] feat: collect agent metrics and score from TaskResult

### DIFF
--- a/docs/source/concepts/gateway-and-trajectories.md
+++ b/docs/source/concepts/gateway-and-trajectories.md
@@ -37,8 +37,8 @@ For each rollout session, the Agent Framework:
 4. The runner injects the session endpoint into `agent.model`.
 5. The Agent sends OpenAI Chat Completions or Anthropic Messages requests to the session URL.
 6. The Gateway forwards tokenized requests to the verl rollout engine.
-7. The Task posts its final reward to the session.
-8. The framework finalizes the session and writes trajectories to TransferQueue.
+7. The Task returns a `TaskResult` with `reward` / `accuracy` / `finished` / `metrics`.
+8. The framework finalizes the session, scores from `TaskResult`, and writes trajectories to TransferQueue.
 
 The model-facing endpoints are:
 
@@ -67,9 +67,10 @@ finalized trajectories before reward scoring and artifact logging. The order is:
 
 ```text
 Gateway finalization
+    -> Framework copies TaskResult reward/acc/finished onto every trajectory as reward_info
     -> Runner trajectory_selection (all or longest)
     -> trajectory postprocessor
-    -> reward scoring
+    -> score from TaskResult; merge TaskResult.metrics onto the last trajectory
     -> trajectory logs and TransferQueue
 ```
 
@@ -150,25 +151,34 @@ by default and can be disabled with
 
 ## Reward Flow
 
-The built-in Task Runner posts:
+The built-in Task Runner returns a `TaskResult`. Reward does not enter the
+Gateway. After finalization the Agent Framework copies `reward` / `acc` /
+`finished` onto every trajectory as session `reward_info` (dump /
+`mask_unfinished_episode` metadata only):
 
 ```json
 {
-  "reward_info": {
-    "reward": 1.0,
-    "acc": 1.0,
-    "finished": true
-  }
+  "reward": 1.0,
+  "acc": 1.0,
+  "finished": true
 }
 ```
 
-The Agent Framework reads the session reward, applies it to finalized trajectories, and writes a sparse token-level `rm_scores` tensor with the reward on the final token.
+Scoring and metrics stay on `TaskResult`. After `trajectory_selection` /
+`trajectory_postprocessor`, the Framework writes `TaskResult.reward` onto a
+sparse token-level `rm_scores` tensor and merges `TaskResult.metrics` onto the
+last trajectory's `agent_metrics`.
+
+Not returning a `TaskResult` is the same as a Gateway session that never
+received a reward. Session `reward_info` is scored if the Gateway has one. A
+configured `RewardLoopWorker` is the custom reward path for sessions with no
+Task-provided reward (judge / RewardManager), not a last-resort fallback.
+Without a session reward and without a RewardLoopWorker score, `rm_scores`
+remains zero and the framework emits a warning.
 
 Agent completion is factual session metadata; the Framework, not the Task, decides how training consumes it. When the training configuration enables `mask_unfinished_episode`, a session with `finished=false` is still written and tagged as successful, but its TransferQueue `response_mask` and `loss_mask` are all zero so it does not contribute policy gradients, loss-normalization counts, or auxiliary losses.
 
 Masking stops at the loss. The trajectory keeps its reward in `rm_scores`, so a group-relative estimator such as GRPO or RLOO still folds that reward into the group mean and standard deviation, shifting the advantages of the sibling rollouts sharing its `uid`. The masked trajectory itself gets a zero advantage, and it still costs a full forward and backward pass. Treat unfinished episodes as evidence that keeps the baseline honest, not as samples removed from the batch.
-
-If no Task reward is reported, an optional verl Reward Loop Worker can score the final trajectory. Without either source, `rm_scores` remains zero and the framework emits a warning.
 
 ## TransferQueue
 
@@ -202,7 +212,6 @@ The trainer's ReplayBuffer consumes completed records independently of rollout t
 - A prompt is marked `finished` when any of its sessions succeeds.
 - A prompt is marked `failure` when all sessions fail.
 - A batch raises only when every rollout fails.
-- Reward reporting is best-effort and logs failures.
 
 This isolation is important for long-horizon workloads, where session latency and failure modes vary widely.
 

--- a/docs/source/concepts/rl-insight-integration.md
+++ b/docs/source/concepts/rl-insight-integration.md
@@ -77,9 +77,9 @@ agent sessions run.
 
 ### `TaskSpanState`
 
-Mutable state collected while a task runs. Call `record_result(result,
-reward_posted=...)` after the task and reward POST complete. The context manager
-reports the final `agent_task` span, including failures that propagate.
+Mutable state collected while a task runs. Call `record_result(result)` after
+the task completes. The context manager reports the final `agent_task` span,
+including failures that propagate.
 
 ### `task_span(tools_kwargs, task_name, prompt)`
 

--- a/docs/source/concepts/task-and-reward.md
+++ b/docs/source/concepts/task-and-reward.md
@@ -78,9 +78,11 @@ Task-rendered messages are not guaranteed to equal a self-rendering Agent's fina
 
 ## Episode Implementation
 
-A Task implements `run()` without arguments because all sample state lives on its config:
+A Task implements `run()` without arguments because all sample state lives on its config.
+Each Task installs per-task metrics in `run()` with :class:`~uni_agent.metrics.task_metrics`.
 
 ```python
+from uni_agent.metrics import task_metrics, timing
 from uni_agent.tasks.base import Task, TaskResult
 from uni_agent.tasks.registry import register_task
 
@@ -90,28 +92,34 @@ class MyTask(Task):
     config_model = MyTaskConfig
 
     async def run(self) -> TaskResult:
-        config: MyTaskConfig = self.config
+        async with task_metrics() as collector:
+            with timing("task.total_s"):
+                config: MyTaskConfig = self.config
 
-        async with self.build_sandbox() as sandbox:
-            agent = self.build_agent()
-            agent_result = await agent.run(
-                sandbox=sandbox,
-                messages=config.prompt,
-                workdir=None,
-            )
+                async with self.build_sandbox() as sandbox:
+                    agent = self.build_agent()
+                    with timing("task.generate_s"):
+                        agent_result = await agent.run(
+                            sandbox=sandbox,
+                            messages=config.prompt,
+                            workdir=None,
+                        )
 
-            score = await compute_reward(
-                config.metadata,
-                sandbox,
-                agent_result,
-            )
+                    with timing("reward.s"):
+                        score = await compute_reward(
+                            config.metadata,
+                            sandbox,
+                            agent_result,
+                        )
 
-        return TaskResult(
-            reward=score,
-            accuracy=score,
-            finished=agent_result.finished,
-            extra_info={"score": score},
-        )
+                result = TaskResult(
+                    reward=score,
+                    accuracy=score,
+                    finished=agent_result.finished,
+                    extra_info={"score": score},
+                )
+            result.metrics = collector.metrics()
+            return result
 ```
 
 `build_sandbox()` and `build_agent()` dispatch through their registries. Logging is provided by the runtime that invokes the Task; the Task only emits normal log records.
@@ -150,7 +158,12 @@ TaskResult(
 ```
 
 Custom Tasks may return scalar, dense, rubric-based, or multi-component rewards. The framework consumes
-`TaskResult.reward`; additional metrics belong in `accuracy` and `extra_info`.
+`TaskResult.reward`; additional scoring fields belong in `accuracy` and `extra_info`.
+Observability timings and counters belong in `TaskResult.metrics`.
+
+Not returning a `TaskResult` (or returning one with no `reward`) is the same as a
+Gateway session that never received a reward. A configured `RewardLoopWorker` is
+the custom scoring path for that case, not a fallback after Task scoring.
 
 `TaskResult.finished` is factual episode metadata copied from
 `AgentResult.finished`; it does not decide whether the trajectory contributes to

--- a/examples/inference/parallel_infer_api.py
+++ b/examples/inference/parallel_infer_api.py
@@ -35,6 +35,7 @@ from datasets import load_dataset
 from tqdm import tqdm
 
 from uni_agent.logging import LogContext, sample_logging
+from uni_agent.metrics import aggregate, report_metrics
 from uni_agent.tasks import TaskConfigResolver, get_task
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s")
@@ -65,6 +66,7 @@ class InferenceActor:
                         "eval_completed": bool(info.get("eval_completed", True)),
                         "eval_execution_time": info.get("eval_execution_time"),
                         "eval_report": info.get("eval_report"),
+                        "metrics": result.metrics or {},
                     }
                 except Exception as e:
                     logger.error(f"error running {instance_id}: {type(e).__name__}: {e}")
@@ -76,6 +78,7 @@ class InferenceActor:
                         "eval_completed": False,
                         "eval_execution_time": None,
                         "error": f"{type(e).__name__}: {e}",
+                        "metrics": {},
                     }
 
 
@@ -229,6 +232,12 @@ def main() -> None:
     pass_rate = success_num / all_num * 100 if all_num else 0.0
     mean_reward = sum(float(r.get("reward", 0.0)) for r in results) / all_num if all_num else 0.0
 
+    metrics = [r["metrics"] for r in results if r.get("metrics")]
+    flat_metrics = aggregate(metrics)
+    flat_metrics["tasks"] = float(all_num)
+    metrics_path = str(Path(args.log_dir).expanduser() / "metrics.jsonl") if args.log_dir else None
+    report_metrics(flat_metrics, experiment="parallel_infer_api", filepath=metrics_path)
+
     summary = "\n".join(
         [
             "",
@@ -255,6 +264,7 @@ def main() -> None:
         "mean_reward": mean_reward,
         "average_eval_execution_time": avg_exec_time,
         "wall_time": wall,
+        "metrics": flat_metrics,
     }
     if args.result_path:
         output_path = Path(args.result_path).expanduser()

--- a/examples/inference/parallel_infer_verl.py
+++ b/examples/inference/parallel_infer_verl.py
@@ -11,8 +11,8 @@ framework adapter + TransferQueue (TQ):
     ->  per-trajectory records written to TransferQueue
 
 The per-sample score is the trainer's own ``rm_scores`` read back from TQ: ``run_task``
-(``report_reward=True``) posts the task reward to its session, and the framework writes
-it as ``reward_score`` -- no external reward model. Fan-out is ``rollout.n`` (``--n``),
+returns a ``TaskResult``, and the framework stamps it onto the session trajectories as
+``reward_score`` -- no external reward model. Fan-out is ``rollout.n`` (``--n``),
 with no resolved/wrong-answer/timeout bucketing (just mean ``rm_scores``).
 
 Example (single node, 4-way tensor parallel)::
@@ -49,6 +49,7 @@ except ImportError:  # fall back to verl's shim (mock raises a clear error if TQ
     from verl.utils.transferqueue_utils import tq
 
 from uni_agent.framework.entry import AgentFrameworkRolloutAdapter
+from uni_agent.metrics import aggregate, report_metrics
 from uni_agent.tasks import TaskConfigResolver
 from verl.utils import tensordict_utils as tu
 from verl.workers.rollout.llm_server import LLMServerManager
@@ -139,7 +140,6 @@ def init_config(args: argparse.Namespace, *, task_configs: list[dict], served_mo
                 "runner_kwargs": {
                     "task_config_path": args.task_config,
                     "model_name": served_model_name,
-                    "report_reward": True,
                 },
             }
         },
@@ -207,8 +207,15 @@ def _read_rm_scores(uids: list, *, partition_id: str = PARTITION_ID) -> dict:
 
     per_uid: dict[str, list[float]] = defaultdict(list)
     scores: list[float] = []
+    metrics: list = []
     if final_keys:
-        data = tq.kv_batch_get(keys=final_keys, partition_id=partition_id, select_fields=["rm_scores"])
+        try:
+            data = tq.kv_batch_get(
+                keys=final_keys, partition_id=partition_id, select_fields=["rm_scores", "agent_metrics"]
+            )
+            metrics = [item for item in list(data.get("agent_metrics") or []) if item]
+        except ValueError:
+            data = tq.kv_batch_get(keys=final_keys, partition_id=partition_id, select_fields=["rm_scores"])
         scores = [float(s) for s in data["rm_scores"].sum(dim=-1).tolist()]
         for (uid, _session), score in zip(final_sessions, scores, strict=True):
             per_uid[uid].append(score)
@@ -221,6 +228,7 @@ def _read_rm_scores(uids: list, *, partition_id: str = PARTITION_ID) -> dict:
         "final_keys": final_keys,
         "traj_keys": traj_keys,
         "uid_keys": uid_keys,
+        "metrics": metrics,
     }
 
 
@@ -253,6 +261,12 @@ def _report(
         ]
     )
     print(summary)
+
+    metrics = read.get("metrics") or []
+    if metrics:
+        flat_metrics = aggregate(metrics)
+        metrics_path = os.path.join(os.path.expanduser(args.log_dir), "metrics.jsonl") if args.log_dir else None
+        report_metrics(flat_metrics, experiment="parallel_infer_verl", filepath=metrics_path)
 
     if args.result_path:
         result_path = os.path.expanduser(args.result_path)

--- a/examples/mem_agent/train_mem_agent.sh
+++ b/examples/mem_agent/train_mem_agent.sh
@@ -182,7 +182,6 @@ PY
     ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.trajectory_selection=all \
     ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_kwargs.task_config_path="${TASK_CONFIG}" \
     ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_kwargs.model_name="${SERVED_MODEL_NAME}" \
-    ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_kwargs.report_reward=True \
     ++actor_rollout_ref.rollout.custom.agent_framework.use_reward_loop_worker=False \
     ++actor_rollout_ref.rollout.custom.agent_framework.mask_unfinished_episode=False \
     trainer.project_name="${PROJECT_NAME}" \

--- a/examples/mini_swe_agent/README.md
+++ b/examples/mini_swe_agent/README.md
@@ -19,7 +19,7 @@ flowchart TB
     H --> J["MiniSweAgentAgent.run()<br/>base64 task config -> stdin of run_agent.py"]
     J --> K["in-sandbox mini-swe-agent<br/>executes in /testbed, LLM calls via gateway"]
     K --> L["result JSON on stdout<br/>finished = exit_status == Submitted"]
-    L --> M["compute_reward in the same sandbox<br/>POST reward_info to the session"]
+    L --> M["compute_reward in the same sandbox<br/>TaskResult returned to Framework"]
 ```
 
 Per sample, `uni_agent.framework.task_runner.run_task`:
@@ -30,8 +30,10 @@ Per sample, `uni_agent.framework.task_runner.run_task`:
    through the tunnel without needing to reach the training cluster directly.
 3. **Run** mini-swe-agent inside the sandbox: the task config is piped (base64) into the
    tool-image python, which runs the real mini-swe-agent against `/testbed` and the policy.
-4. **Score** in the same sandbox and POST the reward back (`report_reward=True`); an
-   episode counts as finished only when the agent actually submits a patch
+4. **Score** in the same sandbox and return a `TaskResult`; the Framework scores
+   from that result. `reward` / `finished` are also copied onto every trajectory as
+   `reward_info` for dumps and unfinished-episode masking. An episode counts
+   as finished only when the agent actually submits a patch
    (`exit_status == "Submitted"`), so unfinished ones are masked from the loss.
 
 ### Sandbox provider

--- a/examples/mini_swe_agent/run_train.sh
+++ b/examples/mini_swe_agent/run_train.sh
@@ -9,7 +9,7 @@
 #
 # which resolves each sample's task from task_config_mini_swe_agent.yaml
 # (agent + sandbox defaults), deep-merges the sample values and the runtime
-# model binding, and returns the reward via report_reward=True.
+# model binding, and returns a TaskResult that the framework scores from.
 #
 # Usage:
 #   bash examples/mini_swe_agent/run_train.sh
@@ -125,7 +125,6 @@ RUNNER_ARGS=(
     "+actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.session_timeout_seconds=${SESSION_TIMEOUT_SECONDS}"
     "+actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_kwargs.task_config_path=${TASK_CONFIG}"
     "+actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_kwargs.model_name=${SERVED_MODEL_NAME}"
-    "+actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_kwargs.report_reward=True"
     "+actor_rollout_ref.rollout.custom.agent_framework.mask_unfinished_episode=${MASK_UNFINISHED_EPISODE}"
     "+actor_rollout_ref.rollout.custom.agent_framework.use_reward_loop_worker=False"
 )

--- a/examples/quickstart/training/train_npu_qwen3_moe.sh
+++ b/examples/quickstart/training/train_npu_qwen3_moe.sh
@@ -148,7 +148,6 @@ ray job submit --no-wait --runtime-env "$RUNTIME_ENV" \
     ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.max_concurrent_sessions=${CONCURRENCY} \
     ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_kwargs.task_config_path=${TASK_CONFIG} \
     ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_kwargs.model_name=${SERVED_MODEL_NAME} \
-    ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_kwargs.report_reward=True \
     ++actor_rollout_ref.rollout.custom.agent_framework.use_reward_loop_worker=False \
     actor_rollout_ref.rollout.gpu_memory_utilization=${gpu_memory_utilization} \
     actor_rollout_ref.rollout.tensor_model_parallel_size=${gen_tp} \

--- a/examples/quickstart/training/train_qwen3_moe.sh
+++ b/examples/quickstart/training/train_qwen3_moe.sh
@@ -208,7 +208,6 @@ ray job submit --no-wait --runtime-env $RUNTIME_ENV \
     ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.max_concurrent_sessions=${CONCURRENCY} \
     ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_kwargs.task_config_path=${TASK_CONFIG} \
     ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_kwargs.model_name=${SERVED_MODEL_NAME} \
-    ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_kwargs.report_reward=True \
     ++actor_rollout_ref.rollout.custom.agent_framework.mask_unfinished_episode=${MASK_UNFINISHED_EPISODE} \
     ++actor_rollout_ref.rollout.custom.agent_framework.use_reward_loop_worker=False \
     actor_rollout_ref.rollout.gpu_memory_utilization=0.7 \

--- a/examples/quickstart/training/train_qwen3p5_dense.sh
+++ b/examples/quickstart/training/train_qwen3p5_dense.sh
@@ -193,7 +193,6 @@ ray job submit --no-wait --runtime-env $RUNTIME_ENV \
     ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.trajectory_selection=longest \
     ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_kwargs.task_config_path=${TASK_CONFIG} \
     ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_kwargs.model_name=${SERVED_MODEL_NAME} \
-    ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_kwargs.report_reward=True \
     ++actor_rollout_ref.rollout.custom.agent_framework.mask_unfinished_episode=${MASK_UNFINISHED_EPISODE} \
     ++actor_rollout_ref.rollout.custom.agent_framework.use_reward_loop_worker=False \
     actor_rollout_ref.rollout.gpu_memory_utilization=0.7 \

--- a/tests/uni_agent/agents/test_claude_code_agent.py
+++ b/tests/uni_agent/agents/test_claude_code_agent.py
@@ -11,6 +11,7 @@ from uni_agent.agents.claude_code.agent import (
     ClaudeCodeAgent,
     ClaudeCodeConfig,
 )
+from uni_agent.metrics import task_metrics
 from uni_agent.sandbox.base import ExecResult
 
 
@@ -159,6 +160,26 @@ def test_run_forwards_workdir():
     assert sandbox.exec_calls[0]["env"]["CLAUDE_CODE_DISABLE_BACKGROUND_TASKS"] == "1"
     assert sandbox.exec_calls[0]["env"]["CLAUDE_CODE_SKIP_PROMPT_HISTORY"] == "1"
     assert sandbox.exec_calls[0]["env"]["CLAUDE_CODE_DISABLE_TERMINAL_TITLE"] == "1"
+
+
+def test_run_records_outer_wall_clock_when_task_metrics_are_active():
+    config = ClaudeCodeConfig(
+        model=ModelConfig(base_url="http://gateway:8000/v1", model_name="policy"),
+    )
+    sandbox = _FakeSandbox(probe_results=[0])
+
+    with task_metrics() as collector:
+        asyncio.run(
+            ClaudeCodeAgent(config).run(
+                sandbox=sandbox,
+                messages=[{"role": "user", "content": "fix the bug"}],
+            )
+        )
+
+    snap = collector.metrics()
+    assert snap["agent.run_s"]["aggregation"] == "sum"
+    assert len(snap["agent.run_s"]["values"]) == 1
+    assert snap["agent.run_s"]["values"][0] >= 0.0
 
 
 def test_run_accepts_user_only_message_without_rewriting():

--- a/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
+++ b/tests/uni_agent/framework/test_generate_sequences_on_cpu.py
@@ -10,8 +10,17 @@ import pytest
 import torch
 
 from tests.uni_agent.support import logging_runner
-from uni_agent.framework.framework import GatewayAgentFramework, _align_routed_experts
+from uni_agent.framework.framework import (
+    GatewayAgentFramework,
+    _align_routed_experts,
+    _attach_session_reward_info,
+    _reward_info_from_result,
+    _score_from_task_result,
+    _scoring_task_result,
+    _stamp_session_agent_metrics,
+)
 from uni_agent.gateway.session import SessionHandle, Trajectory
+from uni_agent.tasks.base import TaskResult
 from verl.utils import tensordict_utils as tu
 
 _RUNNER_CALLS = []
@@ -84,7 +93,17 @@ async def _async_noop_runner(**kwargs):
 
 async def _inline_runner_proxy(*, runner_key, **kwargs):
     runner = _TEST_INLINE_RUNNERS[runner_key]
-    await runner(**kwargs)
+    return await runner(**kwargs)
+
+
+async def _task_result_runner(*, raw_prompt, session, sample_index, **kwargs):
+    return TaskResult(
+        reward=0.75,
+        accuracy=1.0,
+        finished=True,
+        extra_info={"stdout": "should-not-reach-reward-info"},
+        metrics={"task.total_s": {"aggregation": "sum", "values": [1.2]}},
+    )
 
 
 def _inline_runner_config(
@@ -241,13 +260,44 @@ def test_build_gateway_manager_wires_gateway_config_defaults(
     assert captured["gateway_actor_config"].apply_chat_template_kwargs == expected_chat_template_kwargs
 
 
+def _prompt_put(
+    uid: str,
+    partition_id: str,
+    status: str,
+    *,
+    global_steps: int,
+    expected_sessions: int,
+    success_sessions: int,
+    failed_sessions: int = 0,
+    unfinished_sessions: int = 0,
+    extra_stats: dict | None = None,
+):
+    summary = {
+        "expected_sessions": expected_sessions,
+        "success_sessions": success_sessions,
+        "failed_sessions": failed_sessions,
+        "unfinished_sessions": unfinished_sessions,
+    }
+    if extra_stats:
+        summary.update(extra_stats)
+    return {
+        "key": uid,
+        "partition_id": partition_id,
+        "tag": {"is_prompt": True, "status": status, "global_steps": global_steps},
+        "fields": {"agent_metrics_summary": summary},
+    }
+
+
 class _FakeTransferQueue:
     def __init__(self):
         self.puts = []
         self.batch_puts = []
 
-    async def async_kv_put(self, *, key, partition_id, tag):
-        self.puts.append({"key": key, "partition_id": partition_id, "tag": dict(tag)})
+    async def async_kv_put(self, *, key, partition_id, tag, fields=None):
+        entry = {"key": key, "partition_id": partition_id, "tag": dict(tag)}
+        if fields is not None:
+            entry["fields"] = fields
+        self.puts.append(entry)
 
     async def async_kv_batch_put(self, *, keys, fields, tags, partition_id):
         self.batch_puts.append(
@@ -629,7 +679,16 @@ async def test_generate_sequences_writes_tq_schema_for_each_session(monkeypatch,
 
     assert fake_tq.batch_puts[0]["keys"] == ["uid-0_0_0"]
     assert fake_tq.batch_puts[1]["keys"] == ["uid-0_1_0"]
-    assert fake_tq.puts == [{"key": "uid-0", "partition_id": "train", "tag": {"status": "finished"}}]
+    assert fake_tq.puts == [
+        _prompt_put(
+            "uid-0",
+            "train",
+            "finished",
+            global_steps=7,
+            expected_sessions=2,
+            success_sessions=2,
+        )
+    ]
 
     first = fake_tq.batch_puts[0]
     fields = first["fields"]
@@ -730,7 +789,17 @@ async def test_generate_sequences_masks_unfinished_trajectory_without_dropping_i
     assert "finished" not in batch["tags"][0]
     assert "finished" not in batch["fields"].keys()
     assert tu.get(batch["fields"], "reward_extra_info") == [{}]
-    assert fake_tq.puts == [{"key": "uid-0", "partition_id": "train", "tag": {"status": "finished"}}]
+    assert fake_tq.puts == [
+        _prompt_put(
+            "uid-0",
+            "train",
+            "finished",
+            global_steps=7,
+            expected_sessions=1,
+            success_sessions=1,
+            unfinished_sessions=1,
+        )
+    ]
 
 
 @pytest.mark.asyncio
@@ -787,9 +856,9 @@ async def test_masking_keeps_trajectory_trainable_when_completion_metadata_is_mi
 
 
 @pytest.mark.asyncio
-async def test_generate_sequences_reports_unfinished_episode_count(fake_tq, caplog):
-    # A session materializing two trajectories is still one episode: completion is
-    # session-level metadata copied onto every trajectory it produced.
+async def test_generate_sequences_reports_unfinished_session_count(fake_tq, caplog):
+    # A session materializing two trajectories is still one unfinished session:
+    # completion is session-level metadata copied onto every trajectory it produced.
     runtime = _FakeGatewayManager(
         {
             "session-sample-0-rollout-0": [
@@ -808,7 +877,65 @@ async def test_generate_sequences_reports_unfinished_episode_count(fake_tq, capl
         await framework.generate_sequences(_build_prompts(count=1, global_steps=7))
 
     assert "num_success_outputs=2" in caplog.text
-    assert "num_unfinished_episodes=1" in caplog.text
+    assert "num_unfinished_sessions=1" in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("dispatch_mode", ["inline_async", "ray_task"])
+async def test_generate_sequences_scores_from_runner_task_result(fake_tq, dispatch_mode):
+    """Framework scores from the runner's TaskResult, not Gateway POST."""
+    runtime = _FakeGatewayManager({"session-sample-0-rollout-0": [_trajectory()]})
+    runner_config = (
+        _inline_runner_config(_task_result_runner)
+        if dispatch_mode == "inline_async"
+        else {
+            "runner_fqn": f"{__name__}._task_result_runner",
+            "dispatch_mode": "ray_task",
+        }
+    )
+    framework = await _build_framework_with_agent_runners(
+        agent_runners={"runner": runner_config},
+        gateway_manager=runtime,
+    )
+
+    await framework.generate_sequences(_build_prompts(count=1, global_steps=7))
+
+    fields = fake_tq.batch_puts[0]["fields"]
+    assert fields["rm_scores"][0].tolist() == [0.0, 0.75]
+    assert tu.get(fields, "reward_extra_info") == [{"acc": 1.0}]
+    assert tu.get(fields, "agent_metrics") == [{"task.total_s": {"aggregation": "sum", "values": [1.2]}}]
+    assert "stdout" not in str(tu.get(fields, "reward_extra_info"))
+    assert fake_tq.puts == [
+        _prompt_put(
+            "uid-0",
+            "train",
+            "finished",
+            global_steps=7,
+            expected_sessions=1,
+            success_sessions=1,
+            extra_stats={
+                "task.total_s": {"count": 1.0, "sum": 1.2, "min": 1.2, "max": 1.2},
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_generate_sequences_runner_task_result_overrides_gateway_reward_info(fake_tq):
+    runtime = _FakeGatewayManager(
+        {"session-sample-0-rollout-0": [_trajectory(reward_info={"reward": 0.1, "acc": 0.0, "finished": False})]}
+    )
+    framework = await _build_framework_with_agent_runners(
+        agent_runners={"runner": _inline_runner_config(_task_result_runner)},
+        gateway_manager=runtime,
+        mask_unfinished_episode=True,
+    )
+
+    await framework.generate_sequences(_build_prompts(count=1, global_steps=7))
+
+    fields = fake_tq.batch_puts[0]["fields"]
+    assert fields["rm_scores"][0].tolist() == [0.0, 0.75]
+    assert fields["response_mask"][0].tolist() == [1, 1]
 
 
 @pytest.mark.asyncio
@@ -827,6 +954,114 @@ def test_align_routed_experts_preserves_backend_dtype():
     assert aligned is not None
     assert aligned.dtype == torch.uint16
     assert aligned.tolist() == [[[256, 511]], [[0, 0]]]
+
+
+def test_reward_info_from_result_is_session_metadata_only():
+    result = TaskResult(
+        reward=0.5,
+        accuracy=1.0,
+        finished=True,
+        metrics={"task.total_s": {"aggregation": "sum", "values": [1.2]}},
+    )
+
+    assert _reward_info_from_result(result) == {
+        "reward": 0.5,
+        "acc": 1.0,
+        "finished": True,
+    }
+
+
+def test_score_from_task_result_uses_reward_and_accuracy():
+    result = TaskResult(
+        reward=0.75,
+        accuracy=1.0,
+        finished=True,
+        extra_info={"stdout": "should-not-reach-extra"},
+        metrics={"task.total_s": {"aggregation": "sum", "values": [1.2]}},
+    )
+
+    assert _score_from_task_result(result, 2) == [
+        (0.75, {"acc": 1.0}),
+        (0.75, {"acc": 1.0}),
+    ]
+    assert _score_from_task_result(TaskResult(reward=None, accuracy=1.0), 1) is None
+
+
+def test_reward_info_from_result_rejects_non_boolean_finished():
+    with pytest.raises(ValueError, match="finished must be a bool or None"):
+        _reward_info_from_result(TaskResult(reward=0.0, finished=0))  # type: ignore[arg-type]
+
+
+def test_scoring_task_result_drops_extra_info_and_ignores_non_results():
+    full = TaskResult(reward=1.0, accuracy=1.0, finished=True, extra_info={"stdout": "huge"}, metrics={"n": 1})
+
+    slim = _scoring_task_result(full)
+    assert slim == TaskResult(reward=1.0, accuracy=1.0, finished=True, metrics={"n": 1})
+    assert slim.extra_info is None
+    assert _scoring_task_result(None) is None
+    assert _scoring_task_result({"reward": 1.0}) is None
+
+
+def test_attach_session_reward_info_copies_the_same_dict_onto_every_trajectory():
+    """Mirrors GatewaySession.finalize: one session dict, per-trajectory copies."""
+    reward_info = {"reward": 0.5, "acc": 1.0, "finished": True}
+    left = _trajectory(reward_info={"stale": True})
+    right = _trajectory(reward_info={"stale": True})
+
+    attached = _attach_session_reward_info([left, right], reward_info)
+
+    assert attached[0].reward_info == reward_info
+    assert attached[1].reward_info == reward_info
+    assert attached[0].reward_info is not reward_info
+    assert attached[0].reward_info is not attached[1].reward_info
+    attached[0].reward_info["reward"] = 0.0
+    assert attached[1].reward_info["reward"] == 0.5
+    assert left.reward_info == {"stale": True}
+
+
+def test_stamp_session_agent_metrics_keeps_session_values_on_the_last_trajectory():
+    gateway = {"gateway.requests": {"aggregation": "sum", "values": [2.0]}}
+    task = {"task.total_s": {"aggregation": "sum", "values": [1.2]}}
+    first = _trajectory()
+    last = _trajectory(extra_fields={"agent_metrics": gateway, "materialization_reason": "max_trajectory_length"})
+
+    _stamp_session_agent_metrics([first, last], task)
+
+    assert first.extra_fields["agent_metrics"] == {}
+    assert last.extra_fields["agent_metrics"] == {
+        "gateway.requests": {"aggregation": "sum", "values": [2.0]},
+        "task.total_s": {"aggregation": "sum", "values": [1.2]},
+    }
+    assert last.extra_fields["materialization_reason"] == "max_trajectory_length"
+
+
+@pytest.mark.asyncio
+async def test_generate_sequences_puts_session_metrics_only_on_last_trajectory(fake_tq):
+    runtime = _FakeGatewayManager(
+        {
+            "session-sample-0-rollout-0": [
+                _trajectory(extra_fields={"materialization_reason": "max_trajectory_length"}),
+                _trajectory(
+                    extra_fields={
+                        "agent_metrics": {"gateway.requests": {"aggregation": "sum", "values": [3.0]}},
+                    }
+                ),
+            ]
+        }
+    )
+    framework = await _build_framework_with_agent_runners(
+        agent_runners={"runner": _inline_runner_config(_task_result_runner)},
+        gateway_manager=runtime,
+    )
+
+    await framework.generate_sequences(_build_prompts(count=1, global_steps=7))
+
+    metrics = tu.get(fake_tq.batch_puts[0]["fields"], "agent_metrics")
+    assert metrics[0] == {}
+    assert metrics[1] == {
+        "gateway.requests": {"aggregation": "sum", "values": [3.0]},
+        "task.total_s": {"aggregation": "sum", "values": [1.2]},
+    }
 
 
 @pytest.mark.asyncio
@@ -1068,7 +1303,17 @@ async def test_generate_sequences_keeps_successful_sessions_when_one_session_fai
     await framework.generate_sequences(_build_prompts(count=1, global_steps=8))
 
     assert fake_tq.batch_puts[0]["keys"] == ["uid-0_0_0"]
-    assert fake_tq.puts == [{"key": "uid-0", "partition_id": "train", "tag": {"status": "finished"}}]
+    assert fake_tq.puts == [
+        _prompt_put(
+            "uid-0",
+            "train",
+            "finished",
+            global_steps=8,
+            expected_sessions=2,
+            success_sessions=1,
+            failed_sessions=1,
+        )
+    ]
     assert len(runtime.aborted_sessions) == 1
     assert runtime.aborted_sessions[0].startswith("session-sample-0-rollout-1-")
 
@@ -1095,7 +1340,17 @@ async def test_generate_sequences_marks_prompt_failure_when_all_sessions_fail(fa
         await framework.generate_sequences(_build_prompts(count=1, global_steps=9, validate=True))
 
     assert fake_tq.batch_puts == []
-    assert fake_tq.puts == [{"key": "uid-0", "partition_id": "val", "tag": {"status": "failure"}}]
+    assert fake_tq.puts == [
+        _prompt_put(
+            "uid-0",
+            "val",
+            "failure",
+            global_steps=9,
+            expected_sessions=1,
+            success_sessions=0,
+            failed_sessions=1,
+        )
+    ]
 
 
 @pytest.mark.asyncio
@@ -1142,8 +1397,23 @@ async def test_generate_sequences_keeps_other_prompts_when_one_prompt_fails(fake
 
     assert [put["keys"] for put in fake_tq.batch_puts] == [["uid-1_0_0"]]
     assert sorted(fake_tq.puts, key=lambda put: put["key"]) == [
-        {"key": "uid-0", "partition_id": "train", "tag": {"status": "failure"}},
-        {"key": "uid-1", "partition_id": "train", "tag": {"status": "finished"}},
+        _prompt_put(
+            "uid-0",
+            "train",
+            "failure",
+            global_steps=11,
+            expected_sessions=1,
+            success_sessions=0,
+            failed_sessions=1,
+        ),
+        _prompt_put(
+            "uid-1",
+            "train",
+            "finished",
+            global_steps=11,
+            expected_sessions=1,
+            success_sessions=1,
+        ),
     ]
     assert len(runtime.aborted_sessions) == 1
     assert runtime.aborted_sessions[0].startswith("session-sample-0-rollout-0-")

--- a/tests/uni_agent/framework/test_task_runner.py
+++ b/tests/uni_agent/framework/test_task_runner.py
@@ -4,7 +4,6 @@ from uni_agent.framework import task_runner
 from uni_agent.framework.task_runner import (
     _extract_upstream,
     _inject_gateway_tunnel,
-    _reward_info_from_result,
     _rewrite_gateway_url,
 )
 from uni_agent.gateway.session import SessionHandle
@@ -64,32 +63,6 @@ def test_task_result_positional_field_order():
     assert result.extra_info == {"reason": "limit"}
 
 
-def test_reward_info_omits_unknown_agent_completion():
-    result = TaskResult(reward=0.5, accuracy=1.0)
-
-    assert _reward_info_from_result(result) == {
-        "reward": 0.5,
-        "acc": 1.0,
-    }
-
-
-@pytest.mark.parametrize("finished", [True, False])
-def test_reward_info_forwards_agent_completion(finished):
-    result = TaskResult(reward=0.0, finished=finished)
-
-    assert _reward_info_from_result(result) == {
-        "reward": 0.0,
-        "finished": finished,
-    }
-
-
-def test_reward_info_rejects_non_boolean_agent_completion():
-    result = TaskResult(reward=0.0, finished=0)  # type: ignore[arg-type]
-
-    with pytest.raises(ValueError, match="finished must be a bool or None"):
-        _reward_info_from_result(result)
-
-
 @pytest.mark.asyncio
 async def test_run_task_binds_raw_prompt_to_sample_task_config(monkeypatch, tmp_path):
     config_path = tmp_path / "tasks.yaml"
@@ -116,7 +89,7 @@ async def test_run_task_binds_raw_prompt_to_sample_task_config(monkeypatch, tmp_
     monkeypatch.setattr(task_runner, "get_task", _FakeTask)
     source_prompt = [{"role": "user", "content": "Canonical source problem"}]
 
-    await task_runner.run_task(
+    result = await task_runner.run_task(
         session=SessionHandle(
             session_id="test-session",
             base_url="http://gateway/sessions/test/v1",
@@ -133,3 +106,4 @@ async def test_run_task_binds_raw_prompt_to_sample_task_config(monkeypatch, tmp_
     )
 
     assert captured["config"].prompt == source_prompt
+    assert result == TaskResult(reward=1.0, accuracy=1.0, finished=True)

--- a/tests/uni_agent/gateway/test_session_metrics_on_cpu.py
+++ b/tests/uni_agent/gateway/test_session_metrics_on_cpu.py
@@ -1,0 +1,66 @@
+"""Gateway session-local metrics: request counts and phase timings."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.uni_agent.gateway.test_session_multiple_chains_on_cpu import (
+    _prompt_length,
+    _run,
+    _session,
+)
+from tests.uni_agent.support import SequencedBackend
+
+
+@pytest.mark.asyncio
+async def test_gateway_session_records_request_metrics_on_last_trajectory():
+    session = _session("metrics-session")
+    backend = SequencedBackend(["ONE", "TWO"])
+
+    await _run(session, backend, [{"role": "user", "content": "first"}])
+    await _run(
+        session,
+        backend,
+        [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "ONE"},
+            {"role": "user", "content": "second"},
+        ],
+    )
+    trajectories = await session.finalize()
+
+    assert len(trajectories) == 1
+    metrics = trajectories[0].extra_fields["agent_metrics"]
+    assert metrics["gateway.requests"]["aggregation"] == "sum"
+    assert metrics["gateway.requests"]["values"] == [1.0, 1.0]
+    for name in (
+        "gateway.request_s",
+        "gateway.encode_s",
+        "gateway.backend_generate_s",
+        "gateway.decode_s",
+    ):
+        assert metrics[name]["aggregation"] == "sum"
+        assert len(metrics[name]["values"]) == 2
+        assert all(value >= 0.0 for value in metrics[name]["values"])
+
+
+@pytest.mark.asyncio
+async def test_gateway_session_puts_metrics_only_on_last_of_multiple_chains():
+    first_messages = [{"role": "user", "content": "fill the response budget"}]
+    session = _session(
+        "metrics-multi-chain",
+        prompt_length=_prompt_length(first_messages),
+        response_length=len("FULL"),
+    )
+    backend = SequencedBackend(["FULL", "NEW"])
+
+    await _run(session, backend, first_messages)
+    await _run(session, backend, [*first_messages, {"role": "assistant", "content": "FULL"}])
+    await _run(session, backend, [{"role": "user", "content": "start a fresh chain"}])
+    trajectories = await session.finalize()
+
+    assert len(trajectories) == 2
+    assert "agent_metrics" not in trajectories[0].extra_fields
+    metrics = trajectories[-1].extra_fields["agent_metrics"]
+    assert metrics["gateway.requests"]["aggregation"] == "sum"
+    assert sum(metrics["gateway.requests"]["values"]) >= 2.0

--- a/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
+++ b/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
@@ -87,6 +87,12 @@ def test_gateway_session_enables_last_assistant_rollback_by_default():
     assert session._enable_last_assistant_rollback is True
 
 
+def _extra_fields(trajectory) -> dict:
+    extra = dict(trajectory.extra_fields)
+    extra.pop("agent_metrics", None)
+    return extra
+
+
 async def _run(session: GatewaySession, backend: SequencedBackend, messages: list[dict], **payload_extra):
     request = openai_to_internal(
         {"model": "dummy-model", "messages": messages, **payload_extra},
@@ -1052,8 +1058,8 @@ async def test_multiple_chains_length_exhaustion_orders_before_later_fresh_chain
     assert len(backend.calls) == 2
     assert backend.steps == []
     assert [_decode_response_ids(trajectory.response_ids) for trajectory in trajectories] == ["FULL", "NEW"]
-    assert trajectories[0].extra_fields == {"materialization_reason": "max_trajectory_length"}
-    assert trajectories[1].extra_fields == {}
+    assert _extra_fields(trajectories[0]) == {"materialization_reason": "max_trajectory_length"}
+    assert _extra_fields(trajectories[1]) == {}
 
 
 @pytest.mark.asyncio
@@ -1090,7 +1096,7 @@ async def test_multiple_chains_exactly_exhausted_chain_skips_new_media_extractio
     assert len(backend.calls) == 1
     assert backend.steps == ["SHOULD_NOT_RUN"]
     assert trajectories[0].multi_modal_data is None
-    assert trajectories[0].extra_fields == {"materialization_reason": "max_trajectory_length"}
+    assert _extra_fields(trajectories[0]) == {"materialization_reason": "max_trajectory_length"}
 
 
 @pytest.mark.asyncio
@@ -1154,7 +1160,7 @@ async def test_multiple_chains_closes_when_continuation_fills_total_trajectory_c
     assert outcome.finish_reason == "length"
     assert len(backend.calls) == 1
     assert backend.steps == ["SHOULD_NOT_RUN"]
-    assert trajectories[0].extra_fields == {"materialization_reason": "max_trajectory_length"}
+    assert _extra_fields(trajectories[0]) == {"materialization_reason": "max_trajectory_length"}
 
 
 @pytest.mark.asyncio
@@ -1816,4 +1822,5 @@ async def test_weight_versions_absent_when_backend_omits_them():
     await _run(session, SequencedBackend(["ONLY"]), [{"role": "user", "content": "base"}])
     [trajectory] = await session.finalize()
 
-    assert trajectory.extra_fields == {}
+    assert trajectory.extra_fields.get("agent_metrics")
+    assert _extra_fields(trajectory) == {}

--- a/tests/uni_agent/metrics/test_metrics.py
+++ b/tests/uni_agent/metrics/test_metrics.py
@@ -1,0 +1,339 @@
+import asyncio
+import os
+import time
+
+import pytest
+
+from uni_agent.metrics import (
+    AggregationType,
+    Metric,
+    MetricsCollector,
+    current_collector,
+    incr,
+    reduce_metrics,
+    set_value,
+    task_metrics,
+    timing,
+)
+
+
+def test_metric_mean_sum_min_max():
+    mean = Metric(aggregation="mean", value=[1.0, 3.0])
+    assert mean.aggregate() == 2.0
+    summed = Metric(aggregation=AggregationType.SUM, value=[1.0, 3.0])
+    assert summed.aggregate() == 4.0
+    assert Metric(aggregation="min", value=[1.0, 3.0]).aggregate() == 1.0
+    maximum = Metric(aggregation="max", value=[1.0, 3.0])
+    maximum.extend([4.0])
+    assert maximum.aggregate() == 4.0
+
+
+def test_metric_extend_rejects_aggregation_mismatch():
+    left = Metric(aggregation="mean", value=1.0)
+    right = Metric(aggregation="sum", value=2.0)
+    with pytest.raises(ValueError, match="Aggregation type mismatch"):
+        left.extend(right)
+
+
+def test_collector_timing_records_summed_elapsed():
+    collector = MetricsCollector()
+    with collector.timing("phase"):
+        time.sleep(0.01)
+
+    snap = collector.metrics()
+    entry = snap["phase"]
+    assert entry["aggregation"] == "sum"
+    assert len(entry["values"]) == 1
+    assert entry["values"][0] >= 0.01
+
+
+def test_collector_observe_accumulates_samples():
+    collector = MetricsCollector()
+    collector.observe("phase", 1.0)
+    collector.observe("phase", 3.0)
+
+    assert collector.metrics()["phase"] == {"aggregation": "mean", "values": [1.0, 3.0]}
+    assert Metric.from_dict(collector.metrics()["phase"]).aggregate() == 2.0
+
+
+def test_collector_incr_and_set_value():
+    collector = MetricsCollector()
+    collector.incr("count")
+    collector.incr("count", 2)
+    collector.set_value("gauge", 7)
+    collector.set_value("gauge", 9)  # last write wins
+
+    snap = collector.metrics()
+    assert snap["count"] == {"aggregation": "sum", "values": [1.0, 2.0]}
+    assert snap["gauge"] == {"aggregation": "mean", "values": [9.0]}
+
+
+def test_collector_merge_combines_metrics():
+    collector = MetricsCollector()
+    collector.observe("phase", 2.0)
+    collector.incr("count", 1)
+
+    collector.merge(
+        {
+            "phase": {"aggregation": "mean", "values": [4.0]},
+            "count": {"aggregation": "sum", "values": [2.0]},
+        }
+    )
+
+    snap = collector.metrics()
+    assert snap["phase"] == {"aggregation": "mean", "values": [2.0, 4.0]}
+    assert snap["count"] == {"aggregation": "sum", "values": [1.0, 2.0]}
+
+
+def test_merge_metrics_skips_empty_and_concatenates():
+    from uni_agent.metrics import merge_metrics
+
+    merged = merge_metrics(
+        None,
+        {},
+        {"phase": {"aggregation": "sum", "values": [1.0]}},
+        {"phase": {"aggregation": "sum", "values": [2.0]}, "count": {"aggregation": "sum", "values": [3.0]}},
+    )
+    assert merged["phase"] == {"aggregation": "sum", "values": [1.0, 2.0]}
+    assert merged["count"] == {"aggregation": "sum", "values": [3.0]}
+
+
+def test_task_metrics_binds_and_restores_context():
+    assert current_collector() is None
+    with task_metrics() as collector:
+        assert current_collector() is collector
+        with timing("phase"):
+            pass
+        incr("count")
+        set_value("gauge", 3)
+    assert current_collector() is None
+
+    snap = collector.metrics()
+    assert snap["phase"]["aggregation"] == "sum"
+    assert len(snap["phase"]["values"]) == 1
+    assert snap["count"] == {"aggregation": "sum", "values": [1.0]}
+    assert snap["gauge"] == {"aggregation": "mean", "values": [3.0]}
+
+
+def test_task_metrics_async():
+    async def run():
+        async with task_metrics() as collector:
+            with timing("phase"):
+                await asyncio.sleep(0)
+            return collector.metrics()
+
+    snap = asyncio.run(run())
+    assert snap["phase"]["aggregation"] == "sum"
+    assert current_collector() is None
+
+
+def test_module_helpers_noop_outside_task():
+    with timing("phase"):
+        pass
+    incr("count")
+    set_value("gauge", 1)
+    assert current_collector() is None
+
+
+def test_reduce_metrics_uses_metric_aggregation_and_key_name():
+    flat = reduce_metrics(
+        {
+            "loss": Metric(aggregation="mean", value=[1.0, 3.0]),
+            "phase/max": [5.0, 8.0, 6.0],
+            "phase/min": [0.1, 0.05, 0.2],
+            "count": [1.0, 3.0],
+        }
+    )
+    assert flat["loss"] == 2.0
+    assert flat["phase/max"] == 8.0
+    assert flat["phase/min"] == 0.05
+    assert flat["count"] == 2.0
+
+
+def test_reduce_metrics_aggregates_task_scalars():
+    rows = [
+        {
+            "phase": {"aggregation": "sum", "values": [10.0]},
+            "nested": {"aggregation": "mean", "values": [6.0]},
+            "count": {"aggregation": "sum", "values": [1.0]},
+        },
+        {
+            "phase": {"aggregation": "sum", "values": [20.0]},
+            "nested": {"aggregation": "mean", "values": [3.0, 5.0]},
+            "count": {"aggregation": "sum", "values": [3.0]},
+        },
+    ]
+
+    flat = reduce_metrics(rows)
+
+    assert flat["phase"] == 15.0
+    # Per-task nested is mean of samples (6.0 and 4.0) -> mean 5.0.
+    assert flat["nested"] == 5.0
+    assert flat["count"] == 2.0
+
+
+def test_reduce_metrics_skips_missing_metrics():
+    flat = reduce_metrics([{"phase": {"aggregation": "sum", "values": [4.0]}}, {}])
+
+    assert flat == {"phase": 4.0}
+    assert reduce_metrics([]) == {}
+
+
+def test_prompt_metrics_summary_merges_sufficient_stats():
+    from uni_agent.metrics import build_prompt_metrics_summary
+
+    summary = build_prompt_metrics_summary(
+        expected_sessions=4,
+        success_sessions=3,
+        failed_sessions=1,
+        unfinished_sessions=1,
+        metrics=[
+            {"task.total_s": {"aggregation": "sum", "values": [10.0]}},
+            {"task.total_s": {"aggregation": "sum", "values": [20.0]}},
+            {},
+        ],
+    )
+    assert summary["expected_sessions"] == 4
+    assert summary["success_sessions"] == 3
+    assert summary["failed_sessions"] == 1
+    assert summary["unfinished_sessions"] == 1
+    assert summary["task.total_s"] == {"count": 2.0, "sum": 30.0, "min": 10.0, "max": 20.0}
+
+
+def test_aggregate_maps_internal_names_to_verl_keys():
+    from uni_agent.metrics import aggregate, reduce_agent_metrics, reduce_prompt_summaries
+
+    rows = [
+        {
+            "task.total_s": {"aggregation": "sum", "values": [10.0]},
+            "task.generate_s": {"aggregation": "sum", "values": [8.0]},
+            "gateway.requests": {"aggregation": "sum", "values": [1.0, 1.0]},
+        },
+        {
+            "task.total_s": {"aggregation": "sum", "values": [20.0]},
+            "task.generate_s": {"aggregation": "sum", "values": [16.0]},
+            "gateway.requests": {"aggregation": "sum", "values": [3.0]},
+        },
+        {},
+    ]
+    timing_raw, scalars = reduce_agent_metrics(rows)
+    assert timing_raw["task/total/mean"] == 15.0
+    assert timing_raw["task/total/max"] == 20.0
+    assert scalars["gateway/requests/mean"] == 2.5
+    assert scalars["agent_loop/slowest/task/total"] == 20.0
+    assert scalars["agent_loop/slowest/task/generate"] == 16.0
+
+    flat = aggregate(rows)
+    assert flat["timing_s/task/total/mean"] == 15.0
+    assert flat["timing_s/task/generate/max"] == 16.0
+    assert flat["gateway/requests/max"] == 3.0
+
+    prompt = reduce_prompt_summaries(
+        [
+            {"success_sessions": 3, "failed_sessions": 1, "unfinished_sessions": 1},
+            {"success_sessions": 0, "failed_sessions": 2, "unfinished_sessions": 0},
+        ]
+    )
+    assert prompt == {
+        "agent_loop/failed_prompts": 1.0,
+        "agent_loop/success_sessions": 3.0,
+        "agent_loop/failed_sessions": 3.0,
+        "agent_loop/unfinished_sessions": 1.0,
+    }
+
+
+def test_report_metrics_uses_tracking(monkeypatch):
+    from uni_agent.metrics import report as report_mod
+    from uni_agent.metrics.report import report_metrics
+
+    calls: list[tuple[str, object]] = []
+
+    class _FakeTracking:
+        def __init__(self, project, experiment, default_backend):
+            calls.append(("init", (project, experiment, tuple(default_backend))))
+
+        def log(self, data, step):
+            calls.append(("log", (dict(data), step)))
+
+        def finish(self):
+            calls.append(("finish", None))
+
+    monkeypatch.setattr(report_mod, "_load_tracking", lambda: _FakeTracking)
+    report_metrics({"phase": 1.5}, experiment="unit", step=3)
+
+    assert calls == [
+        ("init", ("uni_agent", "unit", ("console", "file"))),
+        ("log", ({"phase": 1.5}, 3)),
+        ("finish", None),
+    ]
+
+
+def test_report_metrics_sets_file_logger_path(monkeypatch, tmp_path):
+    from uni_agent.metrics import report as report_mod
+    from uni_agent.metrics.report import report_metrics
+
+    seen: dict[str, str | None] = {}
+
+    class _FakeTracking:
+        def __init__(self, project, experiment, default_backend):
+            seen["path"] = os.environ.get("VERL_FILE_LOGGER_PATH")
+
+        def log(self, data, step):
+            pass
+
+        def finish(self):
+            pass
+
+    monkeypatch.setattr(report_mod, "_load_tracking", lambda: _FakeTracking)
+    monkeypatch.delenv("VERL_FILE_LOGGER_PATH", raising=False)
+    filepath = str(tmp_path / "nested" / "metrics.jsonl")
+    report_metrics({"phase": 1.0}, filepath=filepath)
+
+    assert seen["path"] == filepath
+    assert os.environ.get("VERL_FILE_LOGGER_PATH") is None
+    assert (tmp_path / "nested").is_dir()
+
+
+def test_report_metrics_skips_empty(monkeypatch):
+    from uni_agent.metrics import report as report_mod
+    from uni_agent.metrics.report import report_metrics
+
+    monkeypatch.setattr(
+        report_mod,
+        "_load_tracking",
+        lambda: (_ for _ in ()).throw(AssertionError("Tracking must not be constructed")),
+    )
+    report_metrics({})
+
+
+def test_report_metrics_falls_back_without_verl(monkeypatch, caplog):
+    from uni_agent.metrics import report as report_mod
+    from uni_agent.metrics.report import report_metrics
+
+    def _missing():
+        raise ImportError("no verl")
+
+    monkeypatch.setattr(report_mod, "_load_tracking", _missing)
+    caplog.set_level("INFO")
+    report_metrics({"phase": 2.0}, experiment="unit")
+    assert any("metrics: " in rec.message and "2.0" in rec.message for rec in caplog.records)
+
+
+def test_task_run_attaches_metrics():
+    from uni_agent.tasks.base import Task, TaskConfig, TaskResult
+
+    class _TimedTask(Task):
+        async def run(self) -> TaskResult:
+            async with task_metrics() as collector:
+                with timing("task.total_s"):
+                    with timing("reward.s"):
+                        pass
+                    result = TaskResult(reward=1.0)
+                result.metrics = collector.metrics()
+                return result
+
+    result = asyncio.run(_TimedTask(TaskConfig(sandbox={"provider": "local"})).run())
+    assert result.metrics is not None
+    assert result.metrics["task.total_s"]["aggregation"] == "sum"
+    assert result.metrics["reward.s"]["aggregation"] == "sum"
+    assert current_collector() is None

--- a/tests/uni_agent/test_rlinsight_adapter.py
+++ b/tests/uni_agent/test_rlinsight_adapter.py
@@ -56,7 +56,6 @@ def test_task_span_reports_identity_and_result(monkeypatch: pytest.MonkeyPatch) 
     ) as span:
         span.record_result(
             SimpleNamespace(reward=0.5, accuracy=1.0, finished=True),
-            reward_posted=True,
         )
 
     attributes = captured[0]["attributes"]
@@ -67,7 +66,7 @@ def test_task_span_reports_identity_and_result(monkeypatch: pytest.MonkeyPatch) 
     assert attributes["reward"] == 0.5
     assert attributes["accuracy"] == 1.0
     assert attributes["finished"] is True
-    assert attributes["reward_posted"] is True
+    assert "reward_posted" not in attributes
 
 
 def test_generation_span_success_uses_chain_lane(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uni_agent/agents/claude_code/agent.py
+++ b/uni_agent/agents/claude_code/agent.py
@@ -16,6 +16,8 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import Field
 
+from uni_agent.metrics import timing
+
 from ..base import Agent, AgentConfig, AgentResult
 from ..registry import register_agent
 
@@ -120,7 +122,8 @@ class ClaudeCodeAgent(Agent):
         argv = self._claude_argv(user_prompt)
         env = self._claude_env(endpoint)
         logger.info("claude_code: launch with user_prompt:\n%s", user_prompt)
-        proc = await sandbox.exec(argv, env=env, timeout=cfg.run_timeout, workdir=workdir)
+        with timing("agent.run_s"):
+            proc = await sandbox.exec(argv, env=env, timeout=cfg.run_timeout, workdir=workdir)
 
         out_tail = (proc.stdout or "").strip()[-2000:]
         err_tail = (proc.stderr or "").strip()[-2000:]

--- a/uni_agent/framework/framework.py
+++ b/uni_agent/framework/framework.py
@@ -25,7 +25,9 @@ from tensordict.tensorclass import NonTensorData, NonTensorStack
 
 from uni_agent.gateway.session import SessionHandle, Trajectory
 from uni_agent.logging import LogContext, sample_logging
+from uni_agent.metrics import build_prompt_metrics_summary, merge_metrics
 from uni_agent.rlinsight_adapter import agent_loop_session
+from uni_agent.tasks.base import TaskResult
 from verl.tools.tool_registry import initialize_tools_from_config
 from verl.utils import tensordict_utils as tu
 from verl.utils.import_utils import load_class_from_fqn
@@ -39,7 +41,14 @@ logger = logging.getLogger(__name__)
 
 
 class AgentRunner(Protocol):
-    """Callable contract for an agent episode over a Gateway-owned session."""
+    """Callable contract for an agent episode over a Gateway-owned session.
+
+    Return a :class:`~uni_agent.tasks.base.TaskResult` so the Framework can score
+    the session from ``reward`` / ``accuracy`` / ``finished`` / ``metrics``.
+    Returning ``None`` is the same as a Gateway session that never received a
+    reward: score from session ``reward_info`` if present, otherwise a configured
+    RewardLoopWorker can apply custom scoring.
+    """
 
     async def __call__(
         self,
@@ -48,7 +57,7 @@ class AgentRunner(Protocol):
         raw_prompt: object,
         sample_index: int,
         **sample_runner_kwargs: object,
-    ) -> object: ...
+    ) -> TaskResult | None: ...
 
 
 TrajectoryPostprocessor = Callable[..., list[Trajectory] | Awaitable[list[Trajectory]]]
@@ -132,11 +141,15 @@ def _run_agent_runner_ray_task(
     sample_index: int,
     tools_kwargs: object | None,
     log_context: LogContext | None,
-) -> None:
-    """Run only the user runner in Ray; parent owns session lifecycle outputs."""
+) -> TaskResult | None:
+    """Run only the user runner in Ray; parent owns session lifecycle outputs.
+
+    The returned :class:`TaskResult` is slimmed to scoring fields so bulky
+    ``extra_info`` (eval logs, stdout tails) does not cross the Ray boundary.
+    """
     runner = _materialize_runner(runner_fqn, runner_kwargs)
     with _log_scope(log_context):
-        asyncio.run(
+        result = asyncio.run(
             runner(
                 raw_prompt=raw_prompt,
                 session=session,
@@ -144,6 +157,7 @@ def _run_agent_runner_ray_task(
                 **({"tools_kwargs": tools_kwargs} if tools_kwargs is not None else {}),
             )
         )
+    return _scoring_task_result(result)
 
 
 def _short_failure_reason(error: BaseException) -> str:
@@ -151,6 +165,94 @@ def _short_failure_reason(error: BaseException) -> str:
     if not message:
         message = error.__class__.__name__
     return f"{error.__class__.__name__}:{message}"[:512]
+
+
+def _scoring_task_result(value: object) -> TaskResult | None:
+    """Keep only the TaskResult fields the Framework scores from.
+
+    ``extra_info`` can carry sandbox eval logs; drop it before crossing Ray.
+    Non-TaskResult returns are ignored: the session is scored as if the runner
+    returned ``None`` (no Task-provided reward).
+    """
+    if value is None:
+        return None
+    if not isinstance(value, TaskResult):
+        logger.warning(
+            "agent runner returned %s, expected TaskResult; ignoring return value",
+            type(value).__name__,
+        )
+        return None
+    return TaskResult(
+        reward=value.reward,
+        accuracy=value.accuracy,
+        finished=value.finished,
+        metrics=value.metrics,
+    )
+
+
+def _reward_info_from_result(result: TaskResult) -> dict[str, object]:
+    """Copy dump/mask metadata from ``TaskResult`` onto trajectories.
+
+    Scoring and metrics stay on ``TaskResult``; this dict is session metadata
+    (``reward`` / ``acc`` / ``finished``) only.
+    """
+    if result.finished is not None and type(result.finished) is not bool:
+        raise ValueError("TaskResult.finished must be a bool or None")
+    reward_info: dict[str, object] = {"reward": result.reward}
+    if result.accuracy is not None:
+        reward_info["acc"] = result.accuracy
+    if result.finished is not None:
+        reward_info["finished"] = result.finished
+    return reward_info
+
+
+def _score_from_task_result(result: TaskResult, n: int) -> list[tuple[float, dict[str, object]]] | None:
+    """Build per-trajectory annotations from ``TaskResult.reward`` / ``accuracy``.
+
+    ``finished`` is session metadata, not a reward extra. Metrics are stamped
+    separately onto the last trajectory.
+    """
+    if result.reward is None:
+        return None
+    extra: dict[str, object] = {}
+    if result.accuracy is not None:
+        extra["acc"] = result.accuracy
+    return [(float(result.reward), dict(extra)) for _ in range(n)]
+
+
+def _attach_session_reward_info(
+    trajectories: list[Trajectory],
+    reward_info: dict[str, object],
+) -> list[Trajectory]:
+    """Copy session-level ``reward_info`` onto every trajectory.
+
+    Same as ``GatewaySession.finalize``::
+
+        [replace(trajectory, reward_info=dict(self.reward_info)) for trajectory in ...]
+    """
+    return [replace(trajectory, reward_info=dict(reward_info)) for trajectory in trajectories]
+
+
+def _stamp_session_agent_metrics(
+    trajectories: list[Trajectory],
+    task_metrics: dict[str, object] | None,
+) -> None:
+    """Merge Gateway + Task metrics onto the last trajectory of a session.
+
+    Gateway already attached its session snapshot during ``finalize``.  After
+    trajectory selection/postprocess, Framework merges ``TaskResult.metrics``
+    here.  Earlier trajectories keep ``agent_metrics={}`` so TransferQueue still
+    has the column without double-counting session-level timings.
+    """
+    if not trajectories:
+        return
+    last = trajectories[-1]
+    merged = merge_metrics(last.extra_fields.get("agent_metrics"), task_metrics)
+    if not merged:
+        return
+    for trajectory in trajectories[:-1]:
+        trajectory.extra_fields.setdefault("agent_metrics", {})
+    last.extra_fields["agent_metrics"] = merged
 
 
 def _select_session_trajectories(
@@ -298,12 +400,15 @@ class GatewayAgentFramework(AgentFramework):
 
     Each sample in the batch is run as an independent Gateway session: the agent
     communicates through the Gateway's provider adapter (OpenAI Chat Completions
-    or Anthropic Messages), and the Gateway collects token-level trajectories. After
-    finalization, scoring prefers the reward the runner posted to the session
-    (``_score_from_reward_info``); otherwise, if a RewardLoopWorker is configured,
-    ``_score_trajectories`` scores the final trajectory and broadcasts the score to all
-    trajectories in the session (matching ``AgentLoopWorkerTQ._agent_loop_postprocess``).
-    The framework then writes them to the TransferQueue schema consumed by sync training.
+    or Anthropic Messages), and the Gateway collects token-level trajectories.
+    After finalization, the framework copies ``reward`` / ``acc`` / ``finished``
+    from the runner's :class:`TaskResult` onto every trajectory as session
+    ``reward_info`` (dump / ``mask_unfinished_episode`` metadata). Scoring and
+    metrics come from ``TaskResult`` itself after trajectory selection and
+    postprocess. Not returning a ``TaskResult`` is the same as a Gateway session
+    that never received a reward. A configured RewardLoopWorker is the custom
+    reward path for that case. The framework then writes trajectories to the
+    TransferQueue schema consumed by sync training.
     """
 
     #: Grace period for a timed-out runner Ray task to observe a graceful
@@ -313,7 +418,7 @@ class GatewayAgentFramework(AgentFramework):
 
     def __init__(
         self,
-        gateway_manager,  # GatewayManager: framework calls create_session/finalize_session/abort_session
+        gateway_manager,  # GatewayManager: create/finalize/abort session
         *,
         runner_registry: dict[str, _RunnerConfig],
         reward_loop_worker_handles=None,
@@ -485,13 +590,13 @@ class GatewayAgentFramework(AgentFramework):
         )
         logger.info(
             "generate_sequences summary: num_input_prompts=%s num_success_sessions=%s "
-            "num_failed_sessions=%s num_success_outputs=%s num_unfinished_episodes=%s "
+            "num_failed_sessions=%s num_success_outputs=%s num_unfinished_sessions=%s "
             "num_failed_uids=%s failure_reasons=%s",
             stats["num_input_prompts"],
             stats["num_success_sessions"],
             stats["num_failed_sessions"],
             stats["num_success_outputs"],
-            stats["num_unfinished_episodes"],
+            stats["num_unfinished_sessions"],
             stats["num_failed_uids"],
             stats["failure_reasons"][:3],
         )
@@ -536,7 +641,7 @@ class GatewayAgentFramework(AgentFramework):
             "num_success_sessions": 0,
             "num_failed_sessions": 0,
             "num_success_outputs": 0,
-            "num_unfinished_episodes": 0,
+            "num_unfinished_sessions": 0,
             "num_failed_uids": 0,
             "failure_reasons": failure_reasons,
         }
@@ -553,7 +658,7 @@ class GatewayAgentFramework(AgentFramework):
             stats["num_success_sessions"] += outcome["num_success_sessions"]
             stats["num_failed_sessions"] += outcome["num_failed_sessions"]
             stats["num_success_outputs"] += outcome["num_success_outputs"]
-            stats["num_unfinished_episodes"] += outcome["num_unfinished_episodes"]
+            stats["num_unfinished_sessions"] += outcome["num_unfinished_sessions"]
             stats["num_failed_uids"] += outcome["num_failed_uids"]
             failure_reasons.extend(outcome["failure_reasons"])
         return stats
@@ -594,8 +699,9 @@ class GatewayAgentFramework(AgentFramework):
         success_sessions = 0
         failed_sessions = 0
         success_outputs = 0
-        unfinished_episodes = 0
+        unfinished_sessions = 0
         failure_reasons: list[str] = []
+        session_metrics: list[dict[str, dict]] = []
         for session_index, outcome in enumerate(outcomes):
             if isinstance(outcome, Exception):
                 failed_sessions += 1
@@ -628,23 +734,44 @@ class GatewayAgentFramework(AgentFramework):
             else:
                 success_sessions += 1
                 success_outputs += len(trajectories)
-                # One session is one episode; its trajectories all carry the same
-                # session-level completion flag, so this counts episodes, not tokens.
+                # Completion is session-level; count sessions, not trajectories.
                 if any(traj.reward_info.get("finished") is False for traj in trajectories):
-                    unfinished_episodes += 1
+                    unfinished_sessions += 1
+                last_metrics = trajectories[-1].extra_fields.get("agent_metrics")
+                if last_metrics:
+                    session_metrics.append(last_metrics)
 
         if success_sessions > 0:
-            await tq.async_kv_put(key=uid, partition_id=partition_id, tag={"status": "finished"})
+            status = "finished"
             failed_uids = 0
         else:
-            await tq.async_kv_put(key=uid, partition_id=partition_id, tag={"status": "failure"})
+            status = "failure"
             failed_uids = 1
+
+        summary = build_prompt_metrics_summary(
+            expected_sessions=num_sessions,
+            success_sessions=success_sessions,
+            failed_sessions=failed_sessions,
+            unfinished_sessions=unfinished_sessions,
+            metrics=session_metrics,
+        )
+        tag: dict[str, object] = {
+            "is_prompt": True,
+            "status": status,
+            "global_steps": int(global_steps or 0),
+        }
+        await tq.async_kv_put(
+            key=uid,
+            partition_id=partition_id,
+            tag=tag,
+            fields={"agent_metrics_summary": summary},
+        )
 
         return {
             "num_success_sessions": success_sessions,
             "num_failed_sessions": failed_sessions,
             "num_success_outputs": success_outputs,
-            "num_unfinished_episodes": unfinished_episodes,
+            "num_unfinished_sessions": unfinished_sessions,
             "num_failed_uids": failed_uids,
             "failure_reasons": failure_reasons,
         }
@@ -761,6 +888,7 @@ class GatewayAgentFramework(AgentFramework):
                 global_steps,
             )
             try:
+                runner_result: TaskResult | None = None
                 if runner_config.dispatch_mode == "ray_task":
                     # Ray workers run only the runner. Gateway token truth,
                     # finalization, reward scoring, and TQ writes stay in parent.
@@ -783,22 +911,33 @@ class GatewayAgentFramework(AgentFramework):
                     # unwinds and its sandbox context manager tears down cleanly;
                     # force-kill only if it ignores the cancel.
                     try:
-                        await asyncio.wait_for(
-                            object_ref,
-                            timeout=runner_config.session_timeout_seconds,
+                        runner_result = _scoring_task_result(
+                            await asyncio.wait_for(
+                                object_ref,
+                                timeout=runner_config.session_timeout_seconds,
+                            )
                         )
                     except (asyncio.TimeoutError, asyncio.CancelledError):
                         await self._cancel_runner_task(object_ref, session_id)
                         raise
                 else:
                     runner = self._inline_runners[runner_name]
-                    await runner(
-                        raw_prompt=raw_prompt,
-                        session=session,
-                        sample_index=sample_index,
-                        **({"tools_kwargs": tools_kwargs} if tools_kwargs is not None else {}),
+                    runner_result = _scoring_task_result(
+                        await runner(
+                            raw_prompt=raw_prompt,
+                            session=session,
+                            sample_index=sample_index,
+                            **({"tools_kwargs": tools_kwargs} if tools_kwargs is not None else {}),
+                        )
                     )
                 session_trajectories = await self.gateway_manager.finalize_session(session_id)
+                if runner_result is not None:
+                    # Dump / mask_unfinished_episode metadata only. Scoring and
+                    # metrics stay on TaskResult and are applied after selection.
+                    session_trajectories = _attach_session_reward_info(
+                        session_trajectories,
+                        _reward_info_from_result(runner_result),
+                    )
                 session_trajectories = _select_session_trajectories(
                     session_id,
                     session_trajectories,
@@ -833,10 +972,22 @@ class GatewayAgentFramework(AgentFramework):
                 )
                 return session_trajectories, sample_fields
 
-            # Prefer the reward the runner posted to the session (report_reward=True);
-            # otherwise defer to the RewardLoopWorker (if any), else rm_scores stays 0.
-            annotations = self._score_from_reward_info(session_trajectories)
-            reward_source = "reward_info" if annotations is not None else None
+            _stamp_session_agent_metrics(
+                session_trajectories,
+                None if runner_result is None else runner_result.metrics,
+            )
+            annotations = None
+            reward_source = None
+            if runner_result is not None:
+                annotations = _score_from_task_result(runner_result, len(session_trajectories))
+                if annotations is not None:
+                    reward_source = "task_result"
+            else:
+                # No TaskResult: same as a Gateway session that never received
+                # a Task reward. Score session reward_info if the Gateway has one.
+                annotations = self._score_from_reward_info(session_trajectories)
+                if annotations is not None:
+                    reward_source = "reward_info"
             if annotations is None and self.reward_loop_worker_handles:
                 annotations = await self._score_trajectories(session_trajectories, sample_fields)
                 reward_source = "reward_loop_worker"
@@ -976,12 +1127,12 @@ class GatewayAgentFramework(AgentFramework):
     def _score_from_reward_info(
         self, session_trajectories: list[Trajectory]
     ) -> list[tuple[float, dict[str, object]]] | None:
-        """Score from the reward the runner posted to the session, if any.
+        """Score from Gateway session ``reward_info['reward']``, if present.
 
-        reward_score = the posted ``reward``; anything else posted (e.g. ``acc``)
-        rides along as reward_extra_info. ``finished`` is dropped instead: the
-        framework consumes it directly as a completion fact, so it is not a reward
-        metric. See ``task_runner._post_reward_info`` for what's posted.
+        Used when the runner did not return a ``TaskResult`` — the same path as
+        a Gateway session that never received a Task reward. ``finished`` is
+        dropped: the framework consumes it as a completion fact. Metrics never
+        travel on ``reward_info``.
         """
         reward_info = dict(session_trajectories[-1].reward_info or {})
         reward = reward_info.pop("reward", None)
@@ -996,9 +1147,11 @@ class GatewayAgentFramework(AgentFramework):
         session_trajectories: list[Trajectory],
         sample_fields: dict[str, object],
     ) -> list[tuple[float, dict[str, object]]]:
-        """Score the session's final trajectory and broadcast (score, extra_info) to all.
+        """Custom reward: score the session's final trajectory via RewardLoopWorker.
 
-        Mirrors AgentLoopWorkerTQ._agent_loop_postprocess
+        This is the configured custom reward path when the session has no
+        Task-provided reward, not a last-resort fallback. Mirrors
+        AgentLoopWorkerTQ._agent_loop_postprocess
         (verl/trainer/main_ppo_sync.py:353-396): only the final trajectory (the
         session's last interaction segment) is dispatched to RewardLoopWorker;
         its score + reward_extra_info are then broadcast to every trajectory in

--- a/uni_agent/framework/task_runner.py
+++ b/uni_agent/framework/task_runner.py
@@ -84,7 +84,6 @@ async def run_task(
     task_config_path: str | None = None,
     api_key: str = "EMPTY",
     model_name: str | None = None,
-    report_reward: bool = False,
     **_: Any,
 ) -> TaskResult:
     """Resolve the sample's task, run it against ``session``, and return its result.
@@ -95,9 +94,9 @@ async def run_task(
 
     Run-level defaults come from the per-task-name YAML file selected by
     ``task_config_path``. ``TaskConfigResolver`` applies that Task Config, the
-    sample values, and the live endpoint in order. When ``report_reward`` is set,
-    the task's reward + info are POSTed back to the session's reward-info endpoint;
-    the standalone evaluator reads the returned :class:`TaskResult` directly.
+    sample values, and the live endpoint in order. The returned :class:`TaskResult`
+    is the scoring source for both standalone evaluation and Framework-managed
+    training.
     """
     sample_config = tools_kwargs.get("task") if tools_kwargs else None
     if not isinstance(sample_config, dict):
@@ -131,45 +130,12 @@ async def run_task(
     with task_span(tools_kwargs, task_name=task_name, prompt=prompt) as span:
         task_instance = get_task(task)
         result = await task_instance.run()
-        reward_posted = False
-        if report_reward and session.reward_info_url:
-            reward_posted = await _post_reward_info(session.reward_info_url, result)
-        span.record_result(result, reward_posted=reward_posted)
+        span.record_result(result)
         logger.info(
-            "run_task done: task=%s reward=%s acc=%s finished=%s reward_posted=%s",
+            "run_task done: task=%s reward=%s acc=%s finished=%s",
             task_name,
             result.reward,
             result.accuracy,
             result.finished,
-            reward_posted,
         )
         return result
-
-
-async def _post_reward_info(reward_info_url: str, result: TaskResult) -> bool:
-    """Best-effort POST of task reward, accuracy, and Agent completion."""
-    import aiohttp
-
-    reward_info = _reward_info_from_result(result)
-    try:
-        timeout = aiohttp.ClientTimeout(total=None)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.post(reward_info_url, json={"reward_info": reward_info}) as response:
-                response.raise_for_status()
-        logger.debug("posted reward_info to %s: %s", reward_info_url, reward_info)
-    except Exception as exc:  # noqa: BLE001 - reward-info is best-effort telemetry
-        logger.warning("failed to post reward_info to %s: %s: %s", reward_info_url, type(exc).__name__, exc)
-        return False
-    return True
-
-
-def _reward_info_from_result(result: TaskResult) -> dict[str, Any]:
-    """Build the session reward payload consumed by the trajectory framework."""
-    if result.finished is not None and type(result.finished) is not bool:
-        raise ValueError("TaskResult.finished must be a bool or None")
-    reward_info: dict[str, Any] = {"reward": result.reward}
-    if result.accuracy is not None:
-        reward_info["acc"] = result.accuracy
-    if result.finished is not None:
-        reward_info["finished"] = result.finished
-    return reward_info

--- a/uni_agent/gateway/session/session.py
+++ b/uni_agent/gateway/session/session.py
@@ -14,6 +14,7 @@ from fastapi import HTTPException
 
 from uni_agent.gateway.session.codec import MessageCodec
 from uni_agent.gateway.session.types import InternalGenerationRequest, SessionHandle, Trajectory
+from uni_agent.metrics import MetricsCollector, merge_metrics
 from uni_agent.rlinsight_adapter import start_generation_span
 
 _EMPTY_PREFIX_HASH = hashlib.sha256(b"uni-agent-prefix-v1\0empty").hexdigest()
@@ -213,6 +214,8 @@ class GatewaySession:
         self.created_at = time.time()
         self.updated_at = self.created_at
         self.request_lock = asyncio.Lock()
+        # Session-local: Gateway cannot share Task's ContextVar across HTTP/Ray.
+        self._metrics = MetricsCollector()
 
     @property
     def sampling_params(self) -> dict[str, Any]:
@@ -234,110 +237,115 @@ class GatewaySession:
         # and broadcasts that reward, so concurrent siblings share one reward target.
         reserved_chain_id: int | None = None
         generation_span = start_generation_span(self._trace_identity)
+        self._metrics.incr("gateway.requests")
         try:
-            async with self.request_lock:
-                if self.phase != SessionPhase.ACTIVE:
-                    raise HTTPException(
-                        status_code=409,
-                        detail=f"Session {self.handle.session_id} is {self.phase.value.lower()}",
-                    )
-                # Prepare can touch codec and multimodal extractor state, so only
-                # backend generation runs outside the session lock.
-                encoded = await self._prepare_generation_inputs(request)
-                if encoded.capacity_exhausted:
-                    empty_msg = {"role": "assistant", "content": ""}
+            with self._metrics.timing("gateway.request_s"):
+                async with self.request_lock:
+                    if self.phase != SessionPhase.ACTIVE:
+                        raise HTTPException(
+                            status_code=409,
+                            detail=f"Session {self.handle.session_id} is {self.phase.value.lower()}",
+                        )
+                    # Prepare can touch codec and multimodal extractor state, so only
+                    # backend generation runs outside the session lock.
+                    with self._metrics.timing("gateway.encode_s"):
+                        encoded = await self._prepare_generation_inputs(request)
+                    if encoded.capacity_exhausted:
+                        empty_msg = {"role": "assistant", "content": ""}
+                        if encoded.chain_id is not None:
+                            self._close_length_exhausted_chain(encoded)
+                        self._touch()
+                        generation_span.capacity_exhausted(
+                            prompt_tokens=len(encoded.context_ids),
+                            chain_id=encoded.chain_id,
+                        )
+                        return GenerationOutcome(
+                            assistant_msg=empty_msg,
+                            finish_reason="length",
+                            prompt_tokens=len(encoded.context_ids),
+                            completion_tokens=0,
+                        )
                     if encoded.chain_id is not None:
-                        self._close_length_exhausted_chain(encoded)
+                        self.reserved_chain_ids.add(encoded.chain_id)
+                        reserved_chain_id = encoded.chain_id
+
+                try:
+                    with self._metrics.timing("gateway.backend_generate_s"):
+                        output = await backend.generate(
+                            request_id=self.handle.session_id,
+                            prompt_ids=encoded.context_ids,
+                            sampling_params=encoded.sampling_params,
+                            image_data=encoded.image_data,
+                            video_data=encoded.video_data,
+                        )
+                except ValueError as e:
+                    raise HTTPException(status_code=400, detail=str(e)) from e
+                except Exception as e:
+                    raise HTTPException(status_code=500, detail=f"{e.__class__.__name__}: {e}") from e
+
+                response_ids = list(output.token_ids)
+                encoded.buffer.generation_versions.append(
+                    (
+                        output.extra_fields.get("min_global_steps"),
+                        output.extra_fields.get("max_global_steps"),
+                    )
+                )
+                encoded.buffer.response_ids.extend(response_ids)
+                encoded.buffer.response_mask.extend([1] * len(response_ids))
+                if encoded.sampling_params.get("logprobs", False):
+                    if output.log_probs is None:
+                        raise RuntimeError("backend omitted logprobs when requested")
+                    log_probs = list(output.log_probs)
+                    if len(log_probs) != len(response_ids):
+                        raise RuntimeError(
+                            "backend logprobs must align with token_ids: "
+                            f"got {len(log_probs)} logprobs for {len(response_ids)} tokens"
+                        )
+                    encoded.buffer.response_logprobs.extend(log_probs)
+                self._assert_response_logprob_alignment(encoded.buffer)
+
+                # R3 router replay: the backend returns routing for the full context
+                # it just prefilled (prompt + response so far + new tokens), so keep
+                # the latest value; it supersedes prior turns. The framework aligns it
+                # to input_ids when writing to TransferQueue.
+                routed_experts = getattr(output, "routed_experts", None)
+                if routed_experts is not None:
+                    encoded.buffer.routed_experts = routed_experts
+
+                async with self.request_lock:
+                    if self.phase != SessionPhase.ACTIVE:
+                        raise HTTPException(
+                            status_code=409,
+                            detail=f"Session {self.handle.session_id} is {self.phase.value.lower()}",
+                        )
+                    # Decode runs under request_lock so this session's prepare/commit and
+                    # decode stay serialized. It does not serialize decode across sessions,
+                    # which share the actor codec.
+                    with self._metrics.timing("gateway.decode_s"):
+                        assistant_msg, finish_reason = await self._codec.decode_response(
+                            response_ids,
+                            tools=encoded.tools,
+                            stop_reason=output.stop_reason,
+                        )
+                        chain_id = self._commit_generation_to_chain(encoded, assistant_msg)
+                    if reserved_chain_id is not None:
+                        self.reserved_chain_ids.discard(reserved_chain_id)
+                        reserved_chain_id = None
                     self._touch()
-                    generation_span.capacity_exhausted(
+                    generation_span.success(
                         prompt_tokens=len(encoded.context_ids),
-                        chain_id=encoded.chain_id,
+                        completion_tokens=len(response_ids),
+                        chain_id=chain_id,
+                        turn=self._order_seq,
+                        assistant_msg=assistant_msg,
+                        finish_reason=finish_reason,
                     )
                     return GenerationOutcome(
-                        assistant_msg=empty_msg,
-                        finish_reason="length",
+                        assistant_msg=assistant_msg,
+                        finish_reason=finish_reason,
                         prompt_tokens=len(encoded.context_ids),
-                        completion_tokens=0,
+                        completion_tokens=len(response_ids),
                     )
-                if encoded.chain_id is not None:
-                    self.reserved_chain_ids.add(encoded.chain_id)
-                    reserved_chain_id = encoded.chain_id
-
-            try:
-                output = await backend.generate(
-                    request_id=self.handle.session_id,
-                    prompt_ids=encoded.context_ids,
-                    sampling_params=encoded.sampling_params,
-                    image_data=encoded.image_data,
-                    video_data=encoded.video_data,
-                )
-            except ValueError as e:
-                raise HTTPException(status_code=400, detail=str(e)) from e
-            except Exception as e:
-                raise HTTPException(status_code=500, detail=f"{e.__class__.__name__}: {e}") from e
-
-            response_ids = list(output.token_ids)
-            encoded.buffer.generation_versions.append(
-                (
-                    output.extra_fields.get("min_global_steps"),
-                    output.extra_fields.get("max_global_steps"),
-                )
-            )
-            encoded.buffer.response_ids.extend(response_ids)
-            encoded.buffer.response_mask.extend([1] * len(response_ids))
-            if encoded.sampling_params.get("logprobs", False):
-                if output.log_probs is None:
-                    raise RuntimeError("backend omitted logprobs when requested")
-                log_probs = list(output.log_probs)
-                if len(log_probs) != len(response_ids):
-                    raise RuntimeError(
-                        "backend logprobs must align with token_ids: "
-                        f"got {len(log_probs)} logprobs for {len(response_ids)} tokens"
-                    )
-                encoded.buffer.response_logprobs.extend(log_probs)
-            self._assert_response_logprob_alignment(encoded.buffer)
-
-            # R3 router replay: the backend returns routing for the full context
-            # it just prefilled (prompt + response so far + new tokens), so keep
-            # the latest value; it supersedes prior turns. The framework aligns it
-            # to input_ids when writing to TransferQueue.
-            routed_experts = getattr(output, "routed_experts", None)
-            if routed_experts is not None:
-                encoded.buffer.routed_experts = routed_experts
-
-            async with self.request_lock:
-                if self.phase != SessionPhase.ACTIVE:
-                    raise HTTPException(
-                        status_code=409,
-                        detail=f"Session {self.handle.session_id} is {self.phase.value.lower()}",
-                    )
-                # Decode runs under request_lock so this session's prepare/commit and
-                # decode stay serialized. It does not serialize decode across sessions,
-                # which share the actor codec.
-                assistant_msg, finish_reason = await self._codec.decode_response(
-                    response_ids,
-                    tools=encoded.tools,
-                    stop_reason=output.stop_reason,
-                )
-                chain_id = self._commit_generation_to_chain(encoded, assistant_msg)
-                if reserved_chain_id is not None:
-                    self.reserved_chain_ids.discard(reserved_chain_id)
-                    reserved_chain_id = None
-                self._touch()
-                generation_span.success(
-                    prompt_tokens=len(encoded.context_ids),
-                    completion_tokens=len(response_ids),
-                    chain_id=chain_id,
-                    turn=self._order_seq,
-                    assistant_msg=assistant_msg,
-                    finish_reason=finish_reason,
-                )
-                return GenerationOutcome(
-                    assistant_msg=assistant_msg,
-                    finish_reason=finish_reason,
-                    prompt_tokens=len(encoded.context_ids),
-                    completion_tokens=len(response_ids),
-                )
         except Exception as exc:
             generation_span.failure(exc)
             raise
@@ -371,7 +379,14 @@ class GatewaySession:
                 materialized.trajectory
                 for materialized in sorted(self.materialized_chains, key=lambda chain: chain.order_seq)
             ]
-            return [replace(trajectory, reward_info=dict(self.reward_info)) for trajectory in ordered_trajectories]
+            stamped = [replace(trajectory, reward_info=dict(self.reward_info)) for trajectory in ordered_trajectories]
+            metrics = self._metrics.metrics()
+            if metrics and stamped:
+                last = stamped[-1]
+                extra = dict(last.extra_fields)
+                extra["agent_metrics"] = merge_metrics(extra.get("agent_metrics"), metrics)
+                stamped[-1] = replace(last, extra_fields=extra)
+            return stamped
 
     async def abort(self) -> None:
         """Abort the session and prevent further generation."""

--- a/uni_agent/gateway/session/types.py
+++ b/uni_agent/gateway/session/types.py
@@ -31,9 +31,9 @@ class SessionHandle:
         session_id: Stable session identifier assigned by the caller.
         base_url: Per-session provider-compatible ``/v1`` API root, or ``None``
             when the handle only needs to identify the session.
-        reward_info_url: Per-session endpoint used by runners to attach reward
-            metadata; this is a sibling of the provider ``/v1`` root rather
-            than part of that API.
+        reward_info_url: Optional per-session endpoint that can attach reward
+            metadata before finalization (debug). Training copies the runner
+            ``TaskResult`` onto trajectories in the Framework, not through this URL.
     """
 
     session_id: str
@@ -60,8 +60,9 @@ class Trajectory:
         routed_experts: Optional expert-routing data captured by the backend.
         multi_modal_data: Optional image/video data associated with the prompt.
         extra_fields: Gateway-owned extension fields, such as trajectory
-            materialization metadata consumed by training adapters and the
-            ``min_global_steps``/``max_global_steps`` weight-version span.
+            materialization metadata consumed by training adapters, the
+            ``min_global_steps``/``max_global_steps`` weight-version span, and
+            session-level ``agent_metrics`` on the last trajectory.
     """
 
     prompt_ids: list[int]

--- a/uni_agent/metrics/__init__.py
+++ b/uni_agent/metrics/__init__.py
@@ -1,0 +1,40 @@
+"""Per-task metrics built on stdlib ContextVars.
+
+Each Task's :meth:`~uni_agent.tasks.Task.run` installs a :class:`MetricsCollector`
+via :class:`task_metrics`; instrumentation sites record through the module-level
+helpers (:func:`timing`, :func:`incr`, :func:`set_value`), which no-op when no
+task is active -- so library code stays safe to run uninstrumented.
+
+:meth:`MetricsCollector.metrics` crosses process/queue boundaries;
+:func:`reduce_metrics` turns collected samples into a flat scalar dict;
+:func:`aggregate` maps those onto the same verl keys the trainer logs;
+:class:`MetricsReporter` / :func:`report_metrics` export that dict through
+verl's ``Tracking`` (the same sink the trainer uses).
+"""
+
+from __future__ import annotations
+
+from .collector import AggregationType, Metric, MetricsCollector, merge_metrics
+from .context import current_collector, incr, set_value, task_metrics, timing
+from .reduce import build_prompt_metrics_summary, reduce_metrics
+from .report import MetricsReporter, report_metrics
+from .verl_format import aggregate, reduce_agent_metrics, reduce_prompt_summaries
+
+__all__ = [
+    "AggregationType",
+    "Metric",
+    "MetricsCollector",
+    "MetricsReporter",
+    "task_metrics",
+    "current_collector",
+    "timing",
+    "incr",
+    "set_value",
+    "merge_metrics",
+    "reduce_metrics",
+    "build_prompt_metrics_summary",
+    "aggregate",
+    "reduce_agent_metrics",
+    "reduce_prompt_summaries",
+    "report_metrics",
+]

--- a/uni_agent/metrics/collector.py
+++ b/uni_agent/metrics/collector.py
@@ -1,0 +1,156 @@
+"""Task metrics collector: in-process samples -> serializable metrics dict.
+
+One collector per task. Each named series is a :class:`Metric`: a list of
+numeric samples plus an aggregation type (mean / sum / min / max). ``timing``
+sums elapsed seconds; ``incr`` sums deltas; ``observe`` defaults to mean;
+``set_value`` keeps the last write.
+
+:meth:`MetricsCollector.metrics` returns a plain ``dict`` (JSON/pickle-safe)
+that crosses process and queue boundaries unchanged; aggregation into flat
+scalars happens later via :func:`uni_agent.metrics.reduce_metrics`.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from enum import Enum
+from typing import Any
+
+
+class AggregationType(Enum):
+    MEAN = "mean"
+    SUM = "sum"
+    MIN = "min"
+    MAX = "max"
+
+
+class Metric:
+    """Accumulate numeric samples and reduce them with one aggregation type."""
+
+    def __init__(
+        self,
+        aggregation: str | AggregationType,
+        value: float | list[float] | Metric | None = None,
+    ) -> None:
+        if isinstance(aggregation, str):
+            aggregation = AggregationType(aggregation)
+        if not isinstance(aggregation, AggregationType):
+            raise ValueError(f"Unsupported aggregation type: {aggregation}")
+        self.aggregation = aggregation
+        self.values: list[float] = []
+        if value is not None:
+            self.append(value)
+
+    def append(self, value: float | list[float] | Metric) -> None:
+        if isinstance(value, Metric):
+            self.extend(value)
+            return
+        if isinstance(value, list):
+            self.extend(value)
+            return
+        self.values.append(float(value))
+
+    def extend(self, values: Metric | list[float]) -> None:
+        if isinstance(values, Metric):
+            if values.aggregation != self.aggregation:
+                raise ValueError(f"Aggregation type mismatch: {self.aggregation} != {values.aggregation}")
+            values = values.values
+        for value in values:
+            self.append(value)
+
+    def aggregate(self) -> float:
+        return self._aggregate(self.values, self.aggregation)
+
+    @classmethod
+    def _aggregate(cls, values: list[float], aggregation: AggregationType) -> float:
+        if not values:
+            raise ValueError("Cannot aggregate an empty metric.")
+        match aggregation:
+            case AggregationType.MEAN:
+                return sum(values) / len(values)
+            case AggregationType.SUM:
+                return sum(values)
+            case AggregationType.MIN:
+                return min(values)
+            case AggregationType.MAX:
+                return max(values)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"aggregation": self.aggregation.value, "values": list(self.values)}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Metric:
+        metric = cls(aggregation=data.get("aggregation", AggregationType.MEAN))
+        metric.values = [float(v) for v in data.get("values", ())]
+        return metric
+
+
+class MetricsCollector:
+    """Accumulates the metric samples of one task."""
+
+    def __init__(self) -> None:
+        self._metrics: dict[str, Metric] = {}
+
+    def _metric(self, name: str, aggregation: AggregationType) -> Metric:
+        metric = self._metrics.get(name)
+        if metric is None:
+            metric = Metric(aggregation=aggregation)
+            self._metrics[name] = metric
+            return metric
+        if metric.aggregation != aggregation:
+            raise ValueError(f"Aggregation type mismatch for {name!r}: {metric.aggregation} != {aggregation}")
+        return metric
+
+    @contextmanager
+    def timing(self, name: str) -> Iterator[None]:
+        """Time a block and record elapsed seconds (summed)."""
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            self.observe(name, time.perf_counter() - start, aggregation=AggregationType.SUM)
+
+    def observe(
+        self,
+        name: str,
+        value: float,
+        *,
+        aggregation: str | AggregationType = AggregationType.MEAN,
+    ) -> None:
+        """Record one sample."""
+        if isinstance(aggregation, str):
+            aggregation = AggregationType(aggregation)
+        self._metric(name, aggregation).append(value)
+
+    def incr(self, name: str, delta: float = 1) -> None:
+        """Add ``delta`` to a counter (summed)."""
+        self.observe(name, delta, aggregation=AggregationType.SUM)
+
+    def set_value(self, name: str, value: float) -> None:
+        """Set a gauge (last write wins)."""
+        self._metrics[name] = Metric(aggregation=AggregationType.MEAN, value=value)
+
+    def metrics(self) -> dict[str, dict[str, Any]]:
+        """Return the task's samples as a plain serializable dict."""
+        return {name: metric.as_dict() for name, metric in self._metrics.items() if metric.values}
+
+    def merge(self, other: dict[str, dict[str, Any]]) -> None:
+        """Merge another metrics dict into this collector (e.g. a child component's)."""
+        for name, entry in other.items():
+            incoming = Metric.from_dict(entry)
+            existing = self._metrics.get(name)
+            if existing is None:
+                self._metrics[name] = incoming
+            else:
+                existing.extend(incoming)
+
+
+def merge_metrics(*metrics: dict[str, dict[str, Any]] | None) -> dict[str, dict[str, Any]]:
+    """Combine metrics dicts into one, concatenating samples for shared names."""
+    collector = MetricsCollector()
+    for item in metrics:
+        if item:
+            collector.merge(item)
+    return collector.metrics()

--- a/uni_agent/metrics/context.py
+++ b/uni_agent/metrics/context.py
@@ -1,0 +1,79 @@
+"""Metrics context: one collector per task, carried implicitly by a ContextVar.
+
+Each Task's :meth:`~uni_agent.tasks.Task.run` installs a collector via
+:class:`task_metrics`; every instrumentation site below it records through the
+module-level helpers, which no-op when no task is active.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from .collector import MetricsCollector
+
+_current_collector: contextvars.ContextVar[MetricsCollector | None] = contextvars.ContextVar(
+    "uni_agent_metrics", default=None
+)
+
+
+class task_metrics:
+    """Bind a fresh :class:`MetricsCollector` to this block; usable as ``with`` or ``async with``."""
+
+    def __init__(self) -> None:
+        self.collector = MetricsCollector()
+        self._token: contextvars.Token | None = None
+
+    def _enter(self) -> MetricsCollector:
+        self._token = _current_collector.set(self.collector)
+        return self.collector
+
+    def _exit(self) -> None:
+        if self._token is not None:
+            _current_collector.reset(self._token)
+            self._token = None
+
+    def __enter__(self) -> MetricsCollector:
+        return self._enter()
+
+    def __exit__(self, *exc_info) -> bool:
+        self._exit()
+        return False
+
+    async def __aenter__(self) -> MetricsCollector:
+        return self._enter()
+
+    async def __aexit__(self, *exc_info) -> bool:
+        self._exit()
+        return False
+
+
+def current_collector() -> MetricsCollector | None:
+    """The active task's collector, or ``None`` outside a task."""
+    return _current_collector.get()
+
+
+@contextmanager
+def timing(name: str) -> Iterator[None]:
+    """Time the block on the active collector; no-op outside a task."""
+    collector = _current_collector.get()
+    if collector is None:
+        yield
+        return
+    with collector.timing(name):
+        yield
+
+
+def incr(name: str, delta: float = 1) -> None:
+    """Add to a counter on the active collector; no-op outside a task."""
+    collector = _current_collector.get()
+    if collector is not None:
+        collector.incr(name, delta)
+
+
+def set_value(name: str, value: float) -> None:
+    """Set a gauge on the active collector; no-op outside a task."""
+    collector = _current_collector.get()
+    if collector is not None:
+        collector.set_value(name, value)

--- a/uni_agent/metrics/reduce.py
+++ b/uni_agent/metrics/reduce.py
@@ -1,0 +1,127 @@
+"""Reduce per-task metrics to flat scalars.
+
+``reduce_metrics`` takes a dict of :class:`~uni_agent.metrics.collector.Metric`
+instances or sample lists and collapses each key to one number. The aggregation
+is taken from the ``Metric`` when present; otherwise the key name decides
+(``max`` / ``min`` in the name, else mean). A list of per-task metrics dicts is
+reduced per task first, then across tasks. Callers choose metric names; this
+module does not.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .collector import Metric
+
+
+def reduce_metrics(
+    metrics: dict[str, Metric | list[Any] | dict[str, Any]] | list[dict[str, dict[str, Any]]],
+) -> dict[str, float]:
+    """Collapse each metric to a single scalar."""
+    if isinstance(metrics, list):
+        grouped: dict[str, list[float]] = {}
+        for item in metrics:
+            for name, entry in item.items():
+                metric = Metric.from_dict(entry)
+                if metric.values:
+                    grouped.setdefault(name, []).append(metric.aggregate())
+        return reduce_metrics(grouped)
+
+    out: dict[str, float] = {}
+    for key, val in metrics.items():
+        if isinstance(val, Metric):
+            if val.values:
+                out[key] = val.aggregate()
+            continue
+        if isinstance(val, dict) and "values" in val:
+            metric = Metric.from_dict(val)
+            if metric.values:
+                out[key] = metric.aggregate()
+            continue
+        values = [float(v) for v in val]
+        if not values:
+            continue
+        key_lower = key.lower()
+        if "max" in key_lower:
+            out[key] = max(values)
+        elif "min" in key_lower:
+            out[key] = min(values)
+        else:
+            out[key] = sum(values) / len(values)
+    return out
+
+
+_PROMPT_COUNT_KEYS = (
+    "expected_sessions",
+    "success_sessions",
+    "failed_sessions",
+    "unfinished_sessions",
+)
+
+
+def _metrics_sufficient_stats(metrics: dict[str, dict[str, Any]] | None) -> dict[str, dict[str, float]]:
+    """Collapse one task's metrics to ``{name: {count, sum, min, max}}``.
+
+    Each metric contributes one task-level scalar (the collector aggregation),
+    so a later merge across sessions is lossless.
+    """
+    if not metrics:
+        return {}
+    stats: dict[str, dict[str, float]] = {}
+    for name, entry in metrics.items():
+        if not isinstance(entry, dict) or "values" not in entry:
+            continue
+        metric = Metric.from_dict(entry)
+        if not metric.values:
+            continue
+        value = float(metric.aggregate())
+        stats[name] = {"count": 1.0, "sum": value, "min": value, "max": value}
+    return stats
+
+
+def merge_sufficient_stats(
+    rows: list[dict[str, dict[str, float]]],
+) -> dict[str, dict[str, float]]:
+    """Merge per-session sufficient stats without losing min/max."""
+    merged: dict[str, dict[str, float]] = {}
+    for row in rows:
+        for name, stats in row.items():
+            if name in _PROMPT_COUNT_KEYS or not isinstance(stats, dict):
+                continue
+            incoming_count = float(stats.get("count", 0.0))
+            if incoming_count <= 0:
+                continue
+            existing = merged.get(name)
+            if existing is None:
+                merged[name] = {
+                    "count": incoming_count,
+                    "sum": float(stats["sum"]),
+                    "min": float(stats["min"]),
+                    "max": float(stats["max"]),
+                }
+                continue
+            existing["count"] += incoming_count
+            existing["sum"] += float(stats["sum"])
+            existing["min"] = min(existing["min"], float(stats["min"]))
+            existing["max"] = max(existing["max"], float(stats["max"]))
+    return merged
+
+
+def build_prompt_metrics_summary(
+    *,
+    expected_sessions: int,
+    success_sessions: int,
+    failed_sessions: int,
+    unfinished_sessions: int,
+    metrics: list[dict[str, dict[str, Any]]] | None = None,
+) -> dict[str, Any]:
+    """Prompt-level TQ payload: session outcomes plus merged sufficient stats."""
+    summary: dict[str, Any] = {
+        "expected_sessions": int(expected_sessions),
+        "success_sessions": int(success_sessions),
+        "failed_sessions": int(failed_sessions),
+        "unfinished_sessions": int(unfinished_sessions),
+    }
+    summary.update(merge_sufficient_stats([_metrics_sufficient_stats(item) for item in metrics or []]))
+    return summary

--- a/uni_agent/metrics/report.py
+++ b/uni_agent/metrics/report.py
@@ -1,0 +1,110 @@
+"""Export reduced metrics through verl's Tracking.
+
+Collection and reduction stay verl-free. This module is the local sink: the
+same ``Tracking.log`` path the trainer uses, with backends chosen by the caller
+(console/file by default). Training still logs via the trainer's own Tracking
+instance; this reporter is for every other entry point that already holds a
+flat ``{name: scalar}`` dict.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections.abc import Sequence
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BACKENDS = ("console", "file")
+
+
+def _load_tracking():
+    from verl.utils.tracking import Tracking
+
+    return Tracking
+
+
+@contextmanager
+def _file_logger_path(filepath: str | None):
+    """Point verl's FileLogger at ``filepath`` for the duration of the block."""
+    if filepath is None:
+        yield
+        return
+    previous = os.environ.get("VERL_FILE_LOGGER_PATH")
+    os.environ["VERL_FILE_LOGGER_PATH"] = filepath
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("VERL_FILE_LOGGER_PATH", None)
+        else:
+            os.environ["VERL_FILE_LOGGER_PATH"] = previous
+
+
+class MetricsReporter:
+    """Thin wrapper around ``verl.utils.tracking.Tracking``.
+
+    ``Tracking`` is imported lazily so ``uni_agent.metrics`` stays importable
+    without verl. When Tracking is unavailable the scalars are logged in-process
+    instead of raising.
+    """
+
+    def __init__(
+        self,
+        *,
+        project: str = "uni_agent",
+        experiment: str = "metrics",
+        backends: Sequence[str] = _DEFAULT_BACKENDS,
+        filepath: str | None = None,
+    ) -> None:
+        self._tracking: Any | None = None
+        try:
+            Tracking = _load_tracking()
+        except ImportError:
+            logger.info("verl Tracking unavailable; metrics will be logged locally")
+            return
+        with _file_logger_path(filepath):
+            if filepath:
+                Path(filepath).expanduser().parent.mkdir(parents=True, exist_ok=True)
+            self._tracking = Tracking(project, experiment, default_backend=list(backends))
+
+    def log(self, metrics: dict[str, Any], *, step: int = 0) -> None:
+        if not metrics:
+            return
+        if self._tracking is None:
+            logger.info("metrics: %s", json.dumps(metrics, default=str))
+            return
+        self._tracking.log(metrics, step)
+
+    def finish(self) -> None:
+        if self._tracking is not None:
+            self._tracking.finish()
+            self._tracking = None
+
+
+def report_metrics(
+    metrics: dict[str, Any],
+    *,
+    step: int = 0,
+    project: str = "uni_agent",
+    experiment: str = "metrics",
+    backends: Sequence[str] = _DEFAULT_BACKENDS,
+    filepath: str | None = None,
+) -> None:
+    """One-shot export: construct a reporter, log ``metrics``, then finish."""
+    if not metrics:
+        return
+    reporter = MetricsReporter(
+        project=project,
+        experiment=experiment,
+        backends=backends,
+        filepath=filepath,
+    )
+    try:
+        reporter.log(metrics, step=step)
+    finally:
+        reporter.finish()

--- a/uni_agent/metrics/verl_format.py
+++ b/uni_agent/metrics/verl_format.py
@@ -1,0 +1,139 @@
+"""Map uni-agent metrics onto verl trainer metric keys.
+
+Collection stays on dotted internal names. This module is the shared format
+exit: training wandb keys and eval console/JSONL keys are the same.
+
+Zero verl imports. The trainer feeds timing stages into ``timing_raw`` so
+``compute_timing_metrics`` can add the ``timing_s/`` prefix; :func:`aggregate`
+applies that prefix itself for eval and other local sinks.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .collector import Metric
+
+# Internal collector name -> timing_raw stage (trainer then prefixes timing_s/).
+_TIMING_STAGES: dict[str, str] = {
+    "task.total_s": "task/total",
+    "task.generate_s": "task/generate",
+    "reward.s": "task/reward",
+    "env.start_s": "task/env_start",
+    "gateway.request_s": "gateway/request",
+    "gateway.encode_s": "gateway/encode",
+    "gateway.backend_generate_s": "gateway/backend_generate",
+    "gateway.decode_s": "gateway/decode",
+    "agent.run_s": "agent/run",
+}
+
+# Counters are not trainer-stage timings; they land on metrics as-is.
+_COUNTER_KEYS: dict[str, str] = {
+    "gateway.requests": "gateway/requests",
+}
+
+
+def _unwrap(value: Any) -> Any:
+    return getattr(value, "data", value)
+
+
+def _as_metrics(value: Any) -> dict[str, dict[str, Any]]:
+    value = _unwrap(value)
+    if not isinstance(value, dict) or not value:
+        return {}
+    return {name: entry for name, entry in value.items() if isinstance(entry, dict) and "values" in entry}
+
+
+def _task_scalars(metrics: dict[str, dict[str, Any]]) -> dict[str, float]:
+    scalars: dict[str, float] = {}
+    for name, entry in metrics.items():
+        metric = Metric.from_dict(entry)
+        if metric.values:
+            scalars[name] = float(metric.aggregate())
+    return scalars
+
+
+def _mean_max(values: list[float]) -> tuple[float, float]:
+    return sum(values) / len(values), max(values)
+
+
+def reduce_agent_metrics(
+    metrics: list[Any],
+    mask: Any | None = None,
+) -> tuple[dict[str, float], dict[str, float]]:
+    """Reduce trajectory ``agent_metrics`` rows to trainer timing + scalar dicts.
+
+    Empty metrics (non-last trajectories in a multi-chain session) are skipped
+    so session-level timings are not double-counted. ``mask`` is a boolean
+    sequence aligned with ``metrics`` (``False`` = padding).
+
+    Returns ``(timing_raw, metrics)``. Timing keys have no ``timing_s/`` prefix.
+    """
+    task_rows: list[dict[str, float]] = []
+    for index, raw in enumerate(metrics):
+        if mask is not None and not bool(mask[index]):
+            continue
+        scalars = _task_scalars(_as_metrics(raw))
+        if scalars:
+            task_rows.append(scalars)
+    if not task_rows:
+        return {}, {}
+
+    grouped: dict[str, list[float]] = {}
+    for row in task_rows:
+        for name, value in row.items():
+            grouped.setdefault(name, []).append(value)
+
+    timing_raw: dict[str, float] = {}
+    metrics: dict[str, float] = {}
+    for name, values in grouped.items():
+        mean_value, max_value = _mean_max(values)
+        stage = _TIMING_STAGES.get(name)
+        if stage is not None:
+            timing_raw[f"{stage}/mean"] = mean_value
+            timing_raw[f"{stage}/max"] = max_value
+            continue
+        counter = _COUNTER_KEYS.get(name)
+        if counter is not None:
+            metrics[f"{counter}/mean"] = mean_value
+            metrics[f"{counter}/max"] = max_value
+
+    slowest = max(task_rows, key=lambda row: row.get("task.total_s", float("-inf")))
+    for name, value in slowest.items():
+        stage = _TIMING_STAGES.get(name)
+        if stage is not None:
+            metrics[f"agent_loop/slowest/{stage}"] = value
+
+    return timing_raw, metrics
+
+
+def aggregate(metrics: list[Any]) -> dict[str, float]:
+    """Eval/local sink: same keys the trainer logs after ``compute_timing_metrics``."""
+    timing_raw, scalars = reduce_agent_metrics(metrics)
+    out = {f"timing_s/{name}": value for name, value in timing_raw.items()}
+    out.update(scalars)
+    return out
+
+
+def reduce_prompt_summaries(summaries: list[Any]) -> dict[str, float]:
+    """Reduce prompt ``agent_metrics_summary`` rows to L0 ``agent_loop/*`` counters.
+
+    Each summary is consumed once (the caller de-dupes by uid). Timing sufficient
+    stats stay on the TQ field for down-drill; they are not re-emitted here so
+    they cannot collide with the batch-level ``timing_s/task/*`` keys.
+    """
+    rows = [_unwrap(item) for item in summaries]
+    rows = [row for row in rows if isinstance(row, dict)]
+    if not rows:
+        return {}
+
+    success_sessions = sum(int(row.get("success_sessions", 0)) for row in rows)
+    failed_sessions = sum(int(row.get("failed_sessions", 0)) for row in rows)
+    unfinished_sessions = sum(int(row.get("unfinished_sessions", 0)) for row in rows)
+    failed_prompts = sum(1 for row in rows if int(row.get("success_sessions", 0)) <= 0)
+    return {
+        "agent_loop/failed_prompts": float(failed_prompts),
+        "agent_loop/success_sessions": float(success_sessions),
+        "agent_loop/failed_sessions": float(failed_sessions),
+        "agent_loop/unfinished_sessions": float(unfinished_sessions),
+    }

--- a/uni_agent/rlinsight_adapter.py
+++ b/uni_agent/rlinsight_adapter.py
@@ -135,13 +135,11 @@ class TaskSpanState:
     reward: Any = None
     accuracy: Any = None
     finished: Any = None
-    reward_posted: bool = False
 
-    def record_result(self, result: Any, *, reward_posted: bool) -> None:
+    def record_result(self, result: Any) -> None:
         self.reward = result.reward
         self.accuracy = result.accuracy
         self.finished = result.finished
-        self.reward_posted = reward_posted
 
     def _attributes(self) -> dict[str, Any]:
         return {
@@ -153,7 +151,6 @@ class TaskSpanState:
             "reward": self.reward,
             "accuracy": self.accuracy,
             "finished": self.finished,
-            "reward_posted": self.reward_posted,
             "error": self.error,
         }
 

--- a/uni_agent/sandbox/base.py
+++ b/uni_agent/sandbox/base.py
@@ -299,6 +299,12 @@ class Sandbox(abc.ABC):
         and is bounded by ``SANDBOX_STARTUP_TIMEOUT``; the slot is released before the
         retry backoff and the cleanup ``stop()``.
         """
+        from ..metrics import timing
+
+        with timing("env.start_s"):
+            return await self._start_with_retry(retry)
+
+    async def _start_with_retry(self, retry: int) -> Sandbox:
         retry = max(1, retry)
         last_exc: BaseException | None = None
         for attempt in range(1, retry + 1):

--- a/uni_agent/tasks/base.py
+++ b/uni_agent/tasks/base.py
@@ -95,6 +95,7 @@ class TaskResult:
     accuracy: float | None = None
     finished: bool | None = None
     extra_info: dict[str, Any] | None = None
+    metrics: dict[str, Any] | None = None
 
 
 class Task(ABC):
@@ -102,7 +103,7 @@ class Task(ABC):
 
     Concrete tasks live in ``tasks/<name>/task.py``: set :attr:`name`, subclass
     :class:`TaskConfig`, and implement :meth:`run` (which also does reward scoring).
-    The base provides the config -> runtime glue (:meth:`build_sandbox`,
+    The base also provides the config -> runtime glue (:meth:`build_sandbox`,
     :meth:`build_agent`) so runners stay generic.
     """
 

--- a/uni_agent/tasks/harbor/task.py
+++ b/uni_agent/tasks/harbor/task.py
@@ -17,6 +17,7 @@ from pydantic import Field, field_validator, model_validator
 
 from uni_agent.agents import AgentConfig
 from uni_agent.logging import get_current_log_context
+from uni_agent.metrics import task_metrics, timing
 
 from ..base import Task, TaskConfig, TaskResult
 from ..registry import register_task
@@ -187,27 +188,31 @@ class HarborTask(Task):
     config_model = HarborTaskConfig
 
     async def run(self) -> TaskResult:
-        config: HarborTaskConfig = self.config  # type: ignore[assignment]
-        log_context = get_current_log_context()
-        output_dir: Path | None = None
-        if log_context is not None and log_context.log_path:
-            rollout_dir = Path(log_context.log_path).expanduser().resolve().parent
-            output_dir = rollout_dir / "harbor"
-            await asyncio.to_thread(rollout_dir.mkdir, parents=True, exist_ok=True)
-            if output_dir.exists():
-                raise RuntimeError(f"Harbor output directory already exists: {output_dir}")
+        async with task_metrics() as collector:
+            with timing("task.total_s"):
+                config: HarborTaskConfig = self.config  # type: ignore[assignment]
+                log_context = get_current_log_context()
+                output_dir: Path | None = None
+                if log_context is not None and log_context.log_path:
+                    rollout_dir = Path(log_context.log_path).expanduser().resolve().parent
+                    output_dir = rollout_dir / "harbor"
+                    await asyncio.to_thread(rollout_dir.mkdir, parents=True, exist_ok=True)
+                    if output_dir.exists():
+                        raise RuntimeError(f"Harbor output directory already exists: {output_dir}")
 
-        trial_name = str(uuid4().hex)
-        trial_dir = _TEMP_TRIALS_DIR / trial_name
-        try:
-            return await self._run_trial(
-                config,
-                _TEMP_TRIALS_DIR,
-                trial_name=trial_name,
-                output_dir=output_dir,
-            )
-        finally:
-            await asyncio.to_thread(shutil.rmtree, trial_dir, ignore_errors=True)
+                trial_name = str(uuid4().hex)
+                trial_dir = _TEMP_TRIALS_DIR / trial_name
+                try:
+                    outcome = await self._run_trial(
+                        config,
+                        _TEMP_TRIALS_DIR,
+                        trial_name=trial_name,
+                        output_dir=output_dir,
+                    )
+                finally:
+                    await asyncio.to_thread(shutil.rmtree, trial_dir, ignore_errors=True)
+            outcome.metrics = collector.metrics()
+            return outcome
 
     async def _run_trial(
         self,
@@ -238,7 +243,8 @@ class HarborTask(Task):
         )
         started = time.perf_counter()
         try:
-            response = await run_harbor_cli(command, env=process_env)
+            with timing("task.generate_s"):
+                response = await run_harbor_cli(command, env=process_env)
         except FileNotFoundError as exc:
             raise RuntimeError(
                 "Harbor CLI executable was not found; install Harbor 0.16.0 or later and ensure `harbor` is on PATH"
@@ -276,14 +282,15 @@ class HarborTask(Task):
                 encoding="utf-8",
             )
 
-        result = task_result_from_harbor_trial(
-            payload,
-            trial_dir=trial_dir,
-            cli_exit_code=response.exit_code,
-            stdout=response.stdout,
-            stderr=response.stderr,
-            elapsed=elapsed,
-        )
+        with timing("reward.s"):
+            result = task_result_from_harbor_trial(
+                payload,
+                trial_dir=trial_dir,
+                cli_exit_code=response.exit_code,
+                stdout=response.stdout,
+                stderr=response.stderr,
+                elapsed=elapsed,
+            )
         info = result.extra_info or {}
         if not info.get("eval_completed"):
             logger.warning(

--- a/uni_agent/tasks/hotpotqa/task.py
+++ b/uni_agent/tasks/hotpotqa/task.py
@@ -6,6 +6,7 @@ from pydantic import Field
 
 from uni_agent.agents.mem_agent import ContextManagerResult
 
+from ...metrics import task_metrics, timing
 from ..base import Task, TaskConfig, TaskResult
 from ..registry import register_task
 from .reward import compute_score
@@ -26,49 +27,55 @@ class HotpotQATask(Task):
     config_model = HotpotQATaskConfig
 
     async def run(self) -> TaskResult:
-        cfg: HotpotQATaskConfig = self.config  # type: ignore[assignment]
-        raw_data = dict(cfg.metadata)
+        async with task_metrics() as collector:
+            with timing("task.total_s"):
+                cfg: HotpotQATaskConfig = self.config  # type: ignore[assignment]
+                raw_data = dict(cfg.metadata)
 
-        async with self.build_sandbox() as sandbox:
-            agent = self.build_agent()
-            agent_result = await agent.run(
-                sandbox=sandbox,
-                messages=cfg.prompt,
-                workdir=None,
-                raw_data=raw_data,
-            )
+                async with self.build_sandbox() as sandbox:
+                    agent = self.build_agent()
+                    with timing("task.generate_s"):
+                        agent_result = await agent.run(
+                            sandbox=sandbox,
+                            messages=cfg.prompt,
+                            workdir=None,
+                            raw_data=raw_data,
+                        )
 
-        response = str(agent_result.output.get("response", ""))
-        ground_truths = list(cfg.ground_truth)
-        if not ground_truths:
-            reward_model = cfg.metadata.get("reward_model", {})
-            raw_ground_truth = reward_model.get("ground_truth", []) if isinstance(reward_model, dict) else []
-            if isinstance(raw_ground_truth, str):
-                ground_truths = [raw_ground_truth]
-            elif isinstance(raw_ground_truth, list | tuple):
-                ground_truths = [str(answer) for answer in raw_ground_truth]
-            elif raw_ground_truth is not None:
-                ground_truths = [str(raw_ground_truth)]
+                response = str(agent_result.output.get("response", ""))
+                ground_truths = list(cfg.ground_truth)
+                if not ground_truths:
+                    reward_model = cfg.metadata.get("reward_model", {})
+                    raw_ground_truth = reward_model.get("ground_truth", []) if isinstance(reward_model, dict) else []
+                    if isinstance(raw_ground_truth, str):
+                        ground_truths = [raw_ground_truth]
+                    elif isinstance(raw_ground_truth, list | tuple):
+                        ground_truths = [str(answer) for answer in raw_ground_truth]
+                    elif raw_ground_truth is not None:
+                        ground_truths = [str(raw_ground_truth)]
 
-        reward = compute_score(response, ground_truths)
-        context_manager_result = agent_result.output.get("context_manager_result")
-        thinking_turns = 0
-        if isinstance(context_manager_result, ContextManagerResult):
-            context_manager_result.set_reward(reward)
-            thinking_turns = sum(
-                "<think" in turn.response.lower() or "</think>" in turn.response.lower()
-                for context_step in context_manager_result.trajectory
-                for turn in context_step.steps
-            )
+                with timing("reward.s"):
+                    reward = compute_score(response, ground_truths)
+                context_manager_result = agent_result.output.get("context_manager_result")
+                thinking_turns = 0
+                if isinstance(context_manager_result, ContextManagerResult):
+                    context_manager_result.set_reward(reward)
+                    thinking_turns = sum(
+                        "<think" in turn.response.lower() or "</think>" in turn.response.lower()
+                        for context_step in context_manager_result.trajectory
+                        for turn in context_step.steps
+                    )
 
-        return TaskResult(
-            reward=reward,
-            accuracy=reward,
-            extra_info={
-                "response": response,
-                "num_contexts": agent_result.info.get("num_contexts", 0),
-                "total_steps": agent_result.info.get("total_steps", 0),
-                "thinking_detected": thinking_turns > 0,
-                "thinking_turns": thinking_turns,
-            },
-        )
+                outcome = TaskResult(
+                    reward=reward,
+                    accuracy=reward,
+                    extra_info={
+                        "response": response,
+                        "num_contexts": agent_result.info.get("num_contexts", 0),
+                        "total_steps": agent_result.info.get("total_steps", 0),
+                        "thinking_detected": thinking_turns > 0,
+                        "thinking_turns": thinking_turns,
+                    },
+                )
+            outcome.metrics = collector.metrics()
+            return outcome

--- a/uni_agent/tasks/swe_bench/task.py
+++ b/uni_agent/tasks/swe_bench/task.py
@@ -7,6 +7,7 @@ import logging
 
 from pydantic import Field
 
+from ...metrics import task_metrics, timing
 from ..base import Task, TaskConfig, TaskResult
 from ..registry import register_task
 
@@ -31,40 +32,50 @@ class SWEBenchTask(Task):
     config_model = SWEBenchTaskConfig
 
     async def run(self) -> TaskResult:
-        cfg: SWEBenchTaskConfig = self.config  # type: ignore[assignment]
-        sample = cfg.metadata  # the dataset sample is carried on the task config
+        async with task_metrics() as collector:
+            with timing("task.total_s"):
+                cfg: SWEBenchTaskConfig = self.config  # type: ignore[assignment]
+                sample = cfg.metadata  # the dataset sample is carried on the task config
 
-        instance_id = sample.get("instance_id", "?") if isinstance(sample, dict) else "?"
-        task_config_dump = cfg.model_dump(mode="json", exclude={"metadata", "prompt"})
-        logger.info(
-            f"starting swe_bench task (instance_id={instance_id}, run_oracle_solution={cfg.run_oracle_solution})\n"
-            f"task config: {json.dumps(task_config_dump, indent=2)}"
-        )
-        async with self.build_sandbox() as sandbox:
-            if cfg.run_oracle_solution:
-                logger.info("applying gold patch to /testbed")
-                await sandbox.write_file("/tmp/gold_patch.patch", sample["patch"])
-                await sandbox.exec(["git", "apply", "--whitespace=fix", "/tmp/gold_patch.patch"], workdir="/testbed")
-                finished = True
-            else:
-                agent = self.build_agent()
-                messages = cfg.prompt
-                # The endpoint the agent calls lives on cfg.agent.model (the agent validates it).
-                agent_result = await agent.run(
-                    sandbox=sandbox,
-                    messages=messages,
-                    workdir="/testbed",
+                instance_id = sample.get("instance_id", "?") if isinstance(sample, dict) else "?"
+                task_config_dump = cfg.model_dump(mode="json", exclude={"metadata", "prompt"})
+                logger.info(
+                    "starting swe_bench task "
+                    f"(instance_id={instance_id}, run_oracle_solution={cfg.run_oracle_solution})\n"
+                    f"task config: {json.dumps(task_config_dump, indent=2)}"
                 )
-                finished = agent_result.finished
+                async with self.build_sandbox() as sandbox:
+                    if cfg.run_oracle_solution:
+                        logger.info("applying gold patch to /testbed")
+                        await sandbox.write_file("/tmp/gold_patch.patch", sample["patch"])
+                        await sandbox.exec(
+                            ["git", "apply", "--whitespace=fix", "/tmp/gold_patch.patch"],
+                            workdir="/testbed",
+                        )
+                        finished = True
+                    else:
+                        agent = self.build_agent()
+                        messages = cfg.prompt
+                        # The endpoint the agent calls lives on cfg.agent.model (the agent validates it).
+                        with timing("task.generate_s"):
+                            agent_result = await agent.run(
+                                sandbox=sandbox,
+                                messages=messages,
+                                workdir="/testbed",
+                            )
+                        finished = agent_result.finished
 
-            from .reward import compute_reward
+                    from .reward import compute_reward
 
-            result = await compute_reward(sample, sandbox, eval_timeout=cfg.eval_timeout)
+                    with timing("reward.s"):
+                        result = await compute_reward(sample, sandbox, eval_timeout=cfg.eval_timeout)
 
-            logger.info(f"task done: resolved={result['resolved']}")
-            return TaskResult(
-                reward=float(result["resolved"]),
-                accuracy=float(result["resolved"]),
-                finished=finished,
-                extra_info=result,
-            )
+                    logger.info(f"task done: resolved={result['resolved']}")
+                    outcome = TaskResult(
+                        reward=float(result["resolved"]),
+                        accuracy=float(result["resolved"]),
+                        finished=finished,
+                        extra_info=result,
+                    )
+            outcome.metrics = collector.metrics()
+            return outcome

--- a/uni_agent/tasks/swe_bench_multilingual/task.py
+++ b/uni_agent/tasks/swe_bench_multilingual/task.py
@@ -7,6 +7,7 @@ import logging
 
 from pydantic import Field
 
+from ...metrics import task_metrics, timing
 from ..base import Task, TaskConfig, TaskResult
 from ..registry import register_task
 
@@ -42,58 +43,64 @@ class SWEBenchMultilingualTask(Task):
     config_model = SWEBenchMultilingualTaskConfig
 
     async def run(self) -> TaskResult:
-        cfg: SWEBenchMultilingualTaskConfig = self.config  # type: ignore[assignment]
-        sample = cfg.metadata
-        instance_id = sample.get("instance_id", "?")
-        task_config_dump = cfg.model_dump(mode="json", exclude={"metadata", "prompt"})
-        logger.info(
-            "starting swe_bench_multilingual task "
-            f"(instance_id={instance_id}, run_oracle_solution={cfg.run_oracle_solution})\n"
-            f"task config: {json.dumps(task_config_dump, indent=2)}"
-        )
-
-        async with self.build_sandbox() as sandbox:
-            # Preserve build-time worktree edits while removing history that could
-            # expose the upstream solution to the agent.
-            await sandbox.exec_shell(_GIT_CLEAN_HISTORY, workdir="/testbed")
-
-            if cfg.run_oracle_solution:
-                logger.info("applying gold patch to /testbed")
-                patch_path = "/tmp/gold_patch.patch"
-                await sandbox.write_file(patch_path, sample["patch"])
-                apply_result = await sandbox.exec(
-                    ["git", "apply", "--whitespace=fix", patch_path],
-                    workdir="/testbed",
+        async with task_metrics() as collector:
+            with timing("task.total_s"):
+                cfg: SWEBenchMultilingualTaskConfig = self.config  # type: ignore[assignment]
+                sample = cfg.metadata
+                instance_id = sample.get("instance_id", "?")
+                task_config_dump = cfg.model_dump(mode="json", exclude={"metadata", "prompt"})
+                logger.info(
+                    "starting swe_bench_multilingual task "
+                    f"(instance_id={instance_id}, run_oracle_solution={cfg.run_oracle_solution})\n"
+                    f"task config: {json.dumps(task_config_dump, indent=2)}"
                 )
-                if apply_result.exit_code != 0:
-                    error = apply_result.stderr.strip() or apply_result.stdout.strip()
-                    raise RuntimeError(f"failed to apply gold patch for {instance_id}: {error}")
-                finished = True
-            else:
-                agent = self.build_agent()
-                agent_result = await agent.run(
-                    sandbox=sandbox,
-                    messages=cfg.prompt,
-                    workdir="/testbed",
-                )
-                finished = agent_result.finished
 
-            try:
-                from .reward import compute_reward
+                async with self.build_sandbox() as sandbox:
+                    # Preserve build-time worktree edits while removing history that could
+                    # expose the upstream solution to the agent.
+                    await sandbox.exec_shell(_GIT_CLEAN_HISTORY, workdir="/testbed")
 
-                result = await compute_reward(
-                    sample,
-                    sandbox,
-                    eval_timeout=cfg.eval_timeout,
-                )
-            except Exception:
-                logger.exception("scoring failed for instance_id=%s", instance_id)
-                raise
+                    if cfg.run_oracle_solution:
+                        logger.info("applying gold patch to /testbed")
+                        patch_path = "/tmp/gold_patch.patch"
+                        await sandbox.write_file(patch_path, sample["patch"])
+                        apply_result = await sandbox.exec(
+                            ["git", "apply", "--whitespace=fix", patch_path],
+                            workdir="/testbed",
+                        )
+                        if apply_result.exit_code != 0:
+                            error = apply_result.stderr.strip() or apply_result.stdout.strip()
+                            raise RuntimeError(f"failed to apply gold patch for {instance_id}: {error}")
+                        finished = True
+                    else:
+                        agent = self.build_agent()
+                        with timing("task.generate_s"):
+                            agent_result = await agent.run(
+                                sandbox=sandbox,
+                                messages=cfg.prompt,
+                                workdir="/testbed",
+                            )
+                        finished = agent_result.finished
 
-            logger.info("task done: resolved=%s", result["resolved"])
-            return TaskResult(
-                reward=float(result["resolved"]),
-                accuracy=float(result["resolved"]),
-                finished=finished,
-                extra_info=result,
-            )
+                    try:
+                        from .reward import compute_reward
+
+                        with timing("reward.s"):
+                            result = await compute_reward(
+                                sample,
+                                sandbox,
+                                eval_timeout=cfg.eval_timeout,
+                            )
+                    except Exception:
+                        logger.exception("scoring failed for instance_id=%s", instance_id)
+                        raise
+
+                    logger.info("task done: resolved=%s", result["resolved"])
+                    outcome = TaskResult(
+                        reward=float(result["resolved"]),
+                        accuracy=float(result["resolved"]),
+                        finished=finished,
+                        extra_info=result,
+                    )
+            outcome.metrics = collector.metrics()
+            return outcome

--- a/uni_agent/tasks/swe_rebench/task.py
+++ b/uni_agent/tasks/swe_rebench/task.py
@@ -13,6 +13,7 @@ import logging
 
 from pydantic import Field
 
+from ...metrics import task_metrics, timing
 from ..base import Task, TaskConfig, TaskResult
 from ..registry import register_task
 
@@ -47,47 +48,57 @@ class SWEREBenchTask(Task):
     config_model = SWEREBenchTaskConfig
 
     async def run(self) -> TaskResult:
-        cfg: SWEREBenchTaskConfig = self.config  # type: ignore[assignment]
-        sample = cfg.metadata  # the dataset sample is carried on the task config
+        async with task_metrics() as collector:
+            with timing("task.total_s"):
+                cfg: SWEREBenchTaskConfig = self.config  # type: ignore[assignment]
+                sample = cfg.metadata  # the dataset sample is carried on the task config
 
-        instance_id = sample.get("instance_id", "?") if isinstance(sample, dict) else "?"
-        task_config_dump = cfg.model_dump(mode="json", exclude={"metadata", "prompt"})
-        logger.info(
-            f"starting swe_rebench task (instance_id={instance_id}, run_oracle_solution={cfg.run_oracle_solution})\n"
-            f"task config: {json.dumps(task_config_dump, indent=2)}"
-        )
-        async with self.build_sandbox() as sandbox:
-            # Clean future history before anything reads the repo.
-            await sandbox.exec_shell(_GIT_CLEAN_HISTORY, workdir="/testbed")
-
-            if cfg.run_oracle_solution:
-                logger.info("applying gold patch to /testbed")
-                await sandbox.write_file("/tmp/gold_patch.patch", sample["patch"])
-                await sandbox.exec(["git", "apply", "--whitespace=fix", "/tmp/gold_patch.patch"], workdir="/testbed")
-                finished = True
-            else:
-                agent = self.build_agent()
-                messages = cfg.prompt
-                # The endpoint the agent calls lives on cfg.agent.model (the agent validates it).
-                agent_result = await agent.run(
-                    sandbox=sandbox,
-                    messages=messages,
-                    workdir="/testbed",
+                instance_id = sample.get("instance_id", "?") if isinstance(sample, dict) else "?"
+                task_config_dump = cfg.model_dump(mode="json", exclude={"metadata", "prompt"})
+                logger.info(
+                    "starting swe_rebench task "
+                    f"(instance_id={instance_id}, run_oracle_solution={cfg.run_oracle_solution})\n"
+                    f"task config: {json.dumps(task_config_dump, indent=2)}"
                 )
-                finished = agent_result.finished
+                async with self.build_sandbox() as sandbox:
+                    # Clean future history before anything reads the repo.
+                    await sandbox.exec_shell(_GIT_CLEAN_HISTORY, workdir="/testbed")
 
-            try:
-                from .reward import compute_reward
+                    if cfg.run_oracle_solution:
+                        logger.info("applying gold patch to /testbed")
+                        await sandbox.write_file("/tmp/gold_patch.patch", sample["patch"])
+                        await sandbox.exec(
+                            ["git", "apply", "--whitespace=fix", "/tmp/gold_patch.patch"],
+                            workdir="/testbed",
+                        )
+                        finished = True
+                    else:
+                        agent = self.build_agent()
+                        messages = cfg.prompt
+                        # The endpoint the agent calls lives on cfg.agent.model (the agent validates it).
+                        with timing("task.generate_s"):
+                            agent_result = await agent.run(
+                                sandbox=sandbox,
+                                messages=messages,
+                                workdir="/testbed",
+                            )
+                        finished = agent_result.finished
 
-                result = await compute_reward(sample, sandbox, eval_timeout=cfg.eval_timeout)
-            except Exception:
-                logger.exception(f"scoring failed for instance_id={instance_id}")
-                raise
+                    try:
+                        from .reward import compute_reward
 
-            logger.info(f"task done: resolved={result['resolved']}")
-            return TaskResult(
-                reward=float(result["resolved"]),
-                accuracy=float(result["resolved"]),
-                finished=finished,
-                extra_info=result,
-            )
+                        with timing("reward.s"):
+                            result = await compute_reward(sample, sandbox, eval_timeout=cfg.eval_timeout)
+                    except Exception:
+                        logger.exception(f"scoring failed for instance_id={instance_id}")
+                        raise
+
+                    logger.info(f"task done: resolved={result['resolved']}")
+                    outcome = TaskResult(
+                        reward=float(result["resolved"]),
+                        accuracy=float(result["resolved"]),
+                        finished=finished,
+                        extra_info=result,
+                    )
+            outcome.metrics = collector.metrics()
+            return outcome

--- a/uni_agent/tasks/terminal_bench/task.py
+++ b/uni_agent/tasks/terminal_bench/task.py
@@ -11,6 +11,7 @@ from pydantic import Field
 
 from uni_agent.sandbox import SandboxConfig, build_sandbox
 
+from ...metrics import task_metrics, timing
 from ..base import Task, TaskConfig, TaskResult
 from ..registry import register_task
 from .reward import install_archive, parse_json_mapping, resolve_env_mapping
@@ -106,99 +107,112 @@ class TerminalBenchTask(Task):
     config_model = TerminalBenchTaskConfig
 
     async def run(self) -> TaskResult:
-        cfg: TerminalBenchTaskConfig = self.config  # type: ignore[assignment]
-        metadata = cfg.metadata
-        instance_id = metadata["instance_id"]
-        dataset_version = metadata["dataset_version"]
-        agent_timeout = float(metadata["agent_timeout"])
-        verifier_timeout = float(metadata["verifier_timeout"])
-        environment = parse_json_mapping(metadata.get("environment_json"), field="environment_json")
-        workdir = str(environment["workdir"]) if environment.get("workdir") else None
-        sandbox_config = build_terminal_bench_sandbox_config(cfg.sandbox, metadata)
-        task_config_dump = cfg.model_dump(mode="json", exclude={"metadata", "prompt"})
-        logger.info(
-            "starting Terminal-Bench %s task (instance_id=%s, oracle=%s) "
-            "agent_timeout=%gs verifier_timeout=%gs sandbox_runtime_timeout=%gs\n"
-            "task config: %s\nsandbox config: %s",
-            dataset_version,
-            instance_id,
-            cfg.run_oracle_solution,
-            agent_timeout,
-            verifier_timeout,
-            sandbox_config.runtime_timeout,
-            json.dumps(task_config_dump, indent=2),
-            json.dumps(sandbox_config.model_dump(mode="json"), indent=2),
-        )
-
-        async with build_sandbox(sandbox_config) as sandbox:
-            prepared = await sandbox.exec_shell(
-                "mkdir -p /logs/agent /logs/verifier /logs/artifacts && "
-                "chmod 777 /logs/agent /logs/verifier /logs/artifacts"
-            )
-            if prepared.exit_code != 0:
-                raise RuntimeError(f"failed to prepare Terminal-Bench log directories: {prepared.stderr.strip()}")
-
-            if cfg.run_oracle_solution:
-                agent_info = await _run_oracle(
-                    metadata,
-                    sandbox,
-                    timeout=agent_timeout,
+        async with task_metrics() as collector:
+            with timing("task.total_s"):
+                cfg: TerminalBenchTaskConfig = self.config  # type: ignore[assignment]
+                metadata = cfg.metadata
+                instance_id = metadata["instance_id"]
+                dataset_version = metadata["dataset_version"]
+                agent_timeout = float(metadata["agent_timeout"])
+                verifier_timeout = float(metadata["verifier_timeout"])
+                environment = parse_json_mapping(metadata.get("environment_json"), field="environment_json")
+                workdir = str(environment["workdir"]) if environment.get("workdir") else None
+                sandbox_config = build_terminal_bench_sandbox_config(cfg.sandbox, metadata)
+                task_config_dump = cfg.model_dump(mode="json", exclude={"metadata", "prompt"})
+                logger.info(
+                    "starting Terminal-Bench %s task (instance_id=%s, oracle=%s) "
+                    "agent_timeout=%gs verifier_timeout=%gs sandbox_runtime_timeout=%gs\n"
+                    "task config: %s\nsandbox config: %s",
+                    dataset_version,
+                    instance_id,
+                    cfg.run_oracle_solution,
+                    agent_timeout,
+                    verifier_timeout,
+                    sandbox_config.runtime_timeout,
+                    json.dumps(task_config_dump, indent=2),
+                    json.dumps(sandbox_config.model_dump(mode="json"), indent=2),
                 )
-                finished: bool | None = agent_info["exit_code"] == 0
-            else:
-                agent = self.build_agent()
-                try:
-                    agent_result = await asyncio.wait_for(
-                        agent.run(
-                            sandbox=sandbox,
-                            messages=cfg.prompt,
-                            workdir=workdir,
-                        ),
-                        timeout=agent_timeout,
+
+                async with build_sandbox(sandbox_config) as sandbox:
+                    prepared = await sandbox.exec_shell(
+                        "mkdir -p /logs/agent /logs/verifier /logs/artifacts && "
+                        "chmod 777 /logs/agent /logs/verifier /logs/artifacts"
                     )
-                except TimeoutError:
-                    logger.warning("Terminal-Bench agent timed out for %s after %.0fs", instance_id, agent_timeout)
-                    agent_info = {
-                        "mode": "agent",
-                        "timed_out": True,
-                        "error": f"agent exceeded {agent_timeout:g}s",
-                    }
-                    finished = False
-                except Exception as exc:  # score the resulting filesystem even when the agent fails
-                    logger.exception("Terminal-Bench agent failed for %s; continuing to verifier", instance_id)
-                    agent_info = {
-                        "mode": "agent",
-                        "timed_out": False,
-                        "error": f"{type(exc).__name__}: {exc}",
-                    }
-                    finished = False
-                else:
-                    agent_info = {
-                        "mode": "agent",
-                        "timed_out": False,
-                        "error": None,
-                        **agent_result.info,
-                    }
-                    finished = agent_result.finished
+                    if prepared.exit_code != 0:
+                        raise RuntimeError(
+                            f"failed to prepare Terminal-Bench log directories: {prepared.stderr.strip()}"
+                        )
 
-            from .reward import compute_reward
+                    if cfg.run_oracle_solution:
+                        with timing("task.generate_s"):
+                            agent_info = await _run_oracle(
+                                metadata,
+                                sandbox,
+                                timeout=agent_timeout,
+                            )
+                        finished: bool | None = agent_info["exit_code"] == 0
+                    else:
+                        agent = self.build_agent()
+                        try:
+                            with timing("task.generate_s"):
+                                agent_result = await asyncio.wait_for(
+                                    agent.run(
+                                        sandbox=sandbox,
+                                        messages=cfg.prompt,
+                                        workdir=workdir,
+                                    ),
+                                    timeout=agent_timeout,
+                                )
+                        except TimeoutError:
+                            logger.warning(
+                                "Terminal-Bench agent timed out for %s after %.0fs",
+                                instance_id,
+                                agent_timeout,
+                            )
+                            agent_info = {
+                                "mode": "agent",
+                                "timed_out": True,
+                                "error": f"agent exceeded {agent_timeout:g}s",
+                            }
+                            finished = False
+                        except Exception as exc:  # score the resulting filesystem even when the agent fails
+                            logger.exception("Terminal-Bench agent failed for %s; continuing to verifier", instance_id)
+                            agent_info = {
+                                "mode": "agent",
+                                "timed_out": False,
+                                "error": f"{type(exc).__name__}: {exc}",
+                            }
+                            finished = False
+                        else:
+                            agent_info = {
+                                "mode": "agent",
+                                "timed_out": False,
+                                "error": None,
+                                **agent_result.info,
+                            }
+                            finished = agent_result.finished
 
-            result = await compute_reward(
-                metadata,
-                sandbox,
-            )
-            result["agent"] = agent_info
+                    from .reward import compute_reward
 
-        score = float(result["reward"])
-        logger.info(
-            "Terminal-Bench task done: instance_id=%s reward=%.3f resolved=%s",
-            instance_id,
-            score,
-            result["resolved"],
-        )
-        return TaskResult(
-            reward=score,
-            accuracy=score,
-            finished=finished,
-            extra_info=result,
-        )
+                    with timing("reward.s"):
+                        result = await compute_reward(
+                            metadata,
+                            sandbox,
+                        )
+                    result["agent"] = agent_info
+
+                score = float(result["reward"])
+                logger.info(
+                    "Terminal-Bench task done: instance_id=%s reward=%.3f resolved=%s",
+                    instance_id,
+                    score,
+                    result["resolved"],
+                )
+                outcome = TaskResult(
+                    reward=score,
+                    accuracy=score,
+                    finished=finished,
+                    extra_info=result,
+                )
+            outcome.metrics = collector.metrics()
+            return outcome


### PR DESCRIPTION
## Summary
- Add a uni-agent metrics collector and record Task / Gateway / sandbox timings on `TaskResult.metrics` and the last trajectory's `agent_metrics`.
- Score sessions from `TaskResult.reward` / `accuracy` instead of posting reward through the Gateway; `reward_info` is dump / `mask_unfinished_episode` metadata only.
- Drop `report_reward` from task runner and training recipes.

## Changes
- New `uni_agent/metrics` SDK (`collector`, ContextVar `task_metrics`, prompt summary, verl format).
- Framework merges Gateway + Task metrics after selection/postprocess and writes prompt `agent_metrics_summary` on the existing `{uid}` status put.
- Concrete Tasks wrap `run()` with `task.total_s` / `task.generate_s` / `reward.s`; sandbox records `env.start_s`; Gateway records request/encode/backend/decode.
- Tests for collector, Gateway session metrics, and Framework scoring.

## Out of scope
- `docs/source/design/` is left untracked on purpose.
- verl submodule still has local trainer consumption (`metric_utils`, `replay_buffer`, `trainer_base`); not pinned in this PR because it needs a matching verl change.

## Test plan
- [ ] `pytest tests/uni_agent/metrics/test_metrics.py tests/uni_agent/gateway/test_session_metrics_on_cpu.py tests/uni_agent/framework/test_generate_sequences_on_cpu.py`
- [ ] Confirm a TaskResult-backed rollout writes `rm_scores` from `TaskResult.reward` and last-traj `agent_metrics` includes Gateway + Task keys
- [ ] Confirm `docs/source/design/` is not in this PR


Made with [Cursor](https://cursor.com)