### PR TITLE
[sandbox, docs] feat: add pull_timeout and start_timeout to DockerSan…

### DIFF
--- a/docs/source/quickstart/launch-sandbox.md
+++ b/docs/source/quickstart/launch-sandbox.md
@@ -52,12 +52,19 @@ Uni-Agent supports multiple sandbox backends. Choose the backend that matches yo
             "pull_policy": "missing",
             # Optional arguments inserted before the image in `docker run`.
             "run_args": ["--network", "none"],
+            # Optional seconds budget for pulling the image and for starting the container.
+            "pull_timeout": 900,
+            "start_timeout": 120,
         },
     )
     ```
 
     The provider starts an ephemeral container, executes commands with `docker exec`,
     transfers files with `docker cp`, and removes the container when the sandbox exits.
+    Setting `pull_timeout` moves the pull into its own `docker pull` step so a stalled
+    registry fails with a clear error instead of eating the whole startup budget
+    (`SANDBOX_STARTUP_TIMEOUT`, 600s by default, which bounds pull and start together);
+    `start_timeout` then bounds only `docker run`. Both are unset by default.
     The default container command is `sleep infinity`; images without `sleep` can override
     `entrypoint` and `command` in `sandbox_kwargs`. Run `docker login <registry>` first when
     pulling from a private registry.

--- a/tests/uni_agent/sandbox/test_docker_sandbox.py
+++ b/tests/uni_agent/sandbox/test_docker_sandbox.py
@@ -128,6 +128,129 @@ def test_rejects_unknown_pull_policy():
 
 @pytest.mark.cpu
 @pytest.mark.level0
+@pytest.mark.parametrize("name", ["pull_timeout", "start_timeout"])
+def test_rejects_non_positive_timeouts(name: str):
+    with pytest.raises(ValueError, match=name):
+        DockerSandbox(**{name: 0})
+
+
+@pytest.mark.cpu
+@pytest.mark.level0
+def test_pull_timeout_pulls_missing_image_separately(monkeypatch):
+    sandbox = DockerSandbox(
+        image="example:local",
+        container_name="agent-test",
+        pull_timeout=900,
+        start_timeout=120,
+    )
+    calls: list[tuple[tuple[str, ...], float | None]] = []
+
+    async def fake_run(*args: str, timeout=None):
+        calls.append((args, timeout))
+        if args[:2] == ("image", "inspect"):
+            return ExecResult(exit_code=1, stdout="", stderr="No such image")
+        return _ok("container-id\n")
+
+    monkeypatch.setattr(sandbox, "_run_docker", fake_run)
+    asyncio.run(sandbox.start())
+
+    assert calls == [
+        (("image", "inspect", "example:local"), None),
+        (("pull", "example:local"), 900.0),
+        (
+            (
+                "run",
+                "--rm",
+                "-d",
+                "--name",
+                "agent-test",
+                "--pull",
+                "never",
+                "--entrypoint",
+                "sleep",
+                "example:local",
+                "infinity",
+            ),
+            120.0,
+        ),
+    ]
+    assert sandbox._container_name == "agent-test"
+
+
+@pytest.mark.cpu
+@pytest.mark.level0
+def test_pull_timeout_skips_pull_when_image_is_local(monkeypatch):
+    sandbox = DockerSandbox(image="example:local", container_name="agent-test", pull_timeout=900)
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run(*args: str, timeout=None):
+        calls.append(args)
+        return _ok("sha256:image\n" if args[:2] == ("image", "inspect") else "container-id\n")
+
+    monkeypatch.setattr(sandbox, "_run_docker", fake_run)
+    asyncio.run(sandbox.start())
+
+    assert [args[0] for args in calls] == ["image", "run"]
+
+
+@pytest.mark.cpu
+@pytest.mark.level0
+def test_pull_policy_always_pulls_without_inspecting(monkeypatch):
+    sandbox = DockerSandbox(
+        image="example:local",
+        container_name="agent-test",
+        pull_policy="always",
+        pull_timeout=900,
+    )
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run(*args: str, timeout=None):
+        calls.append(args)
+        return _ok("container-id\n")
+
+    monkeypatch.setattr(sandbox, "_run_docker", fake_run)
+    asyncio.run(sandbox.start())
+
+    assert [args[0] for args in calls] == ["pull", "run"]
+
+
+@pytest.mark.cpu
+@pytest.mark.level0
+def test_pull_timeout_reported_as_timeout_error(monkeypatch):
+    sandbox = DockerSandbox(image="example:local", pull_policy="always", pull_timeout=900)
+
+    async def fake_run(*args: str, timeout=None):
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(sandbox, "_run_docker", fake_run)
+
+    with pytest.raises(TimeoutError, match="exceeded pull_timeout=900s"):
+        asyncio.run(sandbox.start())
+    assert sandbox._container_name is None
+
+
+@pytest.mark.cpu
+@pytest.mark.level0
+def test_start_timeout_removes_partially_created_container(monkeypatch):
+    sandbox = DockerSandbox(image="example:local", container_name="agent-test", start_timeout=120)
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run(*args: str, timeout=None):
+        calls.append(args)
+        if args[0] == "run":
+            raise asyncio.TimeoutError
+        return _ok()
+
+    monkeypatch.setattr(sandbox, "_run_docker", fake_run)
+
+    with pytest.raises(TimeoutError, match="exceeded start_timeout=120s"):
+        asyncio.run(sandbox.start())
+    assert calls[-1] == ("rm", "-f", "agent-test")
+    assert sandbox._container_name is None
+
+
+@pytest.mark.cpu
+@pytest.mark.level0
 def test_exec_forwards_workdir_environment_and_argv(monkeypatch):
     sandbox = DockerSandbox(image="example:local")
     sandbox._container_name = "agent-test"

--- a/uni_agent/sandbox/docker.py
+++ b/uni_agent/sandbox/docker.py
@@ -12,6 +12,15 @@ if TYPE_CHECKING:
     from .base import SandboxConfig
 
 
+def _positive_timeout(name: str, value: float | None) -> float | None:
+    if value is None:
+        return None
+    value = float(value)
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive number of seconds, got {value!r}")
+    return value
+
+
 @register_sandbox("docker")
 class DockerSandbox(Sandbox):
     """Run an isolated sandbox from an image available to a local Docker daemon."""
@@ -24,6 +33,8 @@ class DockerSandbox(Sandbox):
         container_name: str | None = None,
         run_args: list[str] | None = None,
         pull_policy: str = "missing",
+        pull_timeout: float | None = None,
+        start_timeout: float | None = None,
         entrypoint: str = "sleep",
         command: list[str] | None = None,
     ) -> None:
@@ -34,6 +45,8 @@ class DockerSandbox(Sandbox):
         if pull_policy not in {"always", "missing", "never"}:
             raise ValueError("pull_policy must be one of: 'always', 'missing', 'never'")
         self.pull_policy = pull_policy
+        self.pull_timeout = _positive_timeout("pull_timeout", pull_timeout)
+        self.start_timeout = _positive_timeout("start_timeout", start_timeout)
         self.entrypoint = entrypoint
         self.command = list(command or ["infinity"])
         self._container_name: str | None = None
@@ -69,6 +82,21 @@ class DockerSandbox(Sandbox):
             stderr=_to_str(stderr),
         )
 
+    async def _has_image(self) -> bool:
+        return (await self._run_docker("image", "inspect", self.image)).exit_code == 0
+
+    async def _pull_image(self) -> None:
+        """Fetch the image up front so the pull is bounded by ``pull_timeout``, not by ``docker run``."""
+        try:
+            pulled = await self._run_docker("pull", self.image, timeout=self.pull_timeout)
+        except asyncio.TimeoutError as exc:
+            raise TimeoutError(
+                f"Pulling Docker image {self.image!r} exceeded pull_timeout={self.pull_timeout:g}s"
+            ) from exc
+        if pulled.exit_code != 0:
+            detail = pulled.stderr.strip() or pulled.stdout.strip()
+            raise RuntimeError(f"Failed to pull Docker image {self.image!r}: {detail}")
+
     async def start(self) -> None:
         if self._container_name is not None:
             return
@@ -79,15 +107,30 @@ class DockerSandbox(Sandbox):
                 detail = inspected.stderr.strip() or inspected.stdout.strip()
                 raise RuntimeError(f"Docker image {self.image!r} is not available locally: {detail}")
 
+        # A separate `docker pull` to time-bound the pull on its own
+        pull_policy = self.pull_policy
+        if self.pull_timeout is not None and pull_policy != "never":
+            if pull_policy in ["always", "missing"] or not await self._has_image():
+                await self._pull_image()
+            pull_policy = "never"
+
         name = self.container_name or f"uni-agent-{uuid.uuid4().hex[:12]}"
-        args = ["run", "--rm", "-d", "--name", name, "--pull", self.pull_policy]
+        args = ["run", "--rm", "-d", "--name", name, "--pull", pull_policy]
         if self.entrypoint:
             args.extend(["--entrypoint", self.entrypoint])
         args.extend(self.run_args)
         args.append(self.image)
         args.extend(self.command)
 
-        started = await self._run_docker(*args)
+        try:
+            started = await self._run_docker(*args, timeout=self.start_timeout)
+        except asyncio.TimeoutError as exc:
+            # The timed-out `docker run` may still have created the container; drop it so a
+            # retry with the same container_name does not collide.
+            await self._run_docker("rm", "-f", name, timeout=30.0)
+            raise TimeoutError(
+                f"Starting Docker sandbox from {self.image!r} exceeded start_timeout={self.start_timeout:g}s"
+            ) from exc
         if started.exit_code != 0:
             detail = started.stderr.strip() or started.stdout.strip()
             raise RuntimeError(f"Failed to start Docker sandbox from {self.image!r}: {detail}")

--- a/uni_agent/sandbox/docker.py
+++ b/uni_agent/sandbox/docker.py
@@ -110,7 +110,7 @@ class DockerSandbox(Sandbox):
         # A separate `docker pull` to time-bound the pull on its own
         pull_policy = self.pull_policy
         if self.pull_timeout is not None and pull_policy != "never":
-            if pull_policy in ["always", "missing"] or not await self._has_image():
+            if pull_policy == "always" or not await self._has_image():
                 await self._pull_image()
             pull_policy = "never"
 


### PR DESCRIPTION
## Summary

`DockerSandbox.start()` previously had no way to bound a registry pull separately from `docker run`, so a stalled pull would hang until the outer `SANDBOX_STARTUP_TIMEOUT` (600s default) killed it — with an opaque error and no clear signal of which phase failed. This PR adds two optional knobs, `pull_timeout` and `start_timeout`, that split the startup budget so each phase fails fast with a named, actionable error. Both default to `None`, preserving the previous single-`docker run` behavior.

## Changes

- **`uni_agent/sandbox/docker.py`**
  - Added `_positive_timeout()` helper; rejects `<= 0` at construction time.
  - Added `pull_timeout` and `start_timeout` kwargs to `DockerSandbox.__init__` (both default `None`).
  - Added `_has_image()` and `_pull_image()`; when `pull_timeout` is set, `start()` runs a separate `docker pull` bounded by `pull_timeout`, then `docker run --pull never` so the run no longer re-pulls.
  - `docker run` is now bounded by `start_timeout`; on timeout, the partially-created named container is removed (`docker rm -f`) so a retry with the same `container_name` does not collide, then a `TimeoutError` naming `start_timeout` is raised.
  - Pull timeouts raise `TimeoutError` naming `pull_timeout`; non-zero `docker pull` exits raise `RuntimeError` with the Docker stderr.

- **`tests/uni_agent/sandbox/test_docker_sandbox.py`**
  - `test_rejects_non_positive_timeouts` — `0`/negative rejected at construction.
  - `test_pull_timeout_pulls_missing_image_separately` — verifies `image inspect → pull(900s) → run(120s, --pull never)` argv and timeouts.
  - `test_pull_timeout_skips_pull_when_image_is_local` — image present ⇒ only `inspect → run`.
  - `test_pull_policy_always_pulls_without_inspecting` — `always` ⇒ `pull → run` (no inspect).
  - `test_pull_timeout_reported_as_timeout_error` — pull timeout raises `TimeoutError` matching `pull_timeout`.
  - `test_start_timeout_removes_partially_created_container` — run timeout raises `TimeoutError` matching `start_timeout`, and `docker rm -f <name>` is the last call with `_container_name is None`.

- **`docs/source/quickstart/launch-sandbox.md`**
  - Documented `pull_timeout` / `start_timeout` in the Docker `sandbox_kwargs` example, with a note that `pull_timeout` moves the pull into its own `docker pull` step and that both are unset by default.

## PR title

`[sandbox, docs] feat: add pull_timeout and start_timeout to DockerSandbox`

## Checklist

- [x] The PR is focused and linked to an issue or explains why no issue is needed.
  - No issue; a single focused improvement to sandbox startup reliability.
- [x] The title follows the format above and names the layer that owns the change.
  - `[sandbox, docs] feat: …` — `sandbox` owns the change, `docs` for the launch-sandbox update.
- [x] Tests cover the behavior, or the Validation section explains why they are not practical.
  - See Validation below.
- [x] User-facing API, config, and workflow changes include documentation or runnable examples.
  - `launch-sandbox.md` updated.
- [x] Compatibility impact and migration steps are documented.
  - Both knobs default to `None` ⇒ previous behavior. No migration.
- [x] Logs, fixtures, and examples contain no credentials or private data.
- [x] `pre-commit run --all-files --show-diff-on-failure` passes.
  - Run locally before requesting review (see Validation).

## Validation

```bash
pre-commit run --files uni_agent/sandbox/docker.py tests/uni_agent/sandbox/test_docker_sandbox.py docs/source/quickstart/launch-sandbox.md --show-diff-on-failure
python -m pytest tests/uni_agent/sandbox/test_docker_sandbox.py -q
```

Tests are CPU-only (`@pytest.mark.cpu`, `@pytest.mark.level0`) and mock `_run_docker`, so no Docker daemon is required. All new tests assert exact `docker` argv and timeout forwarding.

## Compatibility

**No breaking changes.** `pull_timeout` and `start_timeout` default to `None`, which reproduces the previous code path exactly: a single `docker run --pull <pull_policy>` with no per-phase timeout (still bounded externally by `SANDBOX_STARTUP_TIMEOUT`). No config migration required.

One operational note for users who set `pull_timeout` above the default `SANDBOX_STARTUP_TIMEOUT` (600s): the outer cap still wraps all of `start()`, so a pull budget larger than 600s requires raising `SANDBOX_STARTUP_TIMEOUT` as well. This is mentioned in the docs.
