### PR TITLE
[agents, examples] feat: support Claude Code on OpenYuanRong

### DIFF
--- a/examples/quickstart/training/task_config_claude_code_openyuanrong.yaml
+++ b/examples/quickstart/training/task_config_claude_code_openyuanrong.yaml
@@ -9,8 +9,8 @@
       - from: "swebench/**"
         to: "swr.cn-east-3.myhuaweicloud.com/openyuanrong/swe-bench-verified/**:v2"
     sandbox_kwargs:
-      env:
-        PATH: /opt/claude-code/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      add_to_path:
+        - /opt/claude-code/bin
       proxy_port: 38197
       mounts:
         - target: /opt/claude-code
@@ -41,8 +41,8 @@
       - from: "swerebench/sweb.eval.x86_64.**"
         to: "swr.cn-east-3.myhuaweicloud.com/openyuanrong/swe-rebench/**:latest"
     sandbox_kwargs:
-      env:
-        PATH: /opt/claude-code/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      add_to_path:
+        - /opt/claude-code/bin
       proxy_port: 38197
       mounts:
         - target: /opt/claude-code

--- a/examples/quickstart/training/task_config_claude_code_openyuanrong.yaml
+++ b/examples/quickstart/training/task_config_claude_code_openyuanrong.yaml
@@ -14,7 +14,7 @@
       proxy_port: 38197
       mounts:
         - target: /opt/claude-code
-          image_url: swr.cn-east-3.myhuaweicloud.com/openyuanrong/claude-code-tool:latest
+          image_url: swr.cn-east-3.myhuaweicloud.com/openyuanrong/claude-code-tool:20260910
   agent:
     name: claude_code
     max_turns: 200
@@ -46,7 +46,7 @@
       proxy_port: 38197
       mounts:
         - target: /opt/claude-code
-          image_url: swr.cn-east-3.myhuaweicloud.com/openyuanrong/claude-code-tool:latest
+          image_url: swr.cn-east-3.myhuaweicloud.com/openyuanrong/claude-code-tool:20260910
   agent:
     name: claude_code
     max_turns: 200

--- a/examples/quickstart/training/task_config_claude_code_openyuanrong.yaml
+++ b/examples/quickstart/training/task_config_claude_code_openyuanrong.yaml
@@ -1,0 +1,58 @@
+# Claude Code tasks running in an OpenYuanrong sandbox. The task image is
+# remapped to the internal registry and the prebuilt Claude Code sidecar is
+# mounted at /opt/claude-code. Its bin directory is placed on the sandbox PATH.
+- name: swe_bench
+  sandbox:
+    provider: openyuanrong
+    runtime_timeout: 7200
+    image_map:
+      - from: "swebench/**"
+        to: "swr.cn-east-3.myhuaweicloud.com/openyuanrong/swe-bench-verified/**:v2"
+    sandbox_kwargs:
+      env:
+        PATH: /opt/claude-code/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      proxy_port: 38197
+      mounts:
+        - target: /opt/claude-code
+          image_url: swr.cn-east-3.myhuaweicloud.com/openyuanrong/claude-code-tool:latest
+  agent:
+    name: claude_code
+    max_turns: 200
+    run_timeout: 4800
+    model:
+      temperature: 1.0
+      top_p: 1.0
+      max_total_tokens: 131072
+  prompt_template: &swe_claude_prompt
+    - role: user
+      content: |-
+        Read the following task description and resolve the issue in the current directory.
+
+        Task description:
+        {problem_statement}
+
+        Inspect the relevant code, make the minimal correct changes, and verify the result with appropriate tests or checks. Do not modify tests or commit changes. When finished, briefly summarize what changed and how it was verified.
+
+- name: swe_rebench
+  sandbox:
+    provider: openyuanrong
+    runtime_timeout: 7200
+    image_map:
+      - from: "swerebench/sweb.eval.x86_64.**"
+        to: "swr.cn-east-3.myhuaweicloud.com/openyuanrong/swe-rebench/**:latest"
+    sandbox_kwargs:
+      env:
+        PATH: /opt/claude-code/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      proxy_port: 38197
+      mounts:
+        - target: /opt/claude-code
+          image_url: swr.cn-east-3.myhuaweicloud.com/openyuanrong/claude-code-tool:latest
+  agent:
+    name: claude_code
+    max_turns: 200
+    run_timeout: 4800
+    model:
+      temperature: 1.0
+      top_p: 1.0
+      max_total_tokens: 131072
+  prompt_template: *swe_claude_prompt

--- a/tests/uni_agent/agents/test_claude_code_agent.py
+++ b/tests/uni_agent/agents/test_claude_code_agent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
 import pytest
 
@@ -52,13 +53,15 @@ def _agent() -> ClaudeCodeAgent:
 
 @pytest.mark.cpu
 @pytest.mark.level0
-def test_ensure_claude_skips_install_when_already_available():
+def test_ensure_claude_skips_install_when_already_available(caplog):
     sandbox = _FakeSandbox(probe_results=[0])
+    caplog.set_level(logging.INFO, logger="uni_agent.agents.claude_code.agent")
 
     asyncio.run(_agent()._ensure_claude(sandbox))
 
     assert len(sandbox.calls) == 1
     assert sandbox.calls[0]["script"].startswith("command -v claude")
+    assert "claude_code: found existing claude on PATH; skipping installation" in caplog.text
 
 
 @pytest.mark.cpu

--- a/tests/uni_agent/sandbox/test_openyuanrong_path.py
+++ b/tests/uni_agent/sandbox/test_openyuanrong_path.py
@@ -1,0 +1,92 @@
+"""Unit coverage for OpenYuanrong's non-destructive PATH extension."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from uni_agent.sandbox.openyuanrong import OpenyuanrongSandbox
+
+
+class _CommandResult:
+    exit_code = 0
+    stdout = ""
+    stderr = ""
+
+
+class _Commands:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    def run(self, command: str, **kwargs):
+        self.calls.append((command, kwargs))
+        return _CommandResult()
+
+
+class _Shell:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int]] = []
+        self.closed = False
+
+    async def run(self, command: str, *, timeout: int):
+        self.calls.append((command, timeout))
+        return _CommandResult()
+
+    async def kill(self) -> None:
+        self.closed = True
+
+
+class _Shells:
+    def __init__(self, shell: _Shell) -> None:
+        self.shell = shell
+        self.create_kwargs: dict | None = None
+
+    async def create(self, **kwargs):
+        self.create_kwargs = kwargs
+        return self.shell
+
+
+def _sandbox(*, add_to_path: list[str] | None = None) -> tuple[OpenyuanrongSandbox, _Commands, _Shells]:
+    commands = _Commands()
+    shells = _Shells(_Shell())
+    sandbox = OpenyuanrongSandbox(image="example:latest", add_to_path=add_to_path)
+    sandbox._sandbox = SimpleNamespace(commands=commands, shells=shells)
+    return sandbox, commands, shells
+
+
+@pytest.mark.cpu
+@pytest.mark.level0
+def test_exec_prepends_paths_without_overwriting_remote_path():
+    sandbox, commands, _ = _sandbox(add_to_path=["/opt/claude-code/bin", "/opt/other/bin"])
+
+    result = asyncio.run(sandbox._exec(["claude", "--version"], env={"TEST": "1"}))
+
+    assert result.exit_code == 0
+    assert commands.calls == [
+        (
+            'export PATH=/opt/claude-code/bin:/opt/other/bin:"${PATH:-}"; claude --version',
+            {"envs": {"TEST": "1"}, "cwd": None, "timeout": 60},
+        )
+    ]
+
+
+@pytest.mark.cpu
+@pytest.mark.level0
+def test_open_shell_uses_the_same_path_setup_as_exec():
+    sandbox, _, shells = _sandbox(add_to_path=["/opt/claude-code/bin"])
+
+    shell = asyncio.run(sandbox.open_shell(cwd="/testbed", env={"TEST": "1"}))
+
+    assert shells.create_kwargs == {"cwd": "/testbed", "envs": {"TEST": "1"}}
+    assert shells.shell.calls == [('export PATH=/opt/claude-code/bin:"${PATH:-}"', 60)]
+    assert shell is not None
+
+
+@pytest.mark.cpu
+@pytest.mark.level0
+@pytest.mark.parametrize("value", ["/opt/claude-code/bin", [""], [1]])
+def test_add_to_path_requires_non_empty_string_list(value):
+    with pytest.raises(ValueError, match="add_to_path"):
+        OpenyuanrongSandbox(image="example:latest", add_to_path=value)

--- a/uni_agent/agents/claude_code/agent.py
+++ b/uni_agent/agents/claude_code/agent.py
@@ -142,6 +142,7 @@ class ClaudeCodeAgent(Agent):
     # ----- helpers -----
     async def _ensure_claude(self, sandbox: Sandbox) -> None:
         if (await sandbox.exec_shell("command -v claude >/dev/null 2>&1")).exit_code == 0:
+            logger.info("claude_code: found existing claude on PATH; skipping installation")
             return
 
         has_npm = (await sandbox.exec_shell("command -v npm >/dev/null 2>&1")).exit_code == 0

--- a/uni_agent/sandbox/openyuanrong.py
+++ b/uni_agent/sandbox/openyuanrong.py
@@ -114,6 +114,7 @@ class OpenyuanrongSandbox(Sandbox):
         mem_limit: int = 12288,
         idle_timeout: int = 7200,
         env: dict[str, str] | None = None,
+        add_to_path: list[str] | None = None,
         cwd: str | None = None,
         name: str | None = None,
         mounts: list[Any] | None = None,
@@ -130,6 +131,11 @@ class OpenyuanrongSandbox(Sandbox):
         self.mem_limit = mem_limit
         self.idle_timeout = idle_timeout
         self.env = env
+        if add_to_path is not None and not isinstance(add_to_path, list):
+            raise ValueError("add_to_path must be a list of non-empty strings")
+        self.add_to_path = tuple(add_to_path or [])
+        if any(not isinstance(path, str) or not path for path in self.add_to_path):
+            raise ValueError("add_to_path must be a list of non-empty strings")
         self.cwd = cwd
         self.name = name
         self.mounts = mounts or []
@@ -202,8 +208,14 @@ class OpenyuanrongSandbox(Sandbox):
     ) -> _OpenyuanrongShell:
         """Return a long-lived SDK shell (cwd/env persist across ``run`` calls)."""
         sb = self._require()
-        shell = await sb.shells.create(cwd=cwd, envs=env)
-        return _OpenyuanrongShell(shell)
+        shell = _OpenyuanrongShell(await sb.shells.create(cwd=cwd, envs=env))
+        if (path_setup := self._path_setup_command()) is not None:
+            result = await shell.run(path_setup)
+            if result.exit_code != 0:
+                await shell.close()
+                detail = result.stderr or result.stdout or f"exit code {result.exit_code}"
+                raise RuntimeError(f"failed to initialize OpenYuanrong shell PATH: {detail}")
+        return shell
 
     # ----- public: data plane (files / ports) -----
     async def read_file(self, path: str) -> bytes:
@@ -250,6 +262,19 @@ class OpenyuanrongSandbox(Sandbox):
     def _is_timeout_error(self, exc: BaseException) -> bool:
         return "Command timed out after" in str(exc) or super()._is_timeout_error(exc)
 
+    def _path_setup_command(self) -> str | None:
+        """Return a shell command that prepends configured directories to PATH.
+
+        ``Sandbox(env=...)`` has ordinary environment-assignment semantics, so
+        setting its ``PATH`` key would replace the task image's original PATH.
+        Expanding ``PATH`` in the remote command/shell preserves image tools
+        such as conda while giving mounted sidecars precedence.
+        """
+        if not self.add_to_path:
+            return None
+        prefix = ":".join(self.add_to_path)
+        return f'export PATH={shlex.quote(prefix)}:"${{PATH:-}}"'
+
     async def _exec(
         self,
         argv: list[str],
@@ -261,8 +286,11 @@ class OpenyuanrongSandbox(Sandbox):
         """Run ``argv`` once via akernel ``Commands.run``."""
         sb = self._require()
         timeout_i = int(timeout) if timeout else 60
+        command = shlex.join(argv)
+        if (path_setup := self._path_setup_command()) is not None:
+            command = f"{path_setup}; {command}"
         # commands.run is a blocking SDK poll; run it off the event loop.
-        result = await asyncio.to_thread(sb.commands.run, shlex.join(argv), envs=env, cwd=workdir, timeout=timeout_i)
+        result = await asyncio.to_thread(sb.commands.run, command, envs=env, cwd=workdir, timeout=timeout_i)
         exit_code = int(result.exit_code)
         stdout = _to_str(getattr(result, "stdout", ""))
         stderr = _to_str(getattr(result, "stderr", ""))


### PR DESCRIPTION
## Summary

This change adds an opt-in OpenYuanrong configuration for the existing Claude Code agent. A prebuilt Claude Code sidecar is mounted into each SWE sandbox, and its `bin` directory is *prepended* to the task image's existing `PATH`. This lets the agent use the sidecar-provided `claude` executable without reinstalling Claude Code in every sandbox.

The implementation deliberately keeps the provider integration generic: `add_to_path` is an OpenYuanrong sandbox option rather than Claude Code logic. Any mounted executable can use the same mechanism.
<img width="1892" height="398" alt="PixPin_2026-09-10_19-35-57" src="https://github.com/user-attachments/assets/7444d21b-1112-4206-89ac-8523a3d11712" />

## Motivation

The original task images do not contain Claude Code. Installing it at rollout time is slow and depends on package/network availability. Mounting the prebuilt sidecar avoids that startup work, but the mounted binary is not usable unless `/opt/claude-code/bin` is discoverable on `PATH`.

It is important not to set `env.PATH` to a fixed value. The OpenYuanrong SDK treats sandbox environment variables as assignments, so that would replace the task image's original `PATH` and can hide tools such as Conda, Git, and system utilities. This PR therefore extends, rather than replaces, `PATH`.

## Changes

### 1. Add an OpenYuanrong Claude Code task configuration

`examples/quickstart/training/task_config_claude_code_openyuanrong.yaml` adds `swe_bench` and `swe_rebench` tasks that:

- select the `openyuanrong` sandbox provider;
- remap SWE task images to the internal OpenYuanrong registry;
- mount the prebuilt `claude-code-tool` sidecar at `/opt/claude-code`;
- request `add_to_path: [/opt/claude-code/bin]`;
- retain the existing `claude_code` agent protocol and use a 131072-token Claude Code limit for long SWE trajectories.

The task configuration contains no endpoint, token, or other private runtime credential. Those belong in the caller's Ray runtime environment.

### 2. Add provider-level `add_to_path` support

`OpenyuanrongSandbox` accepts an optional `add_to_path: list[str]` in `sandbox_kwargs`. Values are validated eagerly: the option must be a list of non-empty strings.

For a configuration such as:

```yaml
sandbox_kwargs:
  add_to_path:
    - /opt/claude-code/bin
```

an ordinary command is executed as:

```sh
export PATH=/opt/claude-code/bin:"${PATH:-}"; claude --version
```

The expansion happens in the remote task shell. Consequently the sidecar is found first, while the image's original `PATH` remains available.

The same setup is applied to both execution paths:

- one-shot `exec()` calls prefix the command with the `PATH` setup;
- persistent `open_shell()` calls initialize the shell once before returning it. If that initialization fails, the shell is closed and a clear error is raised.

This is intentionally not an `env.PATH` override and does not alter normal environment assignment semantics. Omitting `add_to_path` preserves the previous OpenYuanrong command and shell behavior exactly.

### 3. Make the no-install path observable

The existing Claude Code agent already probes `command -v claude` before installing. This PR adds the following INFO log when that probe succeeds:

```text
claude_code: found existing claude on PATH; skipping installation
```

This makes it possible to verify from rollout logs that the mounted sidecar was used and that neither the npm nor native Claude installer ran. The installation fallback remains unchanged when `claude` is genuinely unavailable.

### 4. Add focused unit coverage

The tests cover:

- multiple `add_to_path` entries being prepended without replacing the remote `PATH`;
- propagation of command environment and working-directory arguments;
- identical setup for `open_shell()` and `exec()`;
- invalid `add_to_path` values failing at sandbox construction; and
- the exact skip-install log emitted by the Claude Code agent.

## Configuration and API

`add_to_path` is provider-specific and is supplied under `sandbox.sandbox_kwargs`:

```yaml
sandbox:
  provider: openyuanrong
  sandbox_kwargs:
    mounts:
      - target: /opt/claude-code
        image_url: <internal-registry>/openyuanrong/claude-code-tool:latest
    add_to_path:
      - /opt/claude-code/bin
```

`add_to_path` must be a list of non-empty strings. It is suitable for mounted tool directories; it is not a replacement for general environment variables.

## Compatibility

- Existing OpenYuanrong configurations are unaffected unless they explicitly configure `add_to_path`.
- Existing task-image `PATH` entries are retained.
- The existing Claude Code installation fallback remains available if the mounted executable is absent or not executable.
- No runtime environment, endpoint, token propagation, or generic inference code is changed by this PR.

## Validation

Validated locally against the current PR branch:

```bash
git diff --check origin/main...mengyuyang/codex/claude-code-openyuanrong-main
python3.11 -m py_compile \
  uni_agent/sandbox/openyuanrong.py \
  tests/uni_agent/sandbox/test_openyuanrong_path.py \
  tests/uni_agent/agents/test_claude_code_agent.py
```

Both checks completed successfully. The local Windows development environment does not have the project test dependencies installed, so pytest was not executed there. In a normal project environment, the focused test command is:

```bash
python -m pytest -q \
  tests/uni_agent/sandbox/test_openyuanrong_path.py \
  tests/uni_agent/agents/test_claude_code_agent.py
```

Recommended OpenYuanrong integration verification:

1. Run a task using the new YAML and confirm `command -v claude` and `claude --version` succeed inside the sandbox.
2. Confirm rollout logs contain `found existing claude on PATH; skipping installation`.
3. Confirm the logs do not show the npm/native Claude installation path.

## Rebase note

The branch is based on `bb96eca`. The current upstream `main` additionally contains documentation-only changes after that point, with no file overlap with this PR.

## Checklist

- [x] The sidecar path is added without overwriting the task image `PATH`.
- [x] One-shot commands and persistent shells use the same path semantics.
- [x] The behavior is opt-in and validates invalid configuration early.
- [x] The agent logs when it correctly skips installation.
- [x] No credentials or private endpoint values are committed.
- [x] Diff whitespace and Python syntax checks pass.
