### PR TITLE
[gateway] feat: coalesce exact in-flight retries

### DIFF
--- a/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
+++ b/tests/uni_agent/gateway/test_gateway_actor_on_cpu.py
@@ -64,7 +64,10 @@ def test_gateway_actor_config_rejects_non_positive_prompt_length(prompt_length):
 
 @pytest.mark.cpu
 @pytest.mark.level0
-@pytest.mark.parametrize("field", ["enable_last_assistant_rollback", "enable_tool_parser_cache"])
+@pytest.mark.parametrize(
+    "field",
+    ["enable_last_assistant_rollback", "enable_tool_parser_cache", "coalesce_reserved_exact_requests"],
+)
 @pytest.mark.parametrize("value", ["true", 1, None])
 def test_gateway_actor_config_rejects_non_bool_options(field, value):
     from uni_agent.gateway.config import GatewayActorConfig
@@ -79,6 +82,23 @@ def test_gateway_actor_config_enables_last_assistant_rollback_by_default():
     from uni_agent.gateway.config import GatewayActorConfig
 
     assert GatewayActorConfig(tokenizer=FakeTokenizer()).enable_last_assistant_rollback is True
+
+
+@pytest.mark.cpu
+@pytest.mark.level0
+@pytest.mark.asyncio
+async def test_gateway_actor_forwards_singleflight_to_session():
+    from uni_agent.gateway.config import GatewayActorConfig
+    from uni_agent.gateway.gateway import _GatewayActor
+
+    actor = _GatewayActor(
+        GatewayActorConfig(tokenizer=FakeTokenizer(), coalesce_reserved_exact_requests=True),
+        SequencedBackend(["A"]),
+    )
+    actor._server_base_url = "http://test"
+    await actor.create_session("singleflight-enabled")
+
+    assert actor._sessions["singleflight-enabled"]._coalesce_reserved_exact_requests is True
 
 
 @pytest.mark.cpu

--- a/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
+++ b/tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py
@@ -45,6 +45,7 @@ def _session(
     response_length: int | None = None,
     sampling_params: dict | None = None,
     enable_last_assistant_rollback: bool = False,
+    coalesce_reserved_exact_requests: bool = False,
     processor=None,
     vision_info_extractor=None,
     tool_parser_name: str | None = None,
@@ -61,6 +62,7 @@ def _session(
         response_length=response_length,
         sampling_params=sampling_params,
         enable_last_assistant_rollback=enable_last_assistant_rollback,
+        coalesce_reserved_exact_requests=coalesce_reserved_exact_requests,
     )
 
 
@@ -913,6 +915,64 @@ async def test_multiple_chains_parallel_new_siblings_reuse_session_request_id():
     assert session.snapshot_state()["active_chain_ids"] == [1, 2, 3]
     trajectories = await session.finalize()
     assert sorted(_decode_response_ids(trajectory.response_ids) for trajectory in trajectories) == ["A", "B", "C"]
+
+
+@pytest.mark.cpu
+@pytest.mark.level0
+@pytest.mark.asyncio
+async def test_exact_retry_on_reserved_chain_reuses_inflight_generation():
+    """Let an exact in-flight retry reuse the owner result without forking."""
+    session = _session("singleflight", coalesce_reserved_exact_requests=True)
+    first_messages = [{"role": "user", "content": "first turn"}]
+    await _run(session, SequencedBackend(["FIRST"]), first_messages)
+    continuation = [
+        *first_messages,
+        {"role": "assistant", "content": "FIRST"},
+        {"role": "user", "content": "continue"},
+    ]
+    backend = _ControlledParallelBackend(["SECOND"])
+
+    owner = asyncio.create_task(_run(session, backend, continuation))
+    await backend.wait_for_calls(1)
+    duplicate = asyncio.create_task(_run(session, backend, continuation))
+    await asyncio.sleep(0)
+
+    assert len(backend.calls) == 1
+    backend.release_call(0)
+    assert await owner == await duplicate
+    assert session.snapshot_state()["active_chain_ids"] == [1]
+
+
+@pytest.mark.cpu
+@pytest.mark.level0
+@pytest.mark.asyncio
+async def test_exact_retry_reuses_failure_and_allows_a_later_retry():
+    """Propagate the owner failure, then clear singleflight and reservation state."""
+    session = _session("singleflight-failure", coalesce_reserved_exact_requests=True)
+    first_messages = [{"role": "user", "content": "first turn"}]
+    await _run(session, SequencedBackend(["FIRST"]), first_messages)
+    continuation = [
+        *first_messages,
+        {"role": "assistant", "content": "FIRST"},
+        {"role": "user", "content": "continue"},
+    ]
+    backend = _ControlledParallelBackend([RuntimeError("boom")])
+
+    owner = asyncio.create_task(_run(session, backend, continuation))
+    await backend.wait_for_calls(1)
+    duplicate = asyncio.create_task(_run(session, backend, continuation))
+    await asyncio.sleep(0)
+    backend.release_call(0)
+
+    results = await asyncio.gather(owner, duplicate, return_exceptions=True)
+    assert len(backend.calls) == 1
+    assert all(isinstance(result, HTTPException) and result.status_code == 500 for result in results)
+    assert session.reserved_chain_ids == set()
+    assert session._inflight_exact_requests == {}
+
+    await _run(session, SequencedBackend(["RECOVERED"]), continuation)
+    [trajectory] = await session.finalize()
+    assert _decode_response_ids(trajectory.response_ids).endswith("RECOVERED")
 
 
 @pytest.mark.cpu

--- a/uni_agent/framework/entry.py
+++ b/uni_agent/framework/entry.py
@@ -49,6 +49,7 @@ def build_gateway_manager(*, config, llm_client) -> GatewayManager:
         prompt_length=config.actor_rollout_ref.rollout.prompt_length,
         response_length=config.actor_rollout_ref.rollout.response_length,
         enable_last_assistant_rollback=af_cfg.get("enable_last_assistant_rollback", True),
+        coalesce_reserved_exact_requests=af_cfg.get("coalesce_reserved_exact_requests", False),
     )
 
     return GatewayManager(

--- a/uni_agent/gateway/config.py
+++ b/uni_agent/gateway/config.py
@@ -35,6 +35,9 @@ class GatewayActorConfig:
             The gateway enforces their sum when both values are set.
         enable_last_assistant_rollback: Whether latest-assistant rewrites may
             rollback and reuse an existing chain. Enabled by default.
+        coalesce_reserved_exact_requests: Whether an exact duplicate of a request
+            already generating against a reserved chain should await and reuse that
+            in-flight result instead of creating a sibling sample.
     """
 
     tokenizer: Any
@@ -49,6 +52,7 @@ class GatewayActorConfig:
     prompt_length: int | None = None
     response_length: int | None = None
     enable_last_assistant_rollback: bool = True
+    coalesce_reserved_exact_requests: bool = False
 
     def __post_init__(self) -> None:
         if type(self.enable_tool_parser_cache) is not bool:
@@ -59,6 +63,11 @@ class GatewayActorConfig:
             raise ValueError(
                 "enable_last_assistant_rollback must be a bool, "
                 f"got {type(self.enable_last_assistant_rollback).__name__}"
+            )
+        if type(self.coalesce_reserved_exact_requests) is not bool:
+            raise ValueError(
+                "coalesce_reserved_exact_requests must be a bool, "
+                f"got {type(self.coalesce_reserved_exact_requests).__name__}"
             )
         if self.prompt_length is not None and self.prompt_length <= 0:
             raise ValueError(f"prompt_length must be positive when set, got {self.prompt_length}")

--- a/uni_agent/gateway/gateway.py
+++ b/uni_agent/gateway/gateway.py
@@ -82,6 +82,7 @@ class _GatewayActor:
         self._prompt_length = config.prompt_length
         self._response_length = config.response_length
         self._enable_last_assistant_rollback = config.enable_last_assistant_rollback
+        self._coalesce_reserved_exact_requests = config.coalesce_reserved_exact_requests
         self._sessions: dict[str, GatewaySession] = {}
         self._app = FastAPI()
         self._server_port: int | None = None
@@ -245,6 +246,7 @@ class _GatewayActor:
             response_length=self._response_length,
             sampling_params=sampling_params,
             enable_last_assistant_rollback=self._enable_last_assistant_rollback,
+            coalesce_reserved_exact_requests=self._coalesce_reserved_exact_requests,
             metadata=metadata,
         )
         return handle

--- a/uni_agent/gateway/session/session.py
+++ b/uni_agent/gateway/session/session.py
@@ -182,6 +182,7 @@ class GatewaySession:
         response_length: int | None = None,
         sampling_params: dict[str, Any] | None = None,
         enable_last_assistant_rollback: bool = True,
+        coalesce_reserved_exact_requests: bool = False,
         metadata: dict[str, Any] | None = None,
     ):
         """Create an active session bound to a handle and model codec."""
@@ -199,11 +200,16 @@ class GatewaySession:
         )
         self._sampling_params = dict(sampling_params or {})
         self._enable_last_assistant_rollback = enable_last_assistant_rollback
+        self._coalesce_reserved_exact_requests = coalesce_reserved_exact_requests
         self._metadata = dict(metadata or {})
         self._trace_identity = dict(self._metadata.get("_trace_identity") or {})
         self.active_chains: list[ChainState] = []
         self.materialized_chains: list[MaterializedChain] = []
         self.reserved_chain_ids: set[int] = set()
+        self._inflight_exact_requests: dict[
+            str,
+            asyncio.Future[tuple[bool, Any, int | None, int | None]],
+        ] = {}
         self._next_chain_id = 1
         self._order_seq = 0
         self._rollback_count = 0
@@ -232,6 +238,12 @@ class GatewaySession:
         # completion order. That order also determines which trajectory an optional
         # RewardLoopWorker treats as the session's final scoring input.
         reserved_chain_id: int | None = None
+        request_fingerprint = (
+            self._compute_request_fingerprint(request) if self._coalesce_reserved_exact_requests else None
+        )
+        owner_future: asyncio.Future[tuple[bool, Any, int | None, int | None]] | None = None
+        joined_future: asyncio.Future[tuple[bool, Any, int | None, int | None]] | None = None
+        encoded: EncodedData | None = None
         generation_span = start_generation_span(self._trace_identity)
         try:
             async with self.request_lock:
@@ -242,25 +254,49 @@ class GatewaySession:
                     )
                 # Prepare can touch codec and multimodal extractor state, so only
                 # backend generation runs outside the session lock.
-                encoded = await self._prepare_generation_inputs(request)
-                if encoded.capacity_exhausted:
-                    empty_msg = {"role": "assistant", "content": ""}
+                if request_fingerprint is not None:
+                    joined_future = self._inflight_exact_requests.get(request_fingerprint)
+                if joined_future is None:
+                    encoded = await self._prepare_generation_inputs(request)
+                    if encoded.capacity_exhausted:
+                        empty_msg = {"role": "assistant", "content": ""}
+                        if encoded.chain_id is not None:
+                            self._close_length_exhausted_chain(encoded)
+                        self._touch()
+                        generation_span.capacity_exhausted(
+                            prompt_tokens=len(encoded.context_ids),
+                            chain_id=encoded.chain_id,
+                        )
+                        return GenerationOutcome(
+                            assistant_msg=empty_msg,
+                            finish_reason="length",
+                            prompt_tokens=len(encoded.context_ids),
+                            completion_tokens=0,
+                        )
                     if encoded.chain_id is not None:
-                        self._close_length_exhausted_chain(encoded)
-                    self._touch()
-                    generation_span.capacity_exhausted(
-                        prompt_tokens=len(encoded.context_ids),
-                        chain_id=encoded.chain_id,
-                    )
-                    return GenerationOutcome(
-                        assistant_msg=empty_msg,
-                        finish_reason="length",
-                        prompt_tokens=len(encoded.context_ids),
-                        completion_tokens=0,
-                    )
-                if encoded.chain_id is not None:
-                    self.reserved_chain_ids.add(encoded.chain_id)
-                    reserved_chain_id = encoded.chain_id
+                        self.reserved_chain_ids.add(encoded.chain_id)
+                        reserved_chain_id = encoded.chain_id
+                        if request_fingerprint is not None:
+                            owner_future = asyncio.get_running_loop().create_future()
+                            self._inflight_exact_requests[request_fingerprint] = owner_future
+
+            if joined_future is not None:
+                succeeded, value, chain_id, turn = await asyncio.shield(joined_future)
+                if not succeeded:
+                    raise value
+                outcome = value
+                generation_span.success(
+                    prompt_tokens=outcome.prompt_tokens,
+                    completion_tokens=outcome.completion_tokens,
+                    chain_id=chain_id,
+                    turn=turn or 0,
+                    assistant_msg=outcome.assistant_msg,
+                    finish_reason=outcome.finish_reason,
+                )
+                return outcome
+
+            if encoded is None:
+                raise RuntimeError("generation input preparation did not produce a request")
 
             try:
                 output = await backend.generate(
@@ -323,6 +359,18 @@ class GatewaySession:
                     self.reserved_chain_ids.discard(reserved_chain_id)
                     reserved_chain_id = None
                 self._touch()
+                outcome = GenerationOutcome(
+                    assistant_msg=assistant_msg,
+                    finish_reason=finish_reason,
+                    prompt_tokens=len(encoded.context_ids),
+                    completion_tokens=len(response_ids),
+                )
+                if owner_future is not None and request_fingerprint is not None:
+                    self._resolve_inflight_exact_request(
+                        request_fingerprint,
+                        owner_future,
+                        (True, outcome, chain_id, self._order_seq),
+                    )
                 generation_span.success(
                     prompt_tokens=len(encoded.context_ids),
                     completion_tokens=len(response_ids),
@@ -331,13 +379,19 @@ class GatewaySession:
                     assistant_msg=assistant_msg,
                     finish_reason=finish_reason,
                 )
-                return GenerationOutcome(
-                    assistant_msg=assistant_msg,
-                    finish_reason=finish_reason,
-                    prompt_tokens=len(encoded.context_ids),
-                    completion_tokens=len(response_ids),
+                return outcome
+        except BaseException as exc:
+            if owner_future is not None and reserved_chain_id is not None:
+                # Release the chain before waking retry waiters so an immediate
+                # follow-up can select it instead of creating a sibling.
+                await asyncio.shield(self._release_chain_reservation(reserved_chain_id))
+                reserved_chain_id = None
+            if owner_future is not None and request_fingerprint is not None:
+                self._resolve_inflight_exact_request(
+                    request_fingerprint,
+                    owner_future,
+                    (False, exc, reserved_chain_id, None),
                 )
-        except Exception as exc:
             generation_span.failure(exc)
             raise
         finally:
@@ -632,6 +686,27 @@ class GatewaySession:
             ensure_ascii=False,
         ).encode("utf-8")
         return hashlib.sha256(b"uni-agent-message-v1\0" + canonical_json).hexdigest()
+
+    def _compute_request_fingerprint(self, request: InternalGenerationRequest) -> str:
+        canonical_json = json.dumps(
+            request,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        return hashlib.sha256(b"uni-agent-request-v1\0" + canonical_json).hexdigest()
+
+    def _resolve_inflight_exact_request(
+        self,
+        request_fingerprint: str,
+        future: asyncio.Future[tuple[bool, Any, int | None, int | None]],
+        result: tuple[bool, Any, int | None, int | None],
+    ) -> None:
+        if self._inflight_exact_requests.get(request_fingerprint) is not future:
+            return
+        self._inflight_exact_requests.pop(request_fingerprint, None)
+        if not future.done():
+            future.set_result(result)
 
     def _copy_trajectory_buffer(self, buffer: TrajectoryBuffer) -> TrajectoryBuffer:
         return TrajectoryBuffer(


### PR DESCRIPTION
## Summary

When a session request is retried verbatim while its matching chain is still reserved by an in-flight generation, the Gateway cannot select that chain and may start a sibling generation. This duplicates backend work and can turn a transport retry into an unintended trajectory fork.

This PR adds an opt-in singleflight policy for exact retries against reserved chains.

## Changes

- Add `coalesce_reserved_exact_requests`, disabled by default.
- Fingerprint the provider-normalized request and let exact concurrent retries await the owner generation through an `asyncio.Future`.
- Propagate owner success and failure to waiters and clear coordination state before a later retry.
- Keep concurrent first-turn requests independent because no existing chain is reserved yet.

## Validation

- `PYTHONPATH=.:verl /Users/gaohongkui/repo/uni-agent/.venv/bin/pytest -q tests/uni_agent/gateway/test_session_multiple_chains_on_cpu.py tests/uni_agent/gateway/test_gateway_actor_on_cpu.py` — 119 passed.
- `uvx --from pre-commit pre-commit run --all-files --show-diff-on-failure` — ruff, ruff-format, mypy, and compileall passed.

## Compatibility

The new option defaults to `False`, preserving independent sampling for identical concurrent requests. Clients should enable it only when exact in-flight duplicates represent transport retries.

## Prior work

Repository issue/PR searches found no existing singleflight or exact-request coalescing implementation. PR #65 concerns prefix-trie trajectory storage, and PR #164 concerns Continuous Token encoding; neither coordinates in-flight retries.

## AI assistance

This PR was developed with AI assistance. I reviewed the implementation, diff, and validation results.
