### PR TITLE
[ci, docs] fix: run docs checks for MkDocs config changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "docs/**"
       - "*.md"
+      - "mkdocs.yml"
+      - ".readthedocs.yaml"
       - ".github/workflows/docs.yml"
   push:
     branches:
@@ -12,6 +14,8 @@ on:
     paths:
       - "docs/**"
       - "*.md"
+      - "mkdocs.yml"
+      - ".readthedocs.yaml"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- trigger the docs workflow when `mkdocs.yml` changes
- trigger the same workflow when `.readthedocs.yaml` changes

## Problem
The docs CI currently runs only for changes under `docs/**`, root `*.md`, and the workflow file itself. A PR that changes `mkdocs.yml` or `.readthedocs.yaml` can therefore alter the documentation build configuration without running the repository's docs check at all.

## Changes
- add `mkdocs.yml` to the `pull_request` and `push` path filters
- add `.readthedocs.yaml` to the same path filters because it is part of the docs build contract

## Validation
- parsed the updated workflow YAML locally to confirm the new paths land under both triggers
- reviewed the existing docs build command to confirm it already consumes the MkDocs configuration file

## Compatibility
- no runtime or package changes
- only expands when the existing docs workflow runs
