### PR TITLE
[examples, tasks] feat: add single-node agent RL training quickstart

### DIFF
--- a/examples/quickstart/training/README.md
+++ b/examples/quickstart/training/README.md
@@ -1,0 +1,131 @@
+# Single-node training pipeline smoke test
+
+`train_pipeline_smoke.sh` is the smallest end-to-end Uni-Agent training recipe.
+It is intentionally separate from task-specific recipes such as MemAgent and
+DeepEyes. The default run performs two complete
+rollout -> task reward -> FSDP2 policy-update steps with Qwen3-0.6B.
+
+The task uses the `local` provider only for lifecycle compatibility. The agent is
+given exactly one control tool, `finish(answer=...)`; it has no shell, file-edit,
+or system-command tool, so generated actions cannot execute commands on the host.
+
+## Prerequisites
+
+Use one Python environment containing editable installs of this repository and
+`verl`, plus PyTorch, vLLM, Ray, and TransferQueue. Verify it before training:
+
+```bash
+python -c 'import ray, torch, transfer_queue, uni_agent, verl, vllm; print(torch.cuda.device_count())'
+```
+
+The first run downloads `Qwen/Qwen3-0.6B` if `MODEL_PATH` is not already a
+local model directory. The tiny parquet dataset is regenerated locally on each
+default run and does not download external data. Its 16 training and 4
+validation prompts are disjoint.
+
+The actor defaults to PyTorch SDPA attention, so FlashAttention is not required
+for this smoke test. Set `ATTN_IMPLEMENTATION=flash_attention_2` only when the
+optional `flash-attn` package is already installed and compatible with PyTorch.
+The default prompt limit is 320 tokens and the model window is 512 tokens.
+The prompt includes a tool-call format example to help the small model submit
+its own answer through `finish`.
+
+## Run
+
+From the repository root:
+
+```bash
+PYTHON_BIN=/path/to/venv/bin/python \
+NUM_GPUS=1 \
+bash examples/quickstart/training/train_pipeline_smoke.sh
+```
+
+A successful run reaches `training/global_step=2`, prints task reward and
+actor loss/optimizer metrics to the console, saves the console stream to
+`logs/uni-agent-pipeline-smoke/<experiment>/run-XXXXXXXX/train.log`, and checks the required
+training signals automatically. W&B and checkpoint saving are off by default.
+Each invocation creates a fresh run directory, also when `AGENT_LOG_DIR` is set,
+so previous tool-call evidence cannot satisfy the current run's checks.
+Acceptance additionally requires at least one correct real `finish` observation
+and its saved trajectory with reward 1.0. Plain-text-only runs fail this check.
+
+The useful smoke-test signals are:
+
+- `num_failed_sessions=0` and `num_unfinished_episodes=0` in the rollout summary;
+- `critic/rewards/mean` (plus min/max) for task scoring;
+- `actor/grad_norm`, `timing_s/update_actor`, and `timing_s/update_weights` for
+  the policy update and rollout-weight synchronization.
+
+Set `VERIFY_TRAINING_SIGNALS=0` only for configuration-only commands such as
+Hydra `--cfg job`; normal smoke runs should keep verification enabled.
+
+The task gives reward `1.0` for a correct answer submitted through the real
+`finish` tool, `0.5` for a correct plain-text fallback, and `0.0` for an
+incorrect answer. This keeps correctness as the requirement while providing a
+small learning signal for tool-protocol compliance.
+
+The defaults are `ADV_ESTIMATOR=rloo` and `ROLLOUT_N=1`. In verl's single-sample
+case this is a zero-baseline REINFORCE update: the advantage is the outcome
+reward on each response token. Equal positive rewards therefore remain positive
+instead of being centered to zero. This choice targets a small pipeline check,
+not a recommendation for full training. Using multiple samples per prompt
+restores the leave-one-out baseline and can give zero advantage for equal rewards.
+Acceptance still requires a non-zero actor gradient in at least one step.
+Model correctness and tool use remain empirical checks; no prompt guarantees
+that a sampled response will succeed.
+
+The current defaults completed two training steps on both one and four RTX 3090
+GPUs (24 GB each), with other jobs sharing the devices. Both runs passed the
+automatic verifier and had non-zero gradients in both steps.
+
+| GPUs | Reward mean, steps 1 / 2 | Actor grad norm, steps 1 / 2 |
+| --- | --- | --- |
+| 1 | 0.5 / 0.5 | 70.2565 / 12.5023 |
+| 4 | 0.5625 / 0.625 | 22.0952 / 27.2137 |
+
+The four-GPU run saved 24 trajectories, including async prefetch, with 10 correct
+real `finish` calls. Both training batches included reward 1.0. The one-GPU run
+saved six trajectories; its correct `finish` call was in prefetch rather than
+the two consumed training batches. A tool JSON parsing error was logged during
+the four-GPU run; training continued and rollout summaries reported no failed
+sessions or unfinished episodes. This is pipeline validation, not a guarantee
+of reliable tool use by the small model.
+
+Two-GPU execution and Ascend NPU execution are not validated by these runs.
+The shared task config is device-independent; this launcher targets CUDA.
+
+## 1, 2, or 4 GPUs
+
+The same script scales FSDP2 and colocated rollout workers from one to four GPUs:
+
+```bash
+NUM_GPUS=1 bash examples/quickstart/training/train_pipeline_smoke.sh
+NUM_GPUS=2 bash examples/quickstart/training/train_pipeline_smoke.sh
+NUM_GPUS=4 bash examples/quickstart/training/train_pipeline_smoke.sh
+```
+
+`TRAIN_BATCH_SIZE` defaults to `2 * NUM_GPUS`, so it remains divisible by the
+FSDP world size. `ROLLOUT_TP=1` creates one small-model rollout replica per GPU.
+Set `CUDA_VISIBLE_DEVICES` before the command when only selected GPUs should be
+used.
+
+## Memory controls
+
+The defaults target 24 GB GPUs. If vLLM cannot reserve memory, reduce its share:
+
+```bash
+GPU_MEMORY_UTILIZATION=0.25 \
+bash examples/quickstart/training/train_pipeline_smoke.sh
+```
+
+If actor memory is the limit, enable FSDP CPU offload by appending Hydra
+overrides:
+
+```bash
+bash examples/quickstart/training/train_pipeline_smoke.sh \
+  actor_rollout_ref.actor.fsdp_config.param_offload=True \
+  actor_rollout_ref.actor.fsdp_config.optimizer_offload=True
+```
+
+Every variable used above can also be set with a local model/data path; run the
+script with additional Hydra overrides at the end for advanced settings.

--- a/examples/quickstart/training/task_config_pipeline_smoke.yaml
+++ b/examples/quickstart/training/task_config_pipeline_smoke.yaml
@@ -1,0 +1,19 @@
+- name: pipeline_smoke
+  # local only provides the lifecycle here. The agent receives no shell or file
+  # tools, so model output cannot execute commands on the host.
+  sandbox:
+    provider: local
+    runtime_timeout: 120
+  agent:
+    name: react
+    max_steps: 2
+    timeout_budget: 0
+    tools:
+      - name: finish
+    model:
+      temperature: 1.0
+      top_p: 1.0
+      # Keep this aligned with the launcher's default max_model_len so a
+      # second turn after a malformed tool call still has context headroom.
+      max_total_tokens: 512
+      max_tokens_per_turn: 64

--- a/examples/quickstart/training/train_pipeline_smoke.sh
+++ b/examples/quickstart/training/train_pipeline_smoke.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Minimal single-node rollout -> reward -> FSDP2 policy-update smoke test.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "${SCRIPT_DIR}/../../.." && pwd)}"
+cd "${REPO_ROOT}"
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+MODEL_PATH="${MODEL_PATH:-Qwen/Qwen3-0.6B}"
+NUM_GPUS="${NUM_GPUS:-1}"
+TOTAL_TRAINING_STEPS="${TOTAL_TRAINING_STEPS:-2}"
+TRAIN_BATCH_SIZE="${TRAIN_BATCH_SIZE:-$((NUM_GPUS * 2))}"
+PPO_MINI_BATCH_SIZE="${PPO_MINI_BATCH_SIZE:-${TRAIN_BATCH_SIZE}}"
+PPO_MICRO_BATCH_SIZE_PER_GPU="${PPO_MICRO_BATCH_SIZE_PER_GPU:-1}"
+ROLLOUT_N="${ROLLOUT_N:-1}"
+ROLLOUT_TP="${ROLLOUT_TP:-1}"
+GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.35}"
+ATTN_IMPLEMENTATION="${ATTN_IMPLEMENTATION:-sdpa}"
+ADV_ESTIMATOR="${ADV_ESTIMATOR:-rloo}"
+
+MAX_PROMPT_LENGTH="${MAX_PROMPT_LENGTH:-320}"
+MAX_RESPONSE_LENGTH="${MAX_RESPONSE_LENGTH:-192}"
+MAX_MODEL_LEN=$((MAX_PROMPT_LENGTH + MAX_RESPONSE_LENGTH))
+PPO_MAX_TOKEN_LEN_PER_GPU="${PPO_MAX_TOKEN_LEN_PER_GPU:-1024}"
+
+DATA_DIR="${DATA_DIR:-${REPO_ROOT}/data/pipeline_smoke}"
+DEFAULT_TRAIN_FILE="${DATA_DIR}/train.parquet"
+DEFAULT_VAL_FILE="${DATA_DIR}/val.parquet"
+TRAIN_FILE="${TRAIN_FILE:-${DEFAULT_TRAIN_FILE}}"
+VAL_FILE="${VAL_FILE:-${DEFAULT_VAL_FILE}}"
+TASK_CONFIG="${TASK_CONFIG:-examples/quickstart/training/task_config_pipeline_smoke.yaml}"
+PROJECT_NAME="${PROJECT_NAME:-uni-agent-pipeline-smoke}"
+EXPERIMENT_NAME="${EXPERIMENT_NAME:-qwen3-0.6b-${NUM_GPUS}gpu}"
+AGENT_LOG_DIR="${AGENT_LOG_DIR:-${REPO_ROOT}/logs/${PROJECT_NAME}/${EXPERIMENT_NAME}}"
+# Each invocation gets its own evidence directory, including custom log roots.
+mkdir -p "${AGENT_LOG_DIR}"
+AGENT_LOG_DIR="$(mktemp -d "${AGENT_LOG_DIR}/run-XXXXXXXX")"
+TRAIN_LOG_FILE="${TRAIN_LOG_FILE:-${AGENT_LOG_DIR}/train.log}"
+VERIFY_TRAINING_SIGNALS="${VERIFY_TRAINING_SIGNALS:-1}"
+
+export HYDRA_FULL_ERROR=1
+export PYTHONPATH="${REPO_ROOT}:${REPO_ROOT}/verl:${PYTHONPATH:-}"
+
+"${PYTHON_BIN}" -c 'import ray, torch, transfer_queue, uni_agent, verl, vllm'
+AVAILABLE_GPUS="$("${PYTHON_BIN}" -c 'import torch; print(torch.cuda.device_count())')"
+if ((NUM_GPUS < 1 || NUM_GPUS > AVAILABLE_GPUS)); then
+    echo "NUM_GPUS=${NUM_GPUS}, but this Python environment sees ${AVAILABLE_GPUS} GPU(s)." >&2
+    exit 1
+fi
+if ((TRAIN_BATCH_SIZE < NUM_GPUS || TRAIN_BATCH_SIZE % NUM_GPUS != 0)); then
+    echo "TRAIN_BATCH_SIZE must be at least NUM_GPUS and divisible by NUM_GPUS." >&2
+    exit 1
+fi
+if ((ROLLOUT_TP < 1 || NUM_GPUS % ROLLOUT_TP != 0)); then
+    echo "ROLLOUT_TP must be positive and divide NUM_GPUS." >&2
+    exit 1
+fi
+if [[ "${VERIFY_TRAINING_SIGNALS}" != "0" && "${VERIFY_TRAINING_SIGNALS}" != "1" ]]; then
+    echo "VERIFY_TRAINING_SIGNALS must be 0 or 1." >&2
+    exit 1
+fi
+
+if [[ "${TRAIN_FILE}" == "${DEFAULT_TRAIN_FILE}" && "${VAL_FILE}" == "${DEFAULT_VAL_FILE}" ]]; then
+    "${PYTHON_BIN}" -m uni_agent.tasks.pipeline_smoke.preprocess \
+        --output-dir "${DATA_DIR}" \
+        --train-size 16 \
+        --val-size 4
+elif [[ ! -f "${TRAIN_FILE}" || ! -f "${VAL_FILE}" ]]; then
+    echo "Custom TRAIN_FILE and VAL_FILE must both exist." >&2
+    exit 1
+fi
+mkdir -p "${AGENT_LOG_DIR}"
+mkdir -p "$(dirname "${TRAIN_LOG_FILE}")"
+
+echo "Model: ${MODEL_PATH}"
+echo "GPUs: ${NUM_GPUS}; rollout TP: ${ROLLOUT_TP}"
+echo "Training steps: ${TOTAL_TRAINING_STEPS}; train batch: ${TRAIN_BATCH_SIZE}; rollout n: ${ROLLOUT_N}"
+echo "Advantage estimator: ${ADV_ESTIMATOR}"
+echo "Task tools: finish only (no host command execution)"
+
+set +e
+"${PYTHON_BIN}" -m verl.trainer.main_ppo \
+    --config-name=ppo_trainer \
+    trainer.use_v1=True \
+    trainer.v1.trainer_mode=colocate_async \
+    trainer.v1.colocate_async.num_warmup_batches=1 \
+    transfer_queue.enable=True \
+    data.train_files="${TRAIN_FILE}" \
+    data.val_files="${VAL_FILE}" \
+    data.prompt_key=prompt \
+    data.return_raw_chat=True \
+    ++data.apply_chat_template_kwargs.enable_thinking=False \
+    data.filter_overlong_prompts=False \
+    data.truncation=error \
+    data.max_prompt_length="${MAX_PROMPT_LENGTH}" \
+    data.max_response_length="${MAX_RESPONSE_LENGTH}" \
+    data.train_batch_size="${TRAIN_BATCH_SIZE}" \
+    algorithm.adv_estimator="${ADV_ESTIMATOR}" \
+    algorithm.use_kl_in_reward=False \
+    actor_rollout_ref.model.path="${MODEL_PATH}" \
+    actor_rollout_ref.model.trust_remote_code=True \
+    ++actor_rollout_ref.model.override_config.attn_implementation="${ATTN_IMPLEMENTATION}" \
+    actor_rollout_ref.model.use_remove_padding=False \
+    actor_rollout_ref.model.enable_gradient_checkpointing=False \
+    actor_rollout_ref.actor.strategy=fsdp2 \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.use_kl_loss=False \
+    actor_rollout_ref.actor.use_dynamic_bsz=False \
+    actor_rollout_ref.actor.ppo_mini_batch_size="${PPO_MINI_BATCH_SIZE}" \
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu="${PPO_MICRO_BATCH_SIZE_PER_GPU}" \
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu="${PPO_MAX_TOKEN_LEN_PER_GPU}" \
+    actor_rollout_ref.actor.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+    actor_rollout_ref.ref.strategy=fsdp2 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu="${PPO_MICRO_BATCH_SIZE_PER_GPU}" \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.mode=async \
+    actor_rollout_ref.rollout.n="${ROLLOUT_N}" \
+    actor_rollout_ref.rollout.tensor_model_parallel_size="${ROLLOUT_TP}" \
+    actor_rollout_ref.rollout.prompt_length="${MAX_PROMPT_LENGTH}" \
+    actor_rollout_ref.rollout.response_length="${MAX_RESPONSE_LENGTH}" \
+    actor_rollout_ref.rollout.max_model_len="${MAX_MODEL_LEN}" \
+    actor_rollout_ref.rollout.max_num_batched_tokens="${MAX_MODEL_LEN}" \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu="${PPO_MICRO_BATCH_SIZE_PER_GPU}" \
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu="${PPO_MAX_TOKEN_LEN_PER_GPU}" \
+    actor_rollout_ref.rollout.temperature=1.0 \
+    actor_rollout_ref.rollout.top_p=1.0 \
+    actor_rollout_ref.rollout.top_k=-1 \
+    actor_rollout_ref.rollout.calculate_log_probs=True \
+    actor_rollout_ref.rollout.enable_chunked_prefill=True \
+    actor_rollout_ref.rollout.enforce_eager=True \
+    actor_rollout_ref.rollout.free_cache_engine=True \
+    actor_rollout_ref.rollout.gpu_memory_utilization="${GPU_MEMORY_UTILIZATION}" \
+    actor_rollout_ref.rollout.multi_turn.enable=True \
+    actor_rollout_ref.rollout.multi_turn.max_parallel_calls=1 \
+    ++actor_rollout_ref.rollout.multi_turn.format=hermes \
+    actor_rollout_ref.rollout.agent.num_workers="$((NUM_GPUS * 2))" \
+    ++actor_rollout_ref.rollout.agent.agent_loop_manager_class=uni_agent.framework.entry.AgentFrameworkRolloutAdapter \
+    ++actor_rollout_ref.rollout.custom.agent_framework.gateway_count="${NUM_GPUS}" \
+    ++actor_rollout_ref.rollout.custom.agent_framework.log_dir="${AGENT_LOG_DIR}" \
+    ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_fqn=uni_agent.framework.task_runner.run_task \
+    ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.dispatch_mode=ray_task \
+    ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.max_concurrent_sessions="$((NUM_GPUS * 4))" \
+    ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.trajectory_selection=all \
+    ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_kwargs.task_config_path="${TASK_CONFIG}" \
+    ++actor_rollout_ref.rollout.custom.agent_framework.agent_runners.task.runner_kwargs.model_name="$(basename "${MODEL_PATH}")" \
+    ++actor_rollout_ref.rollout.custom.agent_framework.use_reward_loop_worker=False \
+    ++actor_rollout_ref.rollout.custom.agent_framework.mask_unfinished_episode=True \
+    reward.reward_manager.name=dapo \
+    trainer.logger='["console"]' \
+    trainer.project_name="${PROJECT_NAME}" \
+    trainer.experiment_name="${EXPERIMENT_NAME}" \
+    trainer.nnodes=1 \
+    trainer.n_gpus_per_node="${NUM_GPUS}" \
+    trainer.val_before_train=False \
+    trainer.test_freq=-1 \
+    trainer.save_freq=-1 \
+    trainer.resume_mode=disable \
+    trainer.total_epochs=1 \
+    trainer.total_training_steps="${TOTAL_TRAINING_STEPS}" \
+    trainer.device=cuda \
+    ray_kwargs.ray_init.runtime_env.py_executable="${PYTHON_BIN}" \
+    "$@" 2>&1 | tee "${TRAIN_LOG_FILE}"
+TRAIN_PIPE_STATUS=("${PIPESTATUS[@]}")
+set -e
+
+if ((TRAIN_PIPE_STATUS[0] != 0)); then
+    exit "${TRAIN_PIPE_STATUS[0]}"
+fi
+if ((TRAIN_PIPE_STATUS[1] != 0)); then
+    echo "Failed to write training log to ${TRAIN_LOG_FILE}." >&2
+    exit "${TRAIN_PIPE_STATUS[1]}"
+fi
+if [[ "${VERIFY_TRAINING_SIGNALS}" == "1" ]]; then
+    "${PYTHON_BIN}" -m uni_agent.tasks.pipeline_smoke.verify_training \
+        --log-file "${TRAIN_LOG_FILE}" \
+        --agent-log-dir "${AGENT_LOG_DIR}" \
+        --expected-step "${TOTAL_TRAINING_STEPS}"
+fi

--- a/tests/uni_agent/tasks/test_pipeline_smoke.py
+++ b/tests/uni_agent/tasks/test_pipeline_smoke.py
@@ -1,0 +1,310 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from uni_agent.agents.base import AgentResult
+from uni_agent.tasks import TaskConfigResolver, get_task
+from uni_agent.tasks.pipeline_smoke.preprocess import build_rows
+from uni_agent.tasks.pipeline_smoke.reward import compute_reward, compute_score, normalize_answer
+from uni_agent.tasks.pipeline_smoke.task import PipelineSmokeTask, PipelineSmokeTaskConfig, extract_final_answer
+from uni_agent.tasks.pipeline_smoke.verify_training import verify_finish_evidence, verify_training_log
+
+pytestmark = [pytest.mark.cpu, pytest.mark.level0]
+
+
+def test_single_sample_rloo_keeps_equal_positive_rewards():
+    import numpy as np
+    import torch
+
+    from verl.trainer.ppo.core_algos import compute_rloo_outcome_advantage
+
+    rewards = torch.tensor([[0.0, 0.5], [0.0, 0.5]])
+    mask = torch.ones_like(rewards)
+    advantages, _ = compute_rloo_outcome_advantage(rewards, mask, np.array(["a", "b"]))
+    assert torch.equal(advantages, torch.full_like(rewards, 0.5))
+
+
+def test_finish_evidence_rejects_plain_text_and_requires_saved_reward(tmp_path):
+    session = tmp_path / "step_1" / "session-example"
+    session.mkdir(parents=True)
+    task_log = session / "task.log"
+    task_log.write_text('finish {"answer": "42"}', encoding="utf-8")
+    with pytest.raises(ValueError, match="no correct real finish"):
+        verify_finish_evidence(tmp_path)
+    task_log.write_text("pipeline_smoke: correct_finish_observed", encoding="utf-8")
+    with pytest.raises(ValueError, match="missing trajectory"):
+        verify_finish_evidence(tmp_path)
+    trajectory = session / "trajectory.json"
+    trajectory.write_text(json.dumps({"trajectories": [{"finished": True, "reward_score": 0.5}]}))
+    with pytest.raises(ValueError, match="no correct real finish"):
+        verify_finish_evidence(tmp_path)
+    trajectory.write_text(json.dumps({"trajectories": [{"finished": True, "reward_score": 1.0}]}))
+    assert verify_finish_evidence(tmp_path) == 1
+
+
+@pytest.mark.asyncio
+async def test_real_finish_tool_observation_is_scored():
+    from uni_agent.tools import Toolbox
+
+    toolbox = Toolbox.from_specs([{"name": "finish"}], sandbox=None)
+    result = await toolbox.call("finish", {"answer": "42"})
+    assert result.status == "ok"
+    transcript = [{"role": "tool", "name": "finish", "content": result.to_observation()}]
+    assert compute_reward(extract_final_answer(transcript), "42", used_finish_tool=True) == 1.0
+
+
+@pytest.mark.parametrize(
+    ("value", "normalized"),
+    [
+        ("  Quartz  ", "quartz"),
+        ("Forty   Two", "forty two"),
+        (42, "42"),
+    ],
+)
+def test_normalize_answer(value, normalized):
+    assert normalize_answer(value) == normalized
+
+
+def test_compute_score_is_deterministic_exact_match():
+    assert compute_score(" QUARTZ ", "quartz") == 1.0
+    assert compute_score("quartz stone", "quartz") == 0.0
+    assert compute_score("", "quartz") == 0.0
+
+
+def test_compute_reward_adds_finish_tool_compliance_signal():
+    assert compute_reward("quartz", "quartz", used_finish_tool=True) == 1.0
+    assert compute_reward("quartz", "quartz", used_finish_tool=False) == 0.5
+    assert compute_reward("wrong", "quartz", used_finish_tool=True) == 0.0
+
+
+def test_extract_final_answer_prefers_finish_tool():
+    transcript = [
+        {"role": "assistant", "content": "I think the answer is quartz."},
+        {"role": "tool", "name": "finish", "content": "Observation:\nquartz"},
+    ]
+    assert extract_final_answer(transcript) == "quartz"
+
+
+def test_extract_final_answer_accepts_plain_text_fallback():
+    assert extract_final_answer([{"role": "assistant", "content": "42"}]) == "42"
+    assert extract_final_answer([{"role": "assistant", "content": "17 minus 9 is 8."}]) == "8"
+    assert extract_final_answer([]) == ""
+
+
+def test_extract_final_answer_does_not_reward_a_quoted_non_answer():
+    transcript = [{"role": "assistant", "content": 'I considered "nova", but I am not giving a final answer.'}]
+    assert extract_final_answer(transcript) != "nova"
+
+
+def test_extract_final_answer_does_not_treat_comparison_as_equation_result():
+    assert extract_final_answer([{"role": "assistant", "content": "9 != 8"}]) != "8"
+    assert extract_final_answer([{"role": "assistant", "content": "x == 8"}]) != "8"
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ("17 - 9 = 8", "8"),
+        ("6 x 7 = 42\n\n<finish>\n42\n</finish>", "42"),
+        ('The word NOVA in lowercase is "nova".', "nova"),
+        ("The final answer is quartz.", "quartz"),
+        ('finish\n{"answer": "quartz"}', "quartz"),
+    ],
+)
+def test_extract_final_answer_handles_small_model_output(content, expected):
+    assert extract_final_answer([{"role": "assistant", "content": content}]) == expected
+
+
+def test_dataset_rows_are_deterministic_and_self_contained():
+    rows = build_rows(3)
+    assert rows == build_rows(3)
+    assert [row["data_source"] for row in rows] == ["pipeline_smoke"] * 3
+    task = rows[0]["extra_info"]["tools_kwargs"]["task"]
+    assert task["name"] == "pipeline_smoke"
+    assert task["expected_answer"]
+    assert rows[0]["prompt"][0]["role"] == "system"
+
+
+def test_training_and_validation_examples_do_not_overlap():
+    train_rows = build_rows(16)
+    val_rows = build_rows(4, offset=16)
+    train_prompts = {row["prompt"][-1]["content"] for row in train_rows}
+    val_prompts = {row["prompt"][-1]["content"] for row in val_rows}
+    assert train_prompts.isdisjoint(val_prompts)
+
+
+@pytest.mark.parametrize(("size", "offset"), [(21, 0), (4, 17), (1, -1)])
+def test_dataset_rejects_requests_that_repeat_bundled_examples(size, offset):
+    with pytest.raises(ValueError):
+        build_rows(size, offset=offset)
+
+
+def _training_log(
+    *,
+    grad_norms: tuple[float, float] = (2.0, 3.0),
+    failed_sessions: int = 0,
+    reward_mean: float = 0.5,
+) -> str:
+    lines = []
+    for step, grad_norm in enumerate(grad_norms, start=1):
+        lines.append(
+            "generate_sequences summary: num_input_prompts=2 num_success_sessions=4 "
+            "num_success_outputs=4 "
+            f"num_failed_sessions={failed_sessions} num_unfinished_episodes=0 num_failed_uids=0"
+        )
+        lines.append(
+            f"step:{step} - training/global_step:{step} - critic/rewards/mean:{reward_mean} "
+            f"- actor/grad_norm:{grad_norm} - timing_s/update_actor:1.0 - timing_s/update_weights:1.0"
+        )
+    return "\n".join(lines)
+
+
+def test_verify_training_log_accepts_complete_evidence():
+    summary = verify_training_log(_training_log(), expected_step=2)
+    assert summary["global_step"] == 2
+    assert summary["nonzero_grad_steps"] == 2
+
+
+def test_verify_training_log_accepts_additional_worker_summaries():
+    content = _training_log()
+    content += "\n" + content.splitlines()[0]
+    assert verify_training_log(content, expected_step=2)["rollout_summaries"] == 3
+
+
+def test_verify_training_log_rejects_zero_gradient():
+    with pytest.raises(ValueError, match="no non-zero actor gradient"):
+        verify_training_log(_training_log(grad_norms=(0.0, 0.0)), expected_step=2)
+
+
+def test_verify_training_log_rejects_failed_rollout():
+    with pytest.raises(ValueError, match="invalid num_failed_sessions"):
+        verify_training_log(_training_log(failed_sessions=1), expected_step=2)
+
+
+def test_verify_training_log_rejects_missing_success_output():
+    content = _training_log().replace("num_success_outputs=4", "num_success_outputs=3", 1)
+    with pytest.raises(ValueError, match="session/output counts do not match"):
+        verify_training_log(content, expected_step=2)
+
+
+def test_verify_training_log_rejects_all_zero_rewards():
+    with pytest.raises(ValueError, match="no positive task reward"):
+        verify_training_log(_training_log(reward_mean=0.0), expected_step=2)
+
+
+def test_verify_training_log_rejects_incomplete_step_sequence():
+    content = _training_log().replace("training/global_step:1", "training/global_step:2")
+    with pytest.raises(ValueError, match="training steps are"):
+        verify_training_log(content, expected_step=2)
+
+
+def test_verify_training_log_rejects_non_positive_update_timing():
+    content = _training_log().replace("timing_s/update_actor:1.0", "timing_s/update_actor:0.0", 1)
+    with pytest.raises(ValueError, match="non-positive actor-update timing"):
+        verify_training_log(content, expected_step=2)
+
+
+def test_task_config_exposes_finish_only():
+    config_path = Path(__file__).parents[3] / "examples" / "quickstart" / "training" / "task_config_pipeline_smoke.yaml"
+    resolver = TaskConfigResolver.from_file(str(config_path))
+    sample = build_rows(1)[0]["extra_info"]["tools_kwargs"]["task"]
+    resolved = resolver.resolve(sample)
+    assert resolved["sandbox"]["provider"] == "local"
+    assert resolved["agent"]["tools"] == [{"name": "finish"}]
+    assert resolved["agent"]["model"]["max_total_tokens"] >= 512
+    assert get_task(resolved).__class__ is PipelineSmokeTask
+
+
+class _FakeSandbox:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class _FakeAgent:
+    async def run(self, **_):
+        return AgentResult(
+            transcript=[{"role": "tool", "name": "finish", "content": "Observation:\nquartz"}],
+            info={"steps": 1, "num_tool_calls": 1},
+            finished=True,
+        )
+
+
+class _FakePlainTextAgent:
+    async def run(self, **_):
+        return AgentResult(
+            transcript=[{"role": "assistant", "content": "quartz"}],
+            info={"steps": 1, "num_tool_calls": 0},
+            finished=True,
+        )
+
+
+class _FakeRecoveredPlainTextAgent:
+    async def run(self, **_):
+        return AgentResult(
+            transcript=[
+                {"role": "tool", "name": "finish", "content": "Observation:\nInvalid action: bad arguments"},
+                {"role": "assistant", "content": "quartz"},
+            ],
+            info={"steps": 2, "num_tool_calls": 1},
+            finished=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_smoke_task_reports_reward(monkeypatch):
+    monkeypatch.setattr(PipelineSmokeTask, "build_sandbox", lambda _: _FakeSandbox())
+    monkeypatch.setattr(PipelineSmokeTask, "build_agent", lambda _: _FakeAgent())
+    task = PipelineSmokeTask(
+        PipelineSmokeTaskConfig(
+            expected_answer="quartz",
+            sandbox={"provider": "local"},
+            prompt=[{"role": "user", "content": "Return quartz."}],
+        )
+    )
+
+    result = await task.run()
+
+    assert result.reward == 1.0
+    assert result.accuracy == 1.0
+    assert result.extra_info["used_finish_tool"] is True
+
+
+@pytest.mark.asyncio
+async def test_pipeline_smoke_task_rewards_correct_plain_text_less(monkeypatch):
+    monkeypatch.setattr(PipelineSmokeTask, "build_sandbox", lambda _: _FakeSandbox())
+    monkeypatch.setattr(PipelineSmokeTask, "build_agent", lambda _: _FakePlainTextAgent())
+    task = PipelineSmokeTask(
+        PipelineSmokeTaskConfig(
+            expected_answer="quartz",
+            sandbox={"provider": "local"},
+            prompt=[{"role": "user", "content": "Return quartz."}],
+        )
+    )
+
+    result = await task.run()
+
+    assert result.reward == 0.5
+    assert result.accuracy == 1.0
+    assert result.extra_info["used_finish_tool"] is False
+
+
+@pytest.mark.asyncio
+async def test_failed_finish_attempt_does_not_earn_tool_bonus(monkeypatch):
+    monkeypatch.setattr(PipelineSmokeTask, "build_sandbox", lambda _: _FakeSandbox())
+    monkeypatch.setattr(PipelineSmokeTask, "build_agent", lambda _: _FakeRecoveredPlainTextAgent())
+    task = PipelineSmokeTask(
+        PipelineSmokeTaskConfig(
+            expected_answer="quartz",
+            sandbox={"provider": "local"},
+            prompt=[{"role": "user", "content": "Return quartz."}],
+        )
+    )
+
+    result = await task.run()
+
+    assert result.reward == 0.5
+    assert result.extra_info["used_finish_tool"] is False

--- a/uni_agent/tasks/pipeline_smoke/__init__.py
+++ b/uni_agent/tasks/pipeline_smoke/__init__.py
@@ -1,0 +1,14 @@
+"""Deterministic task used by the single-node training smoke test."""
+
+from __future__ import annotations
+
+from .reward import compute_reward, compute_score, normalize_answer
+from .task import PipelineSmokeTask, PipelineSmokeTaskConfig
+
+__all__ = [
+    "PipelineSmokeTask",
+    "PipelineSmokeTaskConfig",
+    "compute_reward",
+    "compute_score",
+    "normalize_answer",
+]

--- a/uni_agent/tasks/pipeline_smoke/preprocess.py
+++ b/uni_agent/tasks/pipeline_smoke/preprocess.py
@@ -1,0 +1,112 @@
+"""Create the tiny deterministic parquet files used by the training quickstart."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+DATA_SOURCE = "pipeline_smoke"
+
+EXAMPLES: tuple[tuple[str, str], ...] = (
+    ("Reverse the three-letter string 'lup'.", "pul"),
+    ("Return the third word in: amber cobalt maple orbit.", "maple"),
+    ("What is 17 minus 9? Return only the number.", "8"),
+    ("Convert the word 'NOVA' to lowercase.", "nova"),
+    ("Return the word between the markers: START quartz END.", "quartz"),
+    ("What is 6 multiplied by 7? Return only the number.", "42"),
+    ("Remove the first letter from 'plane'.", "lane"),
+    ("Return the last word in: red green blue.", "blue"),
+    ("What is 12 divided by 3? Return only the number.", "4"),
+    ("Return the first word in: cedar silver meadow.", "cedar"),
+    ("What is 5 plus 6? Return only the number.", "11"),
+    ("Return the middle letter of the word 'cat'.", "a"),
+    ("Reverse the three-letter string 'sun'.", "nus"),
+    ("Return the second word in: alpha beta gamma.", "beta"),
+    ("What is 20 minus 7? Return only the number.", "13"),
+    ("Convert the word 'ORBIT' to lowercase.", "orbit"),
+    ("Return the word between the markers: START willow END.", "willow"),
+    ("What is 9 multiplied by 3? Return only the number.", "27"),
+    ("Remove the first letter from 'stone'.", "tone"),
+    ("Return the last word in: square triangle circle.", "circle"),
+)
+
+SYSTEM_PROMPT = (
+    "You are completing a short deterministic training smoke-test task. "
+    "Solve it yourself, then make a real call to the finish tool with only the final answer. "
+    "Do not merely describe or imitate the tool call in plain text. "
+    "Do not run or describe shell commands. "
+    'Use the tool-call format: <tool_call>\n{"name": "finish", "arguments": {"answer": "YOUR_ANSWER"}}\n</tool_call>. '
+    "Replace YOUR_ANSWER with your solution."
+)
+
+
+def build_rows(size: int, *, offset: int = 0) -> list[dict[str, Any]]:
+    """Build deterministic task rows without downloading an external dataset."""
+    if size <= 0:
+        raise ValueError(f"size must be positive, got {size}")
+    if offset < 0:
+        raise ValueError(f"offset must be non-negative, got {offset}")
+    if offset + size > len(EXAMPLES):
+        raise ValueError(
+            f"requested examples [{offset}, {offset + size}) exceed the {len(EXAMPLES)} unique bundled examples"
+        )
+    rows: list[dict[str, Any]] = []
+    for row_index in range(size):
+        example_index = offset + row_index
+        question, expected_answer = EXAMPLES[example_index]
+        instance_id = f"pipeline-smoke-{offset + row_index:04d}"
+        prompt = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": question},
+        ]
+        rows.append(
+            {
+                "data_source": DATA_SOURCE,
+                "prompt": prompt,
+                "extra_info": {
+                    "tools_kwargs": {
+                        "task": {
+                            "name": "pipeline_smoke",
+                            "expected_answer": expected_answer,
+                            "metadata": {"instance_id": instance_id},
+                        }
+                    }
+                },
+            }
+        )
+    return rows
+
+
+def write_dataset(output_dir: str | Path, *, train_size: int, val_size: int) -> tuple[Path, Path]:
+    """Write train and validation parquet files and return their paths."""
+    from datasets import Dataset
+
+    train_rows = build_rows(train_size)
+    val_rows = build_rows(val_size, offset=train_size)
+    destination = Path(output_dir).expanduser()
+    destination.mkdir(parents=True, exist_ok=True)
+    train_path = destination / "train.parquet"
+    val_path = destination / "val.parquet"
+    Dataset.from_list(train_rows).to_parquet(train_path)
+    Dataset.from_list(val_rows).to_parquet(val_path)
+    return train_path, val_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", default="data/pipeline_smoke")
+    parser.add_argument("--train-size", type=int, default=16)
+    parser.add_argument("--val-size", type=int, default=4)
+    args = parser.parse_args()
+    train_path, val_path = write_dataset(
+        args.output_dir,
+        train_size=args.train_size,
+        val_size=args.val_size,
+    )
+    print(f"Wrote training data to {train_path}")
+    print(f"Wrote validation data to {val_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/uni_agent/tasks/pipeline_smoke/reward.py
+++ b/uni_agent/tasks/pipeline_smoke/reward.py
@@ -1,0 +1,25 @@
+"""Correctness and tool-compliance reward for the pipeline smoke task."""
+
+from __future__ import annotations
+
+
+def normalize_answer(value: object) -> str:
+    """Normalize harmless presentation differences without changing semantics."""
+    return " ".join(str(value).strip().casefold().split())
+
+
+def compute_score(answer: object, expected_answer: object) -> float:
+    """Return a deterministic binary reward for an exact normalized match."""
+    normalized_answer = normalize_answer(answer)
+    normalized_expected = normalize_answer(expected_answer)
+    if not normalized_answer or not normalized_expected:
+        return 0.0
+    return float(normalized_answer == normalized_expected)
+
+
+def compute_reward(answer: object, expected_answer: object, *, used_finish_tool: bool) -> float:
+    """Reward a correct answer, with full credit for using the control tool."""
+    accuracy = compute_score(answer, expected_answer)
+    if not accuracy:
+        return 0.0
+    return 1.0 if used_finish_tool else 0.5

--- a/uni_agent/tasks/pipeline_smoke/task.py
+++ b/uni_agent/tasks/pipeline_smoke/task.py
@@ -1,0 +1,112 @@
+"""Small text task that exercises rollout, reward reporting, and policy update."""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from pydantic import Field
+
+from ..base import Task, TaskConfig, TaskResult
+from ..registry import register_task
+from .reward import compute_reward, compute_score
+
+logger = logging.getLogger(__name__)
+
+
+class PipelineSmokeTaskConfig(TaskConfig):
+    """One deterministic prompt and its expected short answer."""
+
+    name: str = "pipeline_smoke"
+    expected_answer: str = Field(description="Exact answer after whitespace/case normalization.")
+
+
+_FINISH_TAG_RE = re.compile(r"<finish>\s*(.*?)\s*</finish>", re.IGNORECASE | re.DOTALL)
+_FINAL_LABEL_RE = re.compile(r"(?:final\s+answer|answer)\s*(?:is|:|=)\s*:?\s*([^\n]+)", re.IGNORECASE)
+_ANSWER_JSON_RE = re.compile(r"['\"]answer['\"]\s*:\s*['\"]([^'\"]+)['\"]", re.IGNORECASE)
+_EQUATION_SUFFIX_RE = re.compile(r"(?<![!<>=])=(?!=)\s*['\"]?([^'\"\n,;!?=]+)['\"]?[.,;!?]*\s*$")
+_IS_SUFFIX_RE = re.compile(r"\bis\s+['\"]?([^'\"\n.,:;!?]+)['\"]?[.,;!?]*\s*$", re.IGNORECASE)
+_OBSERVATION_PREFIX_RE = re.compile(r"^Observation:[ \t]*(?:\r?\n)?", re.IGNORECASE)
+
+
+def _clean_candidate(value: str) -> str:
+    return value.strip().strip("`*_ ").strip(".,:;!? ").strip("'\"").strip()
+
+
+def _extract_answer_from_text(content: str) -> str:
+    """Extract common concise-answer forms emitted by small chat models."""
+    tagged = _FINISH_TAG_RE.search(content)
+    if tagged:
+        return _clean_candidate(tagged.group(1))
+
+    json_answer = _ANSWER_JSON_RE.search(content)
+    if json_answer:
+        return _clean_candidate(json_answer.group(1))
+
+    labelled = _FINAL_LABEL_RE.search(content)
+    if labelled:
+        return _clean_candidate(labelled.group(1))
+
+    lines = [line.strip() for line in content.splitlines() if line.strip()]
+    for line in reversed(lines):
+        equation_suffix = _EQUATION_SUFFIX_RE.search(line)
+        if equation_suffix:
+            return _clean_candidate(equation_suffix.group(1))
+        is_suffix = _IS_SUFFIX_RE.search(line)
+        if is_suffix:
+            return _clean_candidate(is_suffix.group(1))
+    return _clean_candidate(lines[-1]) if lines else ""
+
+
+def _extract_final_answer_and_source(transcript: Sequence[Mapping[str, Any]]) -> tuple[str, bool]:
+    """Return the latest answer and whether it came from a finish observation."""
+    for message in reversed(transcript):
+        if message.get("role") == "tool" and message.get("name") == "finish":
+            observation = _OBSERVATION_PREFIX_RE.sub("", str(message.get("content", "")), count=1)
+            return _clean_candidate(observation), True
+        if message.get("role") == "assistant" and message.get("content"):
+            return _extract_answer_from_text(str(message["content"])), False
+    return "", False
+
+
+def extract_final_answer(transcript: Sequence[Mapping[str, Any]]) -> str:
+    """Read the latest finish observation or conservative plain-text answer."""
+    return _extract_final_answer_and_source(transcript)[0]
+
+
+@register_task("pipeline_smoke")
+class PipelineSmokeTask(Task):
+    """Run a tool-safe ReAct episode and score its final text answer."""
+
+    config_model = PipelineSmokeTaskConfig
+
+    async def run(self) -> TaskResult:
+        cfg: PipelineSmokeTaskConfig = self.config  # type: ignore[assignment]
+        async with self.build_sandbox() as sandbox:
+            agent = self.build_agent()
+            agent_result = await agent.run(
+                sandbox=sandbox,
+                messages=cfg.prompt,
+                workdir=None,
+            )
+
+        answer, used_finish_tool = _extract_final_answer_and_source(agent_result.transcript)
+        accuracy = compute_score(answer, cfg.expected_answer)
+        reward = compute_reward(answer, cfg.expected_answer, used_finish_tool=used_finish_tool)
+        if used_finish_tool and accuracy == 1.0 and agent_result.finished is True:
+            logger.info("pipeline_smoke: correct_finish_observed")
+        return TaskResult(
+            reward=reward,
+            accuracy=accuracy,
+            finished=agent_result.finished,
+            extra_info={
+                "answer": answer,
+                "expected_answer": cfg.expected_answer,
+                "exact_match": bool(accuracy),
+                "used_finish_tool": used_finish_tool,
+                "steps": agent_result.info.get("steps", 0),
+                "tool_calls": agent_result.info.get("num_tool_calls", 0),
+            },
+        )

--- a/uni_agent/tasks/pipeline_smoke/verify_training.py
+++ b/uni_agent/tasks/pipeline_smoke/verify_training.py
@@ -1,0 +1,126 @@
+"""Validate that a pipeline-smoke training log contains real RL update signals."""
+
+from __future__ import annotations
+
+import argparse
+import math
+import re
+from pathlib import Path
+
+_FLOAT = r"[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?"
+
+
+def _float_values(pattern: str, content: str) -> list[float]:
+    return [float(value) for value in re.findall(pattern, content)]
+
+
+def verify_training_log(content: str, *, expected_step: int) -> dict[str, int | float]:
+    """Raise ``ValueError`` unless the log proves rollout, reward, and update."""
+    if expected_step < 1:
+        raise ValueError("expected_step must be positive")
+
+    problems: list[str] = []
+    summaries = [line for line in content.splitlines() if "generate_sequences summary:" in line]
+    # Workers emit summaries independently; async prefetch and multiple GPUs
+    # do not have a one-summary-per-training-step relationship.
+    if not summaries:
+        problems.append("missing rollout summary")
+    for line in summaries:
+        input_match = re.search(r"num_input_prompts=(\d+)", line)
+        success_match = re.search(r"num_success_sessions=(\d+)", line)
+        output_match = re.search(r"num_success_outputs=(\d+)", line)
+        if input_match is None or int(input_match.group(1)) == 0:
+            problems.append("rollout summary has no input prompts")
+        if success_match is None or int(success_match.group(1)) == 0:
+            problems.append("rollout summary has no successful sessions")
+        if success_match is None or output_match is None or int(output_match.group(1)) != int(success_match.group(1)):
+            problems.append("rollout summary success session/output counts do not match")
+        for field in ("num_failed_sessions", "num_unfinished_episodes", "num_failed_uids"):
+            match = re.search(rf"{field}=(\d+)", line)
+            if match is None or int(match.group(1)) != 0:
+                problems.append(f"rollout summary has invalid {field}")
+
+    steps = [int(value) for value in re.findall(r"training/global_step:(\d+)", content)]
+    expected_steps = list(range(1, expected_step + 1))
+    if steps != expected_steps:
+        problems.append(f"training steps are {steps}, expected {expected_steps}")
+
+    rewards = _float_values(rf"critic/rewards/mean:({_FLOAT})", content)
+    if len(rewards) != expected_step or not all(math.isfinite(value) for value in rewards):
+        problems.append("missing or non-finite reward metrics")
+    elif not any(value > 0 for value in rewards):
+        problems.append("no positive task reward")
+
+    grad_norms = _float_values(rf"actor/grad_norm:({_FLOAT})", content)
+    if len(grad_norms) != expected_step or not all(math.isfinite(value) for value in grad_norms):
+        problems.append("missing or non-finite actor gradients")
+    elif not any(abs(value) > 0 for value in grad_norms):
+        problems.append("no non-zero actor gradient")
+
+    update_actor_times = _float_values(rf"timing_s/update_actor:({_FLOAT})", content)
+    update_weights_times = _float_values(rf"timing_s/update_weights:({_FLOAT})", content)
+    if len(update_actor_times) != expected_step or not all(
+        math.isfinite(value) and value > 0 for value in update_actor_times
+    ):
+        problems.append("missing, non-finite, or non-positive actor-update timing")
+    if len(update_weights_times) != expected_step or not all(
+        math.isfinite(value) and value > 0 for value in update_weights_times
+    ):
+        problems.append("missing, non-finite, or non-positive rollout-weight synchronization timing")
+
+    if problems:
+        raise ValueError("; ".join(dict.fromkeys(problems)))
+
+    return {
+        "global_step": max(steps),
+        "rollout_summaries": len(summaries),
+        "reward_min": min(rewards),
+        "reward_max": max(rewards),
+        "nonzero_grad_steps": sum(math.isfinite(value) and abs(value) > 0 for value in grad_norms),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log-file", required=True, type=Path)
+    parser.add_argument("--agent-log-dir", required=True, type=Path)
+    parser.add_argument("--expected-step", required=True, type=int)
+    args = parser.parse_args()
+    try:
+        summary = verify_training_log(
+            args.log_file.read_text(encoding="utf-8", errors="replace"),
+            expected_step=args.expected_step,
+        )
+        finish_sessions = verify_finish_evidence(args.agent_log_dir)
+    except (OSError, ValueError) as exc:
+        raise SystemExit(f"Training signal verification failed: {exc}") from exc
+    print(
+        "Verified rollout -> reward -> policy update: "
+        f"global_step={summary['global_step']}, "
+        f"reward_mean_range={summary['reward_min']}..{summary['reward_max']}, "
+        f"nonzero_grad_steps={summary['nonzero_grad_steps']}, correct_finish_sessions={finish_sessions}"
+    )
+
+
+def verify_finish_evidence(log_dir: Path) -> int:
+    """Require a correct real finish observation and a saved rewarded trajectory."""
+    import json
+
+    count = 0
+    for task_log in log_dir.glob("step_*/session-*/task.log"):
+        content = task_log.read_text(encoding="utf-8")
+        if "pipeline_smoke: correct_finish_observed" not in content:
+            continue
+        trajectory_path = task_log.with_name("trajectory.json")
+        if not trajectory_path.is_file():
+            raise ValueError(f"missing trajectory for finish evidence: {task_log.parent.name}")
+        data = json.loads(trajectory_path.read_text(encoding="utf-8"))
+        if any(t.get("finished") is True and t.get("reward_score") == 1.0 for t in data["trajectories"]):
+            count += 1
+    if count == 0:
+        raise ValueError("no correct real finish call with a saved rewarded trajectory")
+    return count
+
+
+if __name__ == "__main__":
+    main()

--- a/uni_agent/tasks/registry.py
+++ b/uni_agent/tasks/registry.py
@@ -23,6 +23,7 @@ TASK_MODULES: dict[str, str] = {
     "harbor": "uni_agent.tasks.harbor.task",
     "swe_bench": "uni_agent.tasks.swe_bench.task",
     "swe_bench_multilingual": "uni_agent.tasks.swe_bench_multilingual.task",
+    "pipeline_smoke": "uni_agent.tasks.pipeline_smoke.task",
     "swe_rebench": "uni_agent.tasks.swe_rebench.task",
     "hotpotqa": "uni_agent.tasks.hotpotqa.task",
     "terminal_bench": "uni_agent.tasks.terminal_bench.task",


### PR DESCRIPTION
## Summary

Related to #114. This draft implements the GPU side of a minimal single-node Uni-Agent RL training quickstart, leaving Ascend A2 validation and integration open for collaboration.

The default recipe runs two Qwen3-0.6B rollout/reward/FSDP2 policy-update steps without external datasets or task services.

## Changes

- Add a deterministic local task with 16 training and 4 disjoint validation examples, plus dataset validation.
- Expose only `finish(answer=...)`; generated actions have no shell or file-execution tools.
- Reward correct real finish calls with 1.0, correct plain-text fallback with 0.5, and incorrect answers with 0.0.
- Add a CUDA launcher configurable for 1/2/4 GPUs, using single-sample RLOO to avoid centering equal positive rewards to zero.
- Verify continuous training steps, positive rewards, finite/nonzero gradients, actor updates and weight synchronization, complete rollout summaries, and correct real finish evidence in a fresh per-run log directory.
- Document setup, scaling, memory controls, observed results, and validation boundaries; add focused regression coverage.

## Validation

- Relevant CPU regression suite: **57 passed** (pipeline smoke, ReAct, and task runner).
- Ruff lint/format checks, shell syntax, Hydra configuration, and staged diff whitespace checks passed.
- Current defaults completed two training steps on shared RTX 3090 24 GB devices and passed the automatic verifier:

| GPUs | Reward mean (steps 1 / 2) | Actor gradient norm (steps 1 / 2) |
| --- | --- | --- |
| 1 | 0.5 / 0.5 | 70.2565 / 12.5023 |
| 4 | 0.5625 / 0.625 | 22.0952 / 27.2137 |

The four-GPU run saved 24 trajectories including async prefetch, with 10 correct real finish calls. Both consumed training batches included reward 1.0. The one-GPU run saved six trajectories; its correct finish was in prefetch, not the two consumed training batches.

## Limitations / review focus

- This is a training-pipeline smoke test, not evidence of learning quality or reliable tool use.
- One Hermes tool JSON parsing error (`JSONDecodeError: Extra data`) occurred during the four-GPU run; training continued, and rollout summaries reported no failed sessions or unfinished episodes. Nonfatal cache/dependency warnings also occurred.
- The verifier's finish evidence covers the run, including prefetch; it does not establish that every successful finish trajectory was consumed in a training batch.
- Two-GPU and Ascend NPU execution have **not** been validated. The task config is device-independent; this launcher targets CUDA.
- Full `pre-commit run --all-files --show-diff-on-failure` was not run: pre-commit is absent from the test environment. The checks listed above are not a substitute for that full suite.

## Compatibility

Additive quickstart/task registration only; no existing workflow migration is required.

## Checklist

- [x] Focused change linked to an issue.
- [x] PR title follows `[area] type: summary`.
- [x] Tests cover new behavior and validation is described.
- [x] Workflow/configuration documentation is included.
- [x] Compatibility impact and migration are described.
- [x] No credentials or private environment paths are included.
- [ ] `pre-commit run --all-files --show-diff-on-failure` passes.
