### PR TITLE
[sandbox] feat: switch OpenYuanrong provider to yr_sandbox SDK

### DIFF
--- a/docs/source/quickstart/launch-sandbox.md
+++ b/docs/source/quickstart/launch-sandbox.md
@@ -149,8 +149,7 @@ Uni-Agent supports multiple sandbox backends. Choose the backend that matches yo
     Install the sandbox SDK:
 
     ```bash
-    pip install akernel_sdk
-    pip install openyuanrong_sdk
+    pip install openyuanrong-sandbox
     ```
 
     Configure the service endpoint and credentials through environment variables:
@@ -158,8 +157,8 @@ Uni-Agent supports multiple sandbox backends. Choose the backend that matches yo
     ```bash
     export OPENYUANRONG_SERVER_ADDRESS="<server-address>"
     export OPENYUANRONG_TOKEN="<token>"
-    # Optional: toggle SSL verification on the reverse tunnel (default "0").
-    export OPENYUANRONG_TUNNEL_SSL_VERIFY="0"
+    # Optional: TLS for the frontend (default "1"). Set to "0" for plain HTTP.
+    export OPENYUANRONG_TLS="1"
     ```
 
     Configure the image, lifecycle timeout, and optional resource limits, mounts, and reverse tunnel:

--- a/examples/mini_swe_agent/README.md
+++ b/examples/mini_swe_agent/README.md
@@ -177,7 +177,7 @@ rewritten through the reverse tunnel when `proxy_port` is set).
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OPENYUANRONG_TUNNEL_SSL_VERIFY` | `0` | TLS verification for the sandbox reverse tunnel |
+| `OPENYUANRONG_TLS` | `1` | TLS for the frontend control plane (`0` for plain HTTP) |
 | `SANDBOX_NAME_PREFIX` | `mini-swe-` | Prefix for created sandbox names |
 
 **Rollout / framework runner**

--- a/examples/mini_swe_agent/run_train.sh
+++ b/examples/mini_swe_agent/run_train.sh
@@ -134,7 +134,7 @@ RUNNER_ARGS=(
 # in the Task Config (task_config_mini_swe_agent.yaml), not here.
 OPENYUANRONG_SERVER_ADDRESS="${OPENYUANRONG_SERVER_ADDRESS:-}"
 OPENYUANRONG_TOKEN="${OPENYUANRONG_TOKEN:-}"
-OPENYUANRONG_TUNNEL_SSL_VERIFY="${OPENYUANRONG_TUNNEL_SSL_VERIFY:-0}"
+OPENYUANRONG_TLS="${OPENYUANRONG_TLS:-1}"
 SANDBOX_NAME_PREFIX="${SANDBOX_NAME_PREFIX:-mini-swe-}"
 
 # ── Logging & checkpointing ──────────────────────────────────────────────
@@ -156,7 +156,7 @@ RL_INSIGHT_SERVER_URL="${RL_INSIGHT_SERVER_URL:-}"
 
 export OPENYUANRONG_SERVER_ADDRESS
 export OPENYUANRONG_TOKEN
-export OPENYUANRONG_TUNNEL_SSL_VERIFY
+export OPENYUANRONG_TLS
 export SANDBOX_NAME_PREFIX
 export VERL_LOGGING_LEVEL="${VERL_LOGGING_LEVEL:-INFO}"
 export RAY_DEDUP_LOGS="${RAY_DEDUP_LOGS:-0}"
@@ -229,7 +229,7 @@ RAY_INIT_ENV_ARGS=(
     "+ray_kwargs.ray_init.runtime_env.env_vars.RL_INSIGHT_SERVER_URL=\"${RL_INSIGHT_SERVER_URL}\""
     "+ray_kwargs.ray_init.runtime_env.env_vars.OPENYUANRONG_SERVER_ADDRESS=\"${OPENYUANRONG_SERVER_ADDRESS}\""
     "+ray_kwargs.ray_init.runtime_env.env_vars.OPENYUANRONG_TOKEN=\"${OPENYUANRONG_TOKEN}\""
-    "+ray_kwargs.ray_init.runtime_env.env_vars.OPENYUANRONG_TUNNEL_SSL_VERIFY=\"${OPENYUANRONG_TUNNEL_SSL_VERIFY}\""
+    "+ray_kwargs.ray_init.runtime_env.env_vars.OPENYUANRONG_TLS=\"${OPENYUANRONG_TLS}\""
 )
 # TRANSFER_QUEUE_ENABLE is a REQUIRED key here: verl main_ppo overwrites it to
 # "1" itself when transfer_queue.enable=True. It must already exist in the

--- a/tests/uni_agent/sandbox/test_openyuanrong_reverse_tunnel.py
+++ b/tests/uni_agent/sandbox/test_openyuanrong_reverse_tunnel.py
@@ -1,0 +1,131 @@
+"""Live reverse-tunnel check through ``uni_agent.sandbox.openyuanrong``.
+
+Creates a real :class:`OpenyuanrongSandbox` (so ``start`` / ``get_tunnel_url`` /
+``exec`` / ``stop`` in ``openyuanrong.py`` all run) and probes a local HTTP
+server via the sandbox-side tunnel.
+
+CI never collects this: ``.github/workflows/ci.yml`` runs
+``pytest tests/uni_agent/ -m='cpu and level0'``. Manual run::
+
+    OPENYUANRONG_SERVER_ADDRESS=... OPENYUANRONG_TOKEN=... PYTHONPATH=. \\
+      pytest tests/uni_agent/sandbox/test_openyuanrong_reverse_tunnel.py -m level1
+"""
+
+from __future__ import annotations
+
+import asyncio
+import http.server
+import importlib.util
+import os
+import shlex
+import socket
+import threading
+import time
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import pytest
+
+_HAS_OPENYUANRONG_SANDBOX = importlib.util.find_spec("openyuanrong_sandbox") is not None
+_HAS_OPENYUANRONG_BACKEND = bool(os.getenv("OPENYUANRONG_SERVER_ADDRESS") and os.getenv("OPENYUANRONG_TOKEN"))
+
+_PROXY_PORT = 38197
+_PROBE_ATTEMPTS = 5
+_PROBE_RETRY_DELAY = 2.0
+_MARKER = f"uni-agent-openyuanrong-tunnel-{uuid.uuid4().hex[:8]}"
+
+pytestmark = [
+    pytest.mark.cpu,
+    pytest.mark.level1,
+    pytest.mark.skipif(
+        not _HAS_OPENYUANRONG_BACKEND,
+        reason="manual: set OPENYUANRONG_SERVER_ADDRESS and OPENYUANRONG_TOKEN against a live cluster",
+    ),
+    pytest.mark.skipif(not _HAS_OPENYUANRONG_SANDBOX, reason="manual: pip install openyuanrong-sandbox"),
+]
+
+
+@contextmanager
+def _local_http_server() -> Iterator[tuple[int, str]]:
+    """Serve a unique health body on an ephemeral 127.0.0.1 port (the tunnel upstream)."""
+
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - stdlib signature
+            body = _MARKER.encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+            return
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    port = int(server.server_address[1])
+    thread = threading.Thread(target=server.serve_forever, name="openyuanrong-tunnel-http", daemon=True)
+    thread.start()
+    try:
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=0.2) as sock:
+                    sock.sendall(b"GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+                    data = sock.recv(1024)
+                if b"200" in data and _MARKER.encode() in data:
+                    break
+            except OSError:
+                time.sleep(0.1)
+        else:
+            raise RuntimeError(f"local reverse-tunnel probe server did not start on port {port}")
+        yield port, _MARKER
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _fetch_cmd(url: str) -> str:
+    """Fetch ``url`` with the sandbox's Python so the image need not ship curl."""
+    script = f"import urllib.request; print(urllib.request.urlopen({url!r}, timeout=30).read().decode())"
+    return f"python3 -c {shlex.quote(script)}"
+
+
+def test_openyuanrong_reverse_tunnel_reaches_local_http_server():
+    """Drive ``OpenyuanrongSandbox`` against a live cluster and fetch through the tunnel."""
+    # Import inside the test so collection does not require ``uni_agent`` on sys.path
+    # (CI still deselects this case via ``-m='cpu and level0'``).
+    from uni_agent.sandbox.openyuanrong import OpenyuanrongSandbox
+
+    image = os.getenv("OPENYUANRONG_TEST_IMAGE", "swr.cn-north-4.myhuaweicloud.com/openyuanrong/python:3.12-slim")
+    with _local_http_server() as (local_port, marker):
+        sandbox = OpenyuanrongSandbox(
+            image=image,
+            cpu=1000,
+            memory=2048,
+            idle_timeout=600,
+            upstream=f"127.0.0.1:{local_port}",
+            proxy_port=_PROXY_PORT,
+        )
+
+        async def _run() -> None:
+            async with sandbox:
+                assert await sandbox.is_alive()
+                tunnel_url = sandbox.get_tunnel_url()
+                assert f"127.0.0.1:{_PROXY_PORT}" in tunnel_url
+
+                last_error = ""
+                for attempt in range(1, _PROBE_ATTEMPTS + 1):
+                    result = await sandbox.exec_shell(_fetch_cmd(f"{tunnel_url}/health"), timeout=60)
+                    if result.exit_code == 0 and marker in result.stdout:
+                        return
+                    last_error = (
+                        f"attempt {attempt}/{_PROBE_ATTEMPTS}: "
+                        f"exit={result.exit_code} stdout={result.stdout!r} stderr={result.stderr!r}"
+                    )
+                    if attempt < _PROBE_ATTEMPTS:
+                        await asyncio.sleep(_PROBE_RETRY_DELAY)
+                raise AssertionError(f"sandbox could not reach the local reverse-tunnel server: {last_error}")
+
+        asyncio.run(_run())

--- a/uni_agent/sandbox/openyuanrong.py
+++ b/uni_agent/sandbox/openyuanrong.py
@@ -10,7 +10,6 @@ import asyncio
 import logging
 import os
 import shlex
-import sys
 import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -23,8 +22,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_sdk_initialized = False
-
 
 def _resolve_sandbox_name() -> str | None:
     """Return ``{prefix}{random}`` when ``SANDBOX_NAME_PREFIX`` env is set."""
@@ -34,45 +31,57 @@ def _resolve_sandbox_name() -> str | None:
     return f"{prefix}{uuid.uuid4().hex[:8]}"
 
 
-def _load_sandbox_module() -> Any:
-    """Configure env and select sandbox SDK via ``sys.modules`` injection."""
-    global _sdk_initialized
-    if _sdk_initialized:
-        return sys.modules["openyuanrong_sandbox_sdk"]
+def _load_sdk() -> Any:
+    """Import ``openyuanrong_sandbox`` lazily so this provider stays importable without it."""
+    try:
+        import yr_sandbox
+    except ImportError as exc:
+        raise ImportError(
+            "the openyuanrong sandbox provider requires the openYuanrong sandbox SDK; "
+            "install it with: pip install openyuanrong-sandbox"
+        ) from exc
+    return yr_sandbox
 
+
+def _connection_config(sdk: Any) -> Any:
+    """Build an SDK ``ConnectionConfig`` from the ``OPENYUANRONG_*`` env vars.
+
+    Only overrides SDK defaults when the matching env var is set:
+
+    * ``OPENYUANRONG_TLS`` → ``use_tls`` (SDK default ``True``)
+    * ``OPENYUANRONG_GATEWAY_ADDRESS`` → ``gateway_address`` (SDK default ``None``)
+    * ``OPENYUANRONG_GATEWAY_TLS`` → ``gateway_use_tls`` (SDK default ``False``)
+    * ``OPENYUANRONG_TLS_VERIFY`` → ``verify_tls`` (SDK default ``False``)
+    * ``OPENYUANRONG_TUNNEL_SSL_VERIFY`` → ``YR_TUNNEL_SSL_VERIFY`` (tunnel
+      client default ``"1"``; process-env only, no ``ConnectionConfig`` field)
+    """
     server = os.getenv("OPENYUANRONG_SERVER_ADDRESS")
     token = os.getenv("OPENYUANRONG_TOKEN")
     if not server or not token:
         raise ValueError(
             "OPENYUANRONG_SERVER_ADDRESS and OPENYUANRONG_TOKEN environment variables must be set for sandbox"
         )
-    os.environ["TUNNEL_SSL_VERIFY"] = os.getenv("OPENYUANRONG_TUNNEL_SSL_VERIFY", "0")
-
-    if os.getenv("USE_OPENYUANRONG_SDK", "0") == "1":
-        try:
-            import openyuanrong_sandbox_sdk as mod
-        except ImportError as exc:
-            raise ImportError(
-                "USE_OPENYUANRONG_SDK=1 but openyuanrong_sandbox_sdk is not installed. "
-                "Please install openyuanrong_sandbox_sdk or set USE_OPENYUANRONG_SDK=0."
-            ) from exc
-    else:
-        os.environ["AKERNEL_SERVER_ADDRESS"] = server
-        os.environ["AKERNEL_TOKEN"] = token
-        try:
-            import akernel_sdk as mod
-        except ImportError as exc:
-            raise ImportError(
-                "USE_OPENYUANRONG_SDK=0 but the fallback SDK is not installed. "
-                "Please install it or set USE_OPENYUANRONG_SDK=1."
-            ) from exc
-    sys.modules["openyuanrong_sandbox_sdk"] = mod
-    _sdk_initialized = True
-    return mod
+    kwargs: dict[str, Any] = {"server_address": server, "token": token}
+    tls = os.getenv("OPENYUANRONG_TLS")
+    if tls:
+        kwargs["use_tls"] = tls != "0"
+    gateway_address = os.getenv("OPENYUANRONG_GATEWAY_ADDRESS")
+    if gateway_address:
+        kwargs["gateway_address"] = gateway_address
+    gateway_tls = os.getenv("OPENYUANRONG_GATEWAY_TLS")
+    if gateway_tls:
+        kwargs["gateway_use_tls"] = gateway_tls != "0"
+    tls_verify = os.getenv("OPENYUANRONG_TLS_VERIFY")
+    if tls_verify:
+        kwargs["verify_tls"] = tls_verify != "0"
+    tunnel_ssl_verify = os.getenv("OPENYUANRONG_TUNNEL_SSL_VERIFY")
+    if tunnel_ssl_verify:
+        os.environ["YR_TUNNEL_SSL_VERIFY"] = tunnel_ssl_verify
+    return sdk.ConnectionConfig(**kwargs)
 
 
 class _OpenyuanrongShell:
-    """Adapt openyuanrong SDK shell to the uni-agent sandbox shell handle.
+    """Adapt an openyuanrong_sandbox shell to the uni-agent sandbox shell handle.
 
     Converts the provider shell protocol (``shell.run`` / ``shell.kill``) into
     uni-agent's ``open_shell()`` contract: ``run`` → :class:`ExecResult`,
@@ -153,7 +162,7 @@ class OpenyuanrongSandbox(Sandbox):
     async def start(self) -> None:
         if self._sandbox is not None:
             return
-        sdk = _load_sandbox_module()
+        sdk = _load_sdk()
         sb_kwargs: dict[str, Any] = {
             "image": self.image,
             "cpu": self.cpu,
@@ -163,7 +172,7 @@ class OpenyuanrongSandbox(Sandbox):
             "idle_timeout": self.idle_timeout,
         }
         if self.mounts:
-            sb_kwargs["mounts"] = [self._coerce_mount(m, sdk.Mount) for m in self.mounts]
+            sb_kwargs["mounts"] = [self._coerce_mount(m, sdk) for m in self.mounts]
         if self.env:
             sb_kwargs["env"] = self.env
         if self.cwd:
@@ -178,6 +187,9 @@ class OpenyuanrongSandbox(Sandbox):
         if name is not None:
             sb_kwargs["name"] = name
         sb_kwargs.update(self.extra_kwargs)
+        # An explicit ``connection`` in sandbox_kwargs wins over the env-derived one.
+        if "connection" not in sb_kwargs:
+            sb_kwargs["connection"] = _connection_config(sdk)
         self._sandbox = await asyncio.to_thread(lambda: sdk.Sandbox(**sb_kwargs))
 
     async def stop(self) -> None:
@@ -253,14 +265,23 @@ class OpenyuanrongSandbox(Sandbox):
         return self._sandbox
 
     @staticmethod
-    def _coerce_mount(m: Any, MountCls: type) -> Any:
-        """Accept a ``Mount`` instance or a dict (``target`` + ``image_url``/``s3_config``)."""
+    def _coerce_mount(m: Any, sdk: Any) -> Any:
+        """Accept a ``Mount`` instance or a dict (``target`` + ``image_url``/``s3_config``).
+
+        The SDK validates types strictly, so a nested ``s3_config`` dict is
+        reified into ``S3Config`` before constructing the ``Mount``.
+        """
         if isinstance(m, dict):
-            return MountCls(**m)
+            m = dict(m)
+            if isinstance(m.get("s3_config"), dict):
+                m["s3_config"] = sdk.S3Config(**m["s3_config"])
+            return sdk.Mount(**m)
         return m
 
     def _is_timeout_error(self, exc: BaseException) -> bool:
-        return "Command timed out after" in str(exc) or super()._is_timeout_error(exc)
+        # openyuanrong_sandbox reports an expired command budget in-band ("Command timed
+        # out after ..."); server-side failures may still raise with that wording.
+        return "timed out after" in str(exc) or super()._is_timeout_error(exc)
 
     def _path_setup_command(self) -> str | None:
         """Return a shell command that prepends configured directories to PATH.
@@ -283,7 +304,7 @@ class OpenyuanrongSandbox(Sandbox):
         workdir: str | None = None,
         env: dict[str, str] | None = None,
     ) -> ExecResult:
-        """Run ``argv`` once via akernel ``Commands.run``."""
+        """Run ``argv`` once via openyuanrong_sandbox ``Commands.run``."""
         sb = self._require()
         timeout_i = int(timeout) if timeout else 60
         command = shlex.join(argv)
@@ -294,6 +315,10 @@ class OpenyuanrongSandbox(Sandbox):
         exit_code = int(result.exit_code)
         stdout = _to_str(getattr(result, "stdout", ""))
         stderr = _to_str(getattr(result, "stderr", ""))
+        # openyuanrong_sandbox surfaces command timeouts as a result (exit_code=-1), not
+        # an exception; re-raise so the shared exec() policy classifies it.
+        if exit_code == -1 and "timed out" in stderr:
+            raise TimeoutError(stderr)
         if exit_code != 0:
             raise RuntimeError(stderr or f"command exited with {exit_code}")
         return ExecResult(exit_code=0, stdout=stdout, stderr=stderr)


### PR DESCRIPTION
## Summary
- Replace the OpenYuanrong sandbox provider's `akernel_sdk` / dual-SDK shim with the `openyuanrong-sandbox` package (`yr_sandbox`), including per-sandbox `ConnectionConfig`.
- Drive TLS scheme from `OPENYUANRONG_TLS` (gateway follows unless `OPENYUANRONG_GATEWAY_TLS` is set); leave certificate verification off unless `OPENYUANRONG_TLS_VERIFY` / `OPENYUANRONG_TUNNEL_SSL_VERIFY` are set explicitly.
- Update quickstart / mini-swe-agent docs and training env forwarding; add a `level1` live reverse-tunnel test that CI does not run.

## Test plan
- [x] `pytest tests/uni_agent/sandbox/ -m='cpu and level0'` (level1 reverse-tunnel case deselected)
- [x] Manual live check with OpenYuanrong credentials:
  `OPENYUANRONG_SERVER_ADDRESS=... OPENYUANRONG_TOKEN=... PYTHONPATH=. pytest tests/uni_agent/sandbox/test_openyuanrong_reverse_tunnel.py -m level1`
- [x] Smoke a mini-swe-agent / openyuanrong training or inference path that uses reverse tunnel (`proxy_port`)


Made with [Cursor](https://cursor.com)