### PR TITLE
[gateway] feat: support opt-in repeated-prompt rollback

### DIFF
--- a/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
+++ b/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
@@ -64,7 +64,10 @@ def test_gateway_actor_config_rejects_non_positive_prompt_length(prompt_length):
 
 @pytest.mark.cpu
 @pytest.mark.level0
-@pytest.mark.parametrize("field", ["enable_last_assistant_rollback", "enable_tool_parser_cache"])
+@pytest.mark.parametrize(
+    "field",
+    ["enable_last_assistant_rollback", "enable_repeated_prompt_rollback", "enable_tool_parser_cache"],
+)
 @pytest.mark.parametrize("value", ["true", 1, None])
 def test_gateway_actor_config_rejects_non_bool_options(field, value):
     from uni_agent.gateway.config import GatewayActorConfig
@@ -83,17 +86,31 @@ def test_gateway_actor_config_enables_last_assistant_rollback_by_default():
 
 @pytest.mark.cpu
 @pytest.mark.level0
+def test_repeated_prompt_rollback_requires_last_assistant_rollback():
+    from uni_agent.gateway.config import GatewayActorConfig
+
+    with pytest.raises(ValueError, match="requires enable_last_assistant_rollback"):
+        GatewayActorConfig(
+            tokenizer=FakeTokenizer(),
+            enable_last_assistant_rollback=False,
+            enable_repeated_prompt_rollback=True,
+        )
+
+
+@pytest.mark.cpu
+@pytest.mark.level0
 @pytest.mark.asyncio
-async def test_gateway_actor_forwards_last_assistant_rollback_to_session():
+async def test_gateway_actor_forwards_rollback_config_to_session():
     from uni_agent.gateway.config import GatewayActorConfig
     from uni_agent.gateway.gateway import _GatewayActor
 
     actor = _GatewayActor(
-        GatewayActorConfig(tokenizer=FakeTokenizer()),
+        GatewayActorConfig(tokenizer=FakeTokenizer(), enable_repeated_prompt_rollback=True),
         SequencedBackend(["A1", "A2", "FIXED"]),
     )
     actor._server_base_url = "http://test"
     await actor.create_session("rollback-enabled")
+    assert actor._sessions["rollback-enabled"]._enable_repeated_prompt_rollback is True
     prompt = [{"role": "user", "content": "run"}]
     continuation = [
         *prompt,

--- a/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
+++ b/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
@@ -45,6 +45,7 @@ def _session(
     response_length: int | None = None,
     sampling_params: dict | None = None,
     enable_last_assistant_rollback: bool = False,
+    enable_repeated_prompt_rollback: bool = False,
     processor=None,
     vision_info_extractor=None,
     tool_parser_name: str | None = None,
@@ -61,6 +62,7 @@ def _session(
         response_length=response_length,
         sampling_params=sampling_params,
         enable_last_assistant_rollback=enable_last_assistant_rollback,
+        enable_repeated_prompt_rollback=enable_repeated_prompt_rollback,
     )
 
 
@@ -773,6 +775,39 @@ async def test_multiple_chains_repeated_same_prompt_creates_siblings_and_continu
     assert decoded[-1].endswith("NEXT")
     assert trajectories[-1].response_mask[-len("NEXT") :] == [1] * len("NEXT")
     assert 0 in trajectories[-1].response_mask
+
+
+@pytest.mark.cpu
+@pytest.mark.level0
+@pytest.mark.asyncio
+async def test_repeated_prompt_can_replace_the_previous_assistant():
+    """Regenerate a rejected assistant without forking or dropping its prompt suffix."""
+    session = _session(
+        "repeated-prompt-rollback",
+        enable_last_assistant_rollback=True,
+        enable_repeated_prompt_rollback=True,
+    )
+    backend = SequencedBackend(["FIRST", "REJECTED", "REPLACEMENT"])
+    prompt = [{"role": "user", "content": "first turn"}]
+    continuation = [
+        *prompt,
+        {"role": "assistant", "content": "FIRST"},
+        {"role": "user", "content": "try the second turn"},
+    ]
+
+    await _run(session, backend, prompt)
+    await _run(session, backend, continuation)
+    await _run(session, backend, continuation)
+
+    assert session.snapshot_state()["active_chain_ids"] == [1]
+    assert session.snapshot_state()["rollback_count"] == 1
+    assert backend.calls[-1]["prompt_ids"] == backend.calls[-2]["prompt_ids"]
+    assert backend.calls[-1]["prompt_ids"][-len(session._codec.generation_prompt) :] == session._codec.generation_prompt
+    trajectories = await session.finalize()
+    decoded = _decode_response_ids(trajectories[0].response_ids)
+    assert decoded.startswith("FIRST")
+    assert decoded.endswith("REPLACEMENT")
+    assert "REJECTED" not in decoded
 
 
 @pytest.mark.cpu

--- a/uni_agent/framework/entry.py
+++ b/uni_agent/framework/entry.py
@@ -49,6 +49,7 @@ def build_gateway_manager(*, config, llm_client) -> GatewayManager:
         prompt_length=config.actor_rollout_ref.rollout.prompt_length,
         response_length=config.actor_rollout_ref.rollout.response_length,
         enable_last_assistant_rollback=af_cfg.get("enable_last_assistant_rollback", True),
+        enable_repeated_prompt_rollback=af_cfg.get("enable_repeated_prompt_rollback", False),
     )
 
     return GatewayManager(

--- a/uni_agent/gateway/config.py
+++ b/uni_agent/gateway/config.py
@@ -35,6 +35,9 @@ class GatewayActorConfig:
             The gateway enforces their sum when both values are set.
         enable_last_assistant_rollback: Whether latest-assistant rewrites may
             rollback and reuse an existing chain. Enabled by default.
+        enable_repeated_prompt_rollback: Whether a request ending at the previous
+            assistant boundary should replace that assistant instead of creating
+            an independent sibling sample. Disabled by default.
     """
 
     tokenizer: Any
@@ -49,6 +52,7 @@ class GatewayActorConfig:
     prompt_length: int | None = None
     response_length: int | None = None
     enable_last_assistant_rollback: bool = True
+    enable_repeated_prompt_rollback: bool = False
 
     def __post_init__(self) -> None:
         if type(self.enable_tool_parser_cache) is not bool:
@@ -60,6 +64,13 @@ class GatewayActorConfig:
                 "enable_last_assistant_rollback must be a bool, "
                 f"got {type(self.enable_last_assistant_rollback).__name__}"
             )
+        if type(self.enable_repeated_prompt_rollback) is not bool:
+            raise ValueError(
+                "enable_repeated_prompt_rollback must be a bool, "
+                f"got {type(self.enable_repeated_prompt_rollback).__name__}"
+            )
+        if self.enable_repeated_prompt_rollback and not self.enable_last_assistant_rollback:
+            raise ValueError("enable_repeated_prompt_rollback requires enable_last_assistant_rollback")
         if self.prompt_length is not None and self.prompt_length <= 0:
             raise ValueError(f"prompt_length must be positive when set, got {self.prompt_length}")
         if self.response_length is not None and self.response_length <= 0:

--- a/uni_agent/gateway/gateway.py
+++ b/uni_agent/gateway/gateway.py
@@ -82,6 +82,7 @@ class _GatewayActor:
         self._prompt_length = config.prompt_length
         self._response_length = config.response_length
         self._enable_last_assistant_rollback = config.enable_last_assistant_rollback
+        self._enable_repeated_prompt_rollback = config.enable_repeated_prompt_rollback
         self._sessions: dict[str, GatewaySession] = {}
         self._app = FastAPI()
         self._server_port: int | None = None
@@ -245,6 +246,7 @@ class _GatewayActor:
             response_length=self._response_length,
             sampling_params=sampling_params,
             enable_last_assistant_rollback=self._enable_last_assistant_rollback,
+            enable_repeated_prompt_rollback=self._enable_repeated_prompt_rollback,
             metadata=metadata,
         )
         return handle

--- a/uni_agent/gateway/session/session.py
+++ b/uni_agent/gateway/session/session.py
@@ -182,6 +182,7 @@ class GatewaySession:
         response_length: int | None = None,
         sampling_params: dict[str, Any] | None = None,
         enable_last_assistant_rollback: bool = True,
+        enable_repeated_prompt_rollback: bool = False,
         metadata: dict[str, Any] | None = None,
     ):
         """Create an active session bound to a handle and model codec."""
@@ -199,6 +200,7 @@ class GatewaySession:
         )
         self._sampling_params = dict(sampling_params or {})
         self._enable_last_assistant_rollback = enable_last_assistant_rollback
+        self._enable_repeated_prompt_rollback = enable_repeated_prompt_rollback
         self._metadata = dict(metadata or {})
         self._trace_identity = dict(self._metadata.get("_trace_identity") or {})
         self.active_chains: list[ChainState] = []
@@ -477,6 +479,14 @@ class GatewaySession:
                     self._trajectory_capacity is not None
                     and current_trajectory_length + len(incremental_ids) >= self._trajectory_capacity
                 )
+            elif rollback_applied and not capacity_exhausted:
+                # Repeated prompts have no incremental messages, so restore the
+                # assistant prefix removed above before regenerating the turn.
+                incremental_ids = self._codec.turn_separator + self._codec.generation_prompt
+                capacity_exhausted = (
+                    self._trajectory_capacity is not None
+                    and current_trajectory_length + len(incremental_ids) >= self._trajectory_capacity
+                )
             if not capacity_exhausted:
                 buffer.response_ids.extend(incremental_ids)
                 buffer.response_mask.extend([0] * len(incremental_ids))
@@ -554,9 +564,16 @@ class GatewaySession:
                 continue
             assistant_start = chain.last_assistant_start
             assistant_start_len = assistant_start.message_history_len
-            # A request ending exactly at the boundary is a fresh sample from
-            # the same prompt, not a rewrite of the abandoned assistant.
-            if assistant_start_len >= len(incoming_message_prefix_hashes):
+            incoming_len = len(incoming_message_prefix_hashes)
+            if assistant_start_len > incoming_len:
+                continue
+            # Repeated prompts remain independent samples unless the client
+            # explicitly opts into treating them as rejected-assistant retries.
+            if assistant_start_len == incoming_len and not (
+                self._enable_repeated_prompt_rollback
+                and self._enable_last_assistant_rollback
+                and assistant_start_len >= 1
+            ):
                 continue
             if incoming_message_prefix_hashes[assistant_start_len - 1] != assistant_start.tip_hash:
                 continue


### PR DESCRIPTION
## Summary

Agent loops may reject an unusable assistant turn and resend the preceding message history unchanged. The Gateway currently interprets a request ending exactly at the previous assistant boundary as an independent sample, so it creates a sibling chain instead of replacing the rejected turn.

This PR adds an opt-in policy for treating that request shape as a last-assistant rollback.

## Changes

- Add `enable_repeated_prompt_rollback`, disabled by default and valid only with `enable_last_assistant_rollback`.
- Allow an exact assistant-boundary match to select the existing chain when the option is enabled.
- Restore the assistant generation prefix when rollback leaves no incremental messages.
- Add regression coverage for both the unchanged default sibling behavior and the opt-in replacement behavior.

## Validation

- `PYTHONPATH=.:verl /Users/gaohongkui/repo/uni-agent/.venv/bin/pytest -q tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py tests/uni_agent/gateway/test_gateway_actor_on_cpu.py` — 118 passed.
- `uvx --from pre-commit pre-commit run --all-files --show-diff-on-failure` — ruff, ruff-format, mypy, and compileall passed.

## Compatibility

The new option defaults to `False`, so repeated prompts continue to create independent sibling samples unless a client explicitly opts into rejected-turn retry semantics. No existing API behavior changes by default.

## Prior work

Repository issue/PR searches found no existing work for repeated-prompt rollback. PR #65 concerns prefix-trie trajectory storage, and PR #164 concerns Continuous Token encoding; neither defines this retry policy.

## AI assistance

This PR was developed with AI assistance. I reviewed the implementation, diff, and validation results.
