### PR TITLE
[examples, tasks, training] fix: align MemAgent reward and PPO settings

### DIFF
--- a/examples/mem_agent/task_config.yaml
+++ b/examples/mem_agent/task_config.yaml
@@ -9,5 +9,5 @@
     max_steps: 9
     model:
       temperature: 1.0
-      top_p: 0.7
+      # Inherit top_p from the VERL rollout configuration.
       top_k: -1

--- a/examples/mem_agent/train_mem_agent.sh
+++ b/examples/mem_agent/train_mem_agent.sh
@@ -54,7 +54,7 @@ fi
 
 PPO_MINI_BATCH_SIZE="${PPO_MINI_BATCH_SIZE:-32}"
 ROLLOUT_N="${ROLLOUT_N:-4}"
-PARAMETER_SYNC_STEP="${PARAMETER_SYNC_STEP:-2}"
+PARAMETER_SYNC_STEP="${PARAMETER_SYNC_STEP:-4}"
 NUM_WARMUP_BATCHES="${NUM_WARMUP_BATCHES:-1}"
 TRAIN_BATCH_SIZE="${TRAIN_BATCH_SIZE:-$((PARAMETER_SYNC_STEP * PPO_MINI_BATCH_SIZE))}"
 
@@ -127,8 +127,9 @@ PY
     data.prompt_key=prompt \
     data.return_raw_chat=True \
     ++data.apply_chat_template_kwargs.enable_thinking=False \
-    data.filter_overlong_prompts=False \
-    data.truncation=error \
+    data.shuffle=False \
+    data.filter_overlong_prompts=True \
+    data.truncation=center \
     data.max_prompt_length="${MAX_PROMPT_LENGTH}" \
     data.max_response_length="${MAX_RESPONSE_LENGTH}" \
     data.train_batch_size="${TRAIN_BATCH_SIZE}" \
@@ -136,14 +137,19 @@ PY
     data.custom_cls.name=HotpotQAMemAgentDataset \
     ++data.context_chunk_size="${CONTEXT_CHUNK_SIZE}" \
     algorithm.adv_estimator=grpo \
+    algorithm.norm_adv_by_std_in_grpo=False \
     algorithm.use_kl_in_reward=False \
     algorithm.rollout_correction.bypass_mode=False \
     actor_rollout_ref.model.path="${MODEL_PATH}" \
     actor_rollout_ref.model.trust_remote_code=True \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \
     actor_rollout_ref.actor.strategy=fsdp2 \
     actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.optim.lr_warmup_steps=20 \
     actor_rollout_ref.actor.use_kl_loss=True \
     actor_rollout_ref.actor.kl_loss_coef=0.001 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
     actor_rollout_ref.actor.clip_ratio_low=0.2 \
     actor_rollout_ref.actor.clip_ratio_high=0.2 \
     actor_rollout_ref.actor.use_dynamic_bsz=True \
@@ -164,7 +170,7 @@ PY
     actor_rollout_ref.rollout.max_model_len="${MAX_MODEL_LEN}" \
     actor_rollout_ref.rollout.max_num_batched_tokens="${MAX_MODEL_LEN}" \
     actor_rollout_ref.rollout.temperature=1.0 \
-    actor_rollout_ref.rollout.top_p=0.7 \
+    actor_rollout_ref.rollout.top_p=1.0 \
     actor_rollout_ref.rollout.top_k=-1 \
     actor_rollout_ref.rollout.calculate_log_probs=True \
     actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu="${PPO_MAX_TOKEN_LEN_PER_GPU}" \

--- a/examples/mem_agent/train_mem_agent.sh
+++ b/examples/mem_agent/train_mem_agent.sh
@@ -142,9 +142,10 @@ PY
     actor_rollout_ref.model.trust_remote_code=True \
     actor_rollout_ref.actor.strategy=fsdp2 \
     actor_rollout_ref.actor.optim.lr=1e-6 \
-    actor_rollout_ref.actor.use_kl_loss=False \
+    actor_rollout_ref.actor.use_kl_loss=True \
+    actor_rollout_ref.actor.kl_loss_coef=0.001 \
     actor_rollout_ref.actor.clip_ratio_low=0.2 \
-    actor_rollout_ref.actor.clip_ratio_high=0.28 \
+    actor_rollout_ref.actor.clip_ratio_high=0.2 \
     actor_rollout_ref.actor.use_dynamic_bsz=True \
     actor_rollout_ref.actor.ppo_mini_batch_size="${PPO_MINI_BATCH_SIZE}" \
     actor_rollout_ref.actor.ppo_max_token_len_per_gpu="${PPO_MAX_TOKEN_LEN_PER_GPU}" \

--- a/tests/uni_agent/tasks/test_hotpotqa_reward.py
+++ b/tests/uni_agent/tasks/test_hotpotqa_reward.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REWARD_PATH = Path(__file__).parents[3] / "uni_agent" / "tasks" / "hotpotqa" / "reward.py"
+SPEC = importlib.util.spec_from_file_location("hotpotqa_reward", REWARD_PATH)
+assert SPEC is not None and SPEC.loader is not None
+REWARD_MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(REWARD_MODULE)
+compute_score = REWARD_MODULE.compute_score
+
+
+@pytest.mark.parametrize(
+    ("solution", "ground_truths", "expected"),
+    [
+        (r"Final answer: \boxed{alpha beta}", ["alpha beta"], 1.0),
+        (r"Final answer: \boxed{alpha beta gamma}", ["alpha beta"], 0.0),
+        (r"Final answer: \boxed{Alpha Beta}", ["alphabeta"], 1.0),
+        (r"Earlier: \boxed{wrong}. Final: \boxed{alpha beta}", ["wrong"], 0.0),
+        (r"Final answer: \boxed{alpha beta}", ["wrong", "alpha beta"], 1.0),
+        ("alpha beta", ["alpha beta"], 0.0),
+    ],
+)
+def test_compute_score_matches_official_memagent_verifier(
+    solution: str,
+    ground_truths: list[str],
+    expected: float,
+) -> None:
+    """Catch replacing the official normalized exact match with partial overlap."""
+
+    assert compute_score(solution, ground_truths) == expected
+
+
+def test_compute_score_returns_zero_for_no_ground_truths() -> None:
+    """Keep the integration safe when a malformed sample has no accepted answer."""
+
+    assert compute_score(r"Final answer: \boxed{alpha beta}", []) == 0.0

--- a/uni_agent/tasks/hotpotqa/reward.py
+++ b/uni_agent/tasks/hotpotqa/reward.py
@@ -4,63 +4,58 @@ from __future__ import annotations
 
 
 def compute_score(solution: str, ground_truths: list[str]) -> float:
-    """Score the final boxed answer with the original token-level LCS metric."""
+    """Score the final boxed answer with MemAgent's normalized exact match."""
 
     solution = solution[-300:].lower()
     return max((_compute_single(solution, answer) for answer in ground_truths), default=0.0)
 
 
 def _compute_single(solution: str, ground_truth: str) -> float:
+    ground_truth = ground_truth.lower()
     try:
         boxed = last_boxed_only_string(solution)
         if boxed is None:
             return 0.0
-        return _lcs_ratio(remove_boxed(boxed), ground_truth.lower())
-    except (AssertionError, ValueError):
+        answer = remove_boxed(boxed)
+        return 1.0 if is_equiv(answer, ground_truth) else 0.0
+    except Exception:  # noqa: BLE001 - match the official MemAgent verifier
         return 0.0
 
 
-def _lcs_ratio(value: str, ground_truth: str) -> float:
-    left = value.lower().split()
-    right = ground_truth.lower().split()
-    if not left or not right:
-        return 0.0
+def is_equiv(left: str | None, right: str | None) -> bool:
+    """Compare two answers using the official MemAgent normalization."""
 
-    dp = [0] * (len(right) + 1)
-    for left_token in left:
-        previous = 0
-        for index, right_token in enumerate(right, start=1):
-            current = dp[index]
-            if left_token == right_token:
-                dp[index] = previous + 1
-            else:
-                dp[index] = max(dp[index], dp[index - 1])
-            previous = current
-    return dp[-1] / max(len(left), len(right))
+    if left is None and right is None:
+        return True
+    if left is None or right is None:
+        return False
+
+    try:
+        return strip_string(left) == strip_string(right)
+    except Exception:  # noqa: BLE001 - match the official MemAgent verifier
+        return left == right
 
 
 def remove_boxed(value: str) -> str:
-    if value.startswith("\\boxed "):
-        return value[len("\\boxed ") :]
+    if "\\boxed " in value:
+        prefix = "\\boxed "
+        assert value[: len(prefix)] == prefix
+        return value[len(prefix) :]
 
     prefix = "\\boxed{"
-    if not value.startswith(prefix) or not value.endswith("}"):
-        raise ValueError(f"Invalid boxed answer: {value!r}")
-    answer = value[len(prefix) : -1]
-    if "\\text{" in answer and "}" in answer:
-        answer = answer.split("\\text")[-1].strip(" {}")
-    return answer
+    assert value[: len(prefix)] == prefix
+    assert value[-1] == "}"
+    return value[len(prefix) : -1]
 
 
 def last_boxed_only_string(value: str) -> str | None:
+    index = value.rfind("\\boxed")
     if "\\boxed " in value:
         return "\\boxed " + value.split("\\boxed ")[-1].split("$")[0]
-
-    index = value.rfind("\\boxed")
     if index < 0:
         index = value.rfind("\\fbox")
-    if index < 0:
-        return None
+        if index < 0:
+            return None
 
     open_braces = 0
     for position in range(index, len(value)):
@@ -71,3 +66,24 @@ def last_boxed_only_string(value: str) -> str | None:
             if open_braces == 0:
                 return value[index : position + 1]
     return None
+
+
+def strip_string(value: str) -> str:
+    """Normalize strings exactly as the official MemAgent HotpotQA verifier."""
+
+    value = value.replace("\n", "")
+    value = value.replace("\\!", "")
+    value = value.replace("\\\\", "\\")
+    value = value.replace("tfrac", "frac")
+    value = value.replace("dfrac", "frac")
+    value = value.replace("\\left", "")
+    value = value.replace("\\right", "")
+    value = value.replace("^{\\circ}", "")
+    value = value.replace("^\\circ", "")
+    value = value.replace("\\$", "")
+    value = value.replace("\\%", "")
+    value = value.replace(" .", " 0.")
+    value = value.replace("{.", "{0.")
+    if not value:
+        return value
+    return value.replace(" ", "")


### PR DESCRIPTION
## Summary

Aligns the HotpotQA reward calculation and PPO training settings with the official MemAgent implementation.

The updated configuration also addresses the Qwen3-4B MemAgent training spikes reported in #175. In a follow-up rerun, the reporter confirmed that the new configuration worked without loss spikes ([result](https://github.com/verl-project/uni-agent/issues/175#issuecomment-5652807334)).

## Changes

### HotpotQA reward

- Replace token-level scoring with MemAgent's normalized exact-match verifier.
- Preserve uni-agent compatibility for empty ground-truth lists.
- Add regression tests for HotpotQA reward calculation.

### MemAgent training configuration

- Enable actor KL loss with coefficient `0.001` and explicitly use `low_var_kl`.
- Set `clip_ratio_high=0.2` to match the official MemAgent recipe.
- Disable GRPO advantage standard-deviation normalization.
- Align separate-async accumulation to a train batch size of 128 (`ppo_mini_batch_size=32`, `parameter_sync_step=4`).
- Disable data shuffling, filter overlong prompts, and use center truncation.
- Set the training rollout `top_p` to `1.0` and let the task configuration inherit VERL's rollout sampling setting.

## Verification

The issue reporter reran the recipe with the combined configuration update and reported no loss spikes. This confirms the end-to-end behavior of the updated configuration, rather than attributing the result to any single parameter in isolation.

Closes #175